### PR TITLE
Fixed a bug where pathMapping had to end with a slash.

### DIFF
--- a/src/chrome/chromeUtils.ts
+++ b/src/chrome/chromeUtils.ts
@@ -24,13 +24,8 @@ export function targetUrlToClientPathByPathMappings(scriptUrl: string, pathMappi
             p = p + '/';
         }
 
-        let localPath = pathMapping[origin + p];
-        if (localPath) {
-            const r = decodeURIComponent(parsedUrl.pathname.substring(p.length));
-            return path.join(localPath, r);
-        }
+        let localPath = pathMapping[origin + p] || pathMapping[p];
 
-        localPath = pathMapping[p];
         if (localPath) {
             const r = decodeURIComponent(parsedUrl.pathname.substring(p.length));
             return path.join(localPath, r);

--- a/src/chrome/chromeUtils.ts
+++ b/src/chrome/chromeUtils.ts
@@ -20,11 +20,14 @@ export function targetUrlToClientPathByPathMappings(scriptUrl: string, pathMappi
     let pSegments = parsedUrl.pathname.split('/');
     while (pSegments.length) {
         let p = pSegments.join('/');
-        if (!p.endsWith('/')) {
-            p = p + '/';
+
+        if (pSegments.length === 1 && p === '') {
+            // Root path segment.
+            p = '/';
         }
 
-        let localPath = pathMapping[origin + p] || pathMapping[p];
+        let localPath = pathMapping[origin + p] || pathMapping[origin + p + '/'] ||
+            pathMapping[p + '/'] || pathMapping[p];
 
         if (localPath) {
             const r = decodeURIComponent(parsedUrl.pathname.substring(p.length));

--- a/test/chrome/chromeUtils.test.ts
+++ b/test/chrome/chromeUtils.test.ts
@@ -96,6 +96,8 @@ suite('ChromeUtils', () => {
 
         const ROOT_MAPPING = { '/': TEST_WEB_ROOT };
         const PAGE_MAPPING = { '/page/': TEST_WEB_ROOT };
+        const PARTIAL_PAGE_MAPPING = { '/page': TEST_WEB_ROOT };
+        const FILE_MAPPING = { '/page.js': TEST_CLIENT_PATH };
 
         test('an empty string is returned for a missing url', () => {
             assert.equal(getChromeUtils().targetUrlToClientPathByPathMappings('', { }), '');
@@ -141,6 +143,30 @@ suite('ChromeUtils', () => {
             assert.equal(
                 getChromeUtils().targetUrlToClientPathByPathMappings(TEST_TARGET_HTTP_URL, PAGE_MAPPING),
                 TEST_CLIENT_PATH);
+        });
+
+        test('resolves webroot-style mapping without tailing slash', () => {
+            assert.equal(
+                getChromeUtils().targetUrlToClientPathByPathMappings(TEST_TARGET_HTTP_URL, PARTIAL_PAGE_MAPPING),
+                TEST_CLIENT_PATH);
+        });
+
+        test('resolves pathMapping for a particular file', () => {
+            assert.equal(
+                getChromeUtils().targetUrlToClientPathByPathMappings('http://site.com/page.js', FILE_MAPPING),
+                TEST_CLIENT_PATH);
+        });
+
+        test('return an empty string for url that has partially matching directory', () => {
+            const url = 'http://site.com/page-alike/scripts/a.js';
+
+            assert.equal(getChromeUtils().targetUrlToClientPathByPathMappings(url, PARTIAL_PAGE_MAPPING), '');
+        });
+
+        test('return an empty string for file matching pathMapped directory', () => {
+            const url = 'http://site.com/page.js';
+
+            assert.equal(getChromeUtils().targetUrlToClientPathByPathMappings(url, PARTIAL_PAGE_MAPPING), '');
         });
     });
 


### PR DESCRIPTION
This PR fixes issue Microsoft/vscode-chrome-debug#393.

There's one thing that I'm not especially proud of in [src/chrome/chromeUtils.ts](https://github.com/mlewand/vscode-chrome-debug-core/blob/7f7c119352c7374e16d2be3eaeaac7808c2f2d03/src/chrome/chromeUtils.ts#L29-L30) file. IMHO it would be better more readable just to go over `pathMapping` members and override it's keys by right-trimming slashes in keys. I'm not comfortable with modifying `pathMapping` object (someone might get surprised after using `targetUrlToClientPathByPathMappings`) so ultimately I'd just clone the `pathMapping` object first, and then trim keys in this local clone.

However I don't what are environment constraints of this plugin, ideally I'd simply use `Object.assign` (shallow clone is OK here), but it's ES6. Writing clone by in loops is not a fun thing to do, and adding a dep just for that seems to be overkill.

Let me know if you'd want me to correct it, or feel free to do it on top of my changes - this use case has now good coverage, so you're safe to modify it.