### PR TITLE
Fixes #187: Nicer error messages when a source map fails to parse

### DIFF
--- a/src/sourceMaps/sourceMapFactory.ts
+++ b/src/sourceMaps/sourceMapFactory.ts
@@ -39,7 +39,7 @@ export function getMapForGeneratedPath(pathToGenerated: string, mapPath: string,
                 // Throws for invalid JSON
                 return new SourceMap(pathToGenerated, contents, webRoot, sourceMapPathOverrides);
             } catch (e) {
-                logger.error(`SourceMaps.getMapForGeneratedPath: exception while processing sourcemap: ${e.stack}`);
+                logger.error(`SourceMaps.getMapForGeneratedPath: exception while processing path: ${pathToGenerated}, sourcemap: ${mapPath}\n${e.stack}`);
                 return null;
             }
         } else {


### PR DESCRIPTION
Adding `mapPath` and `pathToGenerated` to the error message logged.