### PR TITLE
add path to dummy stack frame

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -526,7 +526,7 @@ export class ChromeDebugAdapter implements IDebugAdapter {
                     return {
                         id: i,
                         name: 'Unknown',
-                        source: {name: 'eval:Unknown'},
+                        source: {name: 'eval:Unknown', path: ChromeDebugAdapter.PLACEHOLDER_URL_PROTOCOL + 'Unknown'},
                         line,
                         column
                     };


### PR DESCRIPTION
In cases when we need dummy stack frames, such as iOS simulator, we need to include the `path` attribute so that when `stackTraceResponse` calls `mapToAuthored` on the sourceMap's path it is not `undefined`.

Without this change you'll get an error message of `no method toLowerCase() for undefined`, which comes from having path as `undefined` for this edge case.