### PR TITLE
Fix Microsoft/vscode-chrome-debug#426: handle double dots in path

### DIFF
--- a/src/chrome/chromeUtils.ts
+++ b/src/chrome/chromeUtils.ts
@@ -151,11 +151,8 @@ export function getMatchingTargets(targets: ITarget[], targetUrlPattern: string)
 
     targetUrlPattern = standardizeMatch(targetUrlPattern);
 
-    // Remove parent folders when followed by double dots
-    // Example: localhost/site/../app => localhost/app
-    const doubleDotPattern = /[^\/]+\/\.\.\//g;
-    while (targetUrlPattern.match(doubleDotPattern))
-        targetUrlPattern = targetUrlPattern.replace(doubleDotPattern, '');
+    // Normalize to take care of single and double dots
+    targetUrlPattern = path.normalize(targetUrlPattern);
 
     targetUrlPattern = utils.escapeRegExpCharacters(targetUrlPattern).replace(/\\\*/g, '.*');
 

--- a/src/chrome/chromeUtils.ts
+++ b/src/chrome/chromeUtils.ts
@@ -150,6 +150,13 @@ export function getMatchingTargets(targets: ITarget[], targetUrlPattern: string)
     };
 
     targetUrlPattern = standardizeMatch(targetUrlPattern);
+
+    // Remove parent folders when followed by double dots
+    // Example: localhost/site/../app => localhost/app
+    const doubleDotPattern = /[^\/]+\/\.\.\//g;
+    while (targetUrlPattern.match(doubleDotPattern))
+        targetUrlPattern = targetUrlPattern.replace(doubleDotPattern, '');
+
     targetUrlPattern = utils.escapeRegExpCharacters(targetUrlPattern).replace(/\\\*/g, '.*');
 
     const targetUrlRegex = new RegExp('^' + targetUrlPattern + '$', 'g');

--- a/test/chrome/chromeUtils.test.ts
+++ b/test/chrome/chromeUtils.test.ts
@@ -318,6 +318,20 @@ suite('ChromeUtils', () => {
                 chromeUtils.getMatchingTargets(targets, 'http://localhost'),
                 targets);
         });
+
+        test('handles double dots', () => {
+            const targets = makeTargets('http://localhost/app', 'http://localhost/site/../folder/../app');
+            assert.deepEqual(
+                chromeUtils.getMatchingTargets(targets, 'http://localhost/site/../folder/../app'),
+                [targets[0]]);
+        });
+
+        test('handles a series of double dots', () => {
+            const targets = makeTargets('http://localhost/app', 'http://localhost/site/folder/../../app');
+            assert.deepEqual(
+                chromeUtils.getMatchingTargets(targets, 'http://localhost/site/folder/../../app'),
+                [targets[0]]);
+        });
     });
 
     suite('compareVariableNames', () => {

--- a/test/chrome/chromeUtils.test.ts
+++ b/test/chrome/chromeUtils.test.ts
@@ -332,6 +332,13 @@ suite('ChromeUtils', () => {
                 chromeUtils.getMatchingTargets(targets, 'http://localhost/site/folder/../../app'),
                 [targets[0]]);
         });
+
+        test('handles single dot', () => {
+            const targets = makeTargets('http://localhost/site/app', 'http://localhost/site/./app');
+            assert.deepEqual(
+                chromeUtils.getMatchingTargets(targets, 'http://localhost/site/./app'),
+                [targets[0]]);
+        });
     });
 
     suite('compareVariableNames', () => {


### PR DESCRIPTION
I used a regexp to handle double dots and updated the test suite accordingly. 
Linting and tests are ok.