### PR TITLE
Fixes #53. Making SourceMaps query author <=> generated mapping case independent

### DIFF
--- a/src/chrome/chromeConnection.ts
+++ b/src/chrome/chromeConnection.ts
@@ -163,7 +163,6 @@ export class ChromeConnection {
      * Attach the websocket to the first available tab in the chrome instance with the given remote debugging port number.
      */
     public attach(port: number, url?: string, address?: string): Promise<void> {
-        logger.log('Attempting to attach on port ' + port);
         return utils.retryAsync(() => this._attach(port, url, address), /*timeoutMs*/ 6000)
             .then(() => this.sendMessage('Debugger.enable'))
             .then(() => this.sendMessage('Console.enable'))
@@ -172,6 +171,7 @@ export class ChromeConnection {
 
     public _attach(port: number, targetUrl?: string, address?: string): Promise<void> {
         address = address || '127.0.0.1';
+        logger.log(`Attempting to attach on ${address}:${port}`);
         return utils.getURL(`http://${address}:${port}/json`).then(jsonResponse => {
             // Validate every step of processing the response
             try {
@@ -196,6 +196,7 @@ export class ChromeConnection {
                         }
 
                         const wsUrl = targets[0].webSocketDebuggerUrl;
+                        logger.log(`wsUrl: ${wsUrl}`);
                         if (wsUrl) {
                             return this._socket.open(wsUrl);
                         }

--- a/src/chrome/chromeConnection.ts
+++ b/src/chrome/chromeConnection.ts
@@ -196,7 +196,7 @@ export class ChromeConnection {
                         }
 
                         const wsUrl = targets[0].webSocketDebuggerUrl;
-                        logger.log(`wsUrl: ${wsUrl}`);
+                        logger.verbose(`WebSocket Url: ${wsUrl}`);
                         if (wsUrl) {
                             return this._socket.open(wsUrl);
                         }

--- a/src/sourceMaps/sourceMap.ts
+++ b/src/sourceMaps/sourceMap.ts
@@ -63,8 +63,9 @@ export class SourceMap {
 
         // Rewrite sm.sources to same as this._sources but forward slashes and file url
         sm.sources = this._sources.map(sourceAbsPath => {
-            // Convert to file: url. After this, it's a file URL for an absolute path to a file on disk with forward slashes.
-            return utils.pathToFileURL(sourceAbsPath);
+            // Convert to file:/// url. After this, it's a file URL for an absolute path to a file on disk with forward slashes.
+            // We lowercase so authored <-> generated mapping is not case sensitive
+            return utils.pathToFileURL(sourceAbsPath).toLowerCase();
         });
 
         this._smc = new SourceMapConsumer(sm);

--- a/src/sourceMaps/sourceMap.ts
+++ b/src/sourceMaps/sourceMap.ts
@@ -67,7 +67,7 @@ export class SourceMap {
             // Convert to file:/// url. After this, it's a file URL for an absolute path to a file on disk with forward slashes.
             // We lowercase so authored <-> generated mapping is not case sensitive.
             const lowerCaseSourceAbsPath = sourceAbsPath.toLowerCase();
-            this._authoredPathCaseMap[lowerCaseSourceAbsPath] = sourceAbsPath;
+            this._authoredPathCaseMap.set(lowerCaseSourceAbsPath, sourceAbsPath);
             return utils.pathToFileURL(lowerCaseSourceAbsPath);
         });
 
@@ -121,7 +121,7 @@ export class SourceMap {
             position.source = utils.canonicalizeUrl(position.source);
 
             // Convert back to original case
-            position.source = this._authoredPathCaseMap[position.source] || position.source;
+            position.source = this._authoredPathCaseMap.get(position.source) || position.source;
 
             // Back to 0-indexed lines
             position.line--;
@@ -141,7 +141,8 @@ export class SourceMap {
         line++;
 
         // sources in the sourcemap have been forced to file:///
-        source = utils.pathToFileURL(source);
+        // Convert to lowerCase so search is case insensitive
+        source = utils.pathToFileURL(source.toLowerCase());
 
         const lookupArgs = {
             line,

--- a/src/sourceMaps/sourceMap.ts
+++ b/src/sourceMaps/sourceMap.ts
@@ -58,14 +58,14 @@ export class SourceMap {
                 sourcePath = path.resolve(absSourceRoot, sourcePath);
             }
 
-            return sourcePath;
+            // We lowercase so authored <-> generated mapping is not case sensitive
+            return sourcePath.toLowerCase();
         });
 
         // Rewrite sm.sources to same as this._sources but forward slashes and file url
         sm.sources = this._sources.map(sourceAbsPath => {
             // Convert to file:/// url. After this, it's a file URL for an absolute path to a file on disk with forward slashes.
-            // We lowercase so authored <-> generated mapping is not case sensitive
-            return utils.pathToFileURL(sourceAbsPath).toLowerCase();
+            return utils.pathToFileURL(sourceAbsPath);
         });
 
         this._smc = new SourceMapConsumer(sm);

--- a/src/sourceMaps/sourceMaps.ts
+++ b/src/sourceMaps/sourceMaps.ts
@@ -22,12 +22,14 @@ export class SourceMaps {
      * @param pathToSource - The absolute path to the authored file
      */
     public getGeneratedPathFromAuthoredPath(authoredPath: string): string {
+        authoredPath = authoredPath.toLowerCase();
         return this._authoredPathToSourceMap.has(authoredPath) ?
             this._authoredPathToSourceMap.get(authoredPath).generatedPath() :
             null;
     }
 
     public mapToGenerated(authoredPath: string, line: number, column: number): MappedPosition {
+        authoredPath = authoredPath.toLowerCase();
         return this._authoredPathToSourceMap.has(authoredPath) ?
             this._authoredPathToSourceMap.get(authoredPath)
                 .generatedPositionFor(authoredPath, line, column) :
@@ -35,6 +37,7 @@ export class SourceMaps {
     }
 
     public mapToAuthored(pathToGenerated: string, line: number, column: number): MappedPosition {
+        pathToGenerated = pathToGenerated.toLowerCase();
         return this._generatedPathToSourceMap.has(pathToGenerated) ?
             this._generatedPathToSourceMap.get(pathToGenerated)
                 .authoredPositionFor(line, column) :
@@ -42,6 +45,7 @@ export class SourceMaps {
     }
 
     public allMappedSources(pathToGenerated: string): string[] {
+        pathToGenerated = pathToGenerated.toLowerCase();
         return this._generatedPathToSourceMap.has(pathToGenerated) ?
             this._generatedPathToSourceMap.get(pathToGenerated).authoredSources :
             null;
@@ -51,12 +55,12 @@ export class SourceMaps {
      * Given a new path to a new script file, finds and loads the sourcemap for that file
      */
     public processNewSourceMap(pathToGenerated: string, sourceMapURL: string): Promise<void> {
-        return this._generatedPathToSourceMap.has(pathToGenerated) ?
+        return this._generatedPathToSourceMap.has(pathToGenerated.toLowerCase()) ?
             Promise.resolve(null) :
             getMapForGeneratedPath(pathToGenerated, sourceMapURL, this._webRoot).then(sourceMap => {
                 if (sourceMap) {
-                    this._generatedPathToSourceMap.set(pathToGenerated, sourceMap);
-                    sourceMap.authoredSources.forEach(authoredSource => this._authoredPathToSourceMap.set(authoredSource, sourceMap));
+                    this._generatedPathToSourceMap.set(pathToGenerated.toLowerCase(), sourceMap);
+                    sourceMap.authoredSources.forEach(authoredSource => this._authoredPathToSourceMap.set(authoredSource.toLowerCase(), sourceMap));
                 }
             });
     }

--- a/test/sourceMaps/sourceMaps.test.ts
+++ b/test/sourceMaps/sourceMaps.test.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as mockery from 'mockery';
+import * as testUtils from '../testUtils';
+import * as path from 'path';
+import {SourceMaps} from '../../src/sourceMaps/sourceMaps';
+import {MappedPosition} from '../../src/sourceMaps/sourceMap';
+
+suite('SourceMaps', () => {
+    const DIRNAME = __dirname.toLowerCase();
+    const GENERATED_PATH = path.resolve(DIRNAME, 'testdata/app.js');
+    const AUTHORED_PATH = path.resolve(DIRNAME, 'testdata/source1.ts');
+    const ALL_SOURCES = [AUTHORED_PATH, path.resolve(DIRNAME, 'testdata/source2.ts')];
+    const WEBROOT = 'http://localhost';
+    const SOURCEMAP_URL = 'app.js.map';
+    const sourceMaps = new SourceMaps(WEBROOT);
+
+    setup((done) => {
+        testUtils.setupUnhandledRejectionListener();
+        mockery.enable({ warnOnReplace: false, useCleanCache: true, warnOnUnregistered: false });
+        testUtils.registerWin32Mocks();
+        sourceMaps.processNewSourceMap(GENERATED_PATH, SOURCEMAP_URL).then(done);
+    });
+
+    teardown(() => {
+        testUtils.removeUnhandledRejectionListener();
+        mockery.deregisterAll();
+        mockery.disable();
+    });
+
+    test('allMappedSources is case insensitive', () => {
+        assert.deepEqual(sourceMaps.allMappedSources(GENERATED_PATH.toUpperCase()), ALL_SOURCES);
+        assert.deepEqual(sourceMaps.allMappedSources(GENERATED_PATH.toLowerCase()), ALL_SOURCES);
+    });
+
+    test('getGeneratedPathFromAuthoredPath is case insensitive', () => {
+        assert.equal(sourceMaps.getGeneratedPathFromAuthoredPath(AUTHORED_PATH.toUpperCase()), GENERATED_PATH);
+        assert.equal(sourceMaps.getGeneratedPathFromAuthoredPath(AUTHORED_PATH.toLowerCase()), GENERATED_PATH);
+    });
+
+    test('mapToGenerated is case insensitive', () => {
+        const position: MappedPosition = {line: 0, column: 0, source: GENERATED_PATH};
+        assert.deepEqual(sourceMaps.mapToGenerated(AUTHORED_PATH.toUpperCase(), 0, 0), position);
+        assert.deepEqual(sourceMaps.mapToGenerated(AUTHORED_PATH.toLowerCase(), 0, 0), position);
+    });
+
+    test('mapToAuthored is case insensitive', () => {
+        const position: MappedPosition = {line: 0, column: 0, name: null, source: AUTHORED_PATH};
+        assert.deepEqual(sourceMaps.mapToAuthored(GENERATED_PATH.toUpperCase(), 0, 0), position);
+        assert.deepEqual(sourceMaps.mapToAuthored(GENERATED_PATH.toLowerCase(), 0, 0), position);
+    });
+});

--- a/test/sourceMaps/sourceMaps.test.ts
+++ b/test/sourceMaps/sourceMaps.test.ts
@@ -11,9 +11,9 @@ import {MappedPosition} from '../../src/sourceMaps/sourceMap';
 
 suite('SourceMaps', () => {
     const DIRNAME = __dirname.toLowerCase();
-    const GENERATED_PATH = path.resolve(DIRNAME, 'testdata/app.js');
-    const AUTHORED_PATH = path.resolve(DIRNAME, 'testdata/source1.ts');
-    const ALL_SOURCES = [AUTHORED_PATH, path.resolve(DIRNAME, 'testdata/source2.ts')];
+    const GENERATED_PATH = path.resolve(DIRNAME, 'testData/app.js');
+    const AUTHORED_PATH = path.resolve(DIRNAME, 'testData/source1.ts');
+    const ALL_SOURCES = [AUTHORED_PATH, path.resolve(DIRNAME, 'testData/source2.ts')];
     const WEBROOT = 'http://localhost';
     const SOURCEMAP_URL = 'app.js.map';
     const sourceMaps = new SourceMaps(WEBROOT);


### PR DESCRIPTION
Also adding some logging for websocket url and tests.