### PR TITLE
add path mapping

### DIFF
--- a/src/debugAdapterInterfaces.d.ts
+++ b/src/debugAdapterInterfaces.d.ts
@@ -15,6 +15,7 @@ export type ISourceMapPathOverrides = { [pattern: string]: string };
  */
 export interface ICommonRequestArgs {
     webRoot?: string;
+    pathMapping?: {[url: string]: string};
     outDir?: string;
     outFiles?: string[];
     sourceMaps?: boolean;


### PR DESCRIPTION
Hi @roblourens 
this pr fixes #146 and have to be merged with Microsoft/vscode-chrome-debug#324
I added pathMapping in the launcher config:
So it replace webRoot and sourceMapPathOverrides that are no longer needed to configure a launcher
I've tested with some typescript and sourcemap and it seems to work fine with just a pathMapping.

It was tricky to configure the debug environment but I finally installed projects and found the right procedure for launching.

