### PR TITLE
Added parameter to multiplex the CRDP connection into an additional endpoint

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -249,7 +249,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         }
 
         telemetry.reportEvent('debugStarted', { request: 'attach', args: Object.keys(args) });
-        return this.doAttach(args.port, args.url, args.address, args.timeout, args.websocketUrl);
+        return this.doAttach(args.port, args.url, args.address, args.timeout, args.websocketUrl, args.extraCRDPChannelPort);
     }
 
     protected commonArgs(args: ICommonRequestArgs): void {
@@ -322,14 +322,14 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         ];
     }
 
-    protected async doAttach(port: number, targetUrl?: string, address?: string, timeout?: number, websocketUrl?: string): Promise<void> {
+    protected async doAttach(port: number, targetUrl?: string, address?: string, timeout?: number, websocketUrl?: string, extraCRDPChannelPort?: number): Promise<void> {
         // Client is attaching - if not attached to the chrome target, create a connection and attach
         this._clientAttached = true;
         if (!this._chromeConnection.isAttached) {
             if (websocketUrl) {
-                await this._chromeConnection.attachToWebsocketUrl(websocketUrl);
+                await this._chromeConnection.attachToWebsocketUrl(websocketUrl, extraCRDPChannelPort);
             } else {
-                await this._chromeConnection.attach(address, port, targetUrl, timeout);
+                await this._chromeConnection.attach(address, port, targetUrl, timeout, extraCRDPChannelPort);
             }
 
             this._port = port;

--- a/src/chrome/crdpMultiplexing/crdpMultiplexor.ts
+++ b/src/chrome/crdpMultiplexing/crdpMultiplexor.ts
@@ -35,7 +35,7 @@ function decodifyId(encodifiedId: number): number {
 }
 
 function throwCriticalError(message: string): void {
-    logger.log("CRDP Multiplexor - CRITICAL-ERROR: " + message);
+    logger.error("CRDP Multiplexor - CRITICAL-ERROR: " + message);
     throw new Error(message);
 }
 
@@ -144,7 +144,7 @@ export class CRDPChannel implements LikeSocket {
     public send(messageData: string): void {
         const message = JSON.parse(messageData);
         const method = message.method;
-        const isEnableMethod = method && method.indexOf(".enable") >= 0;
+        const isEnableMethod = method && method.endsWith(".enable");
         let domain;
 
         if (isEnableMethod) {

--- a/src/chrome/crdpMultiplexing/crdpMultiplexor.ts
+++ b/src/chrome/crdpMultiplexing/crdpMultiplexor.ts
@@ -1,0 +1,201 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { LikeSocket } from 'noice-json-rpc';
+import { logger } from 'vscode-debugadapter';
+
+/* Assumptions made to implement this multiplexor:
+    1. The message IDs of CRDP don't need to be sent in order
+    2. The Domain.enable messages don't have any side-effects (We might send them multiple times)
+    3. The clients are ready to recieve domain messages when they send the Domain.enable message (A better design would be to assume that they are ready after we've sent the response for that message, but this approach seems to be working so far)
+    4. The clients never disable any Domain
+    5. The clients enable all domains in the first 60 seconds after they've connected
+ */
+
+function extractDomain(method: string): string {
+    const methodParts = method.split(".");
+    if (methodParts.length === 2) {
+        return methodParts[0];
+    } else {
+        throwCriticalError(`The method ${method} didn't have exactly two parts`);
+        return "Unknown";
+    }
+}
+
+function encodifyChannel(channelId: number, id: number): number {
+    return id * 10 + channelId;
+}
+
+function decodifyChannelId(encodifiedId: number): number {
+    return encodifiedId % 10;
+}
+function decodifyId(encodifiedId: number): number {
+    return Math.floor(encodifiedId / 10);
+}
+
+function throwCriticalError(message: string): void {
+    logger.log("CRDP Multiplexor - CRITICAL-ERROR: " + message);
+    throw new Error(message);
+}
+
+export class CRDPMultiplexor {
+    private _channels: CRDPChannel[] = [];
+
+    private onMessage(data: string): void {
+        const message = JSON.parse(data);
+        if (message.id !== undefined) {
+            this.onResponseMessage(message, data);
+        } else if (message.method) {
+            this.onDomainNotification(message, data);
+        } else {
+            throwCriticalError(`Message didn't have id nor method: ${data}`);
+        }
+    }
+
+    private onResponseMessage(message: {id: number}, data: string): void {
+        // The message is a response, so it should only go to the channel that requested this
+        const channel = this._channels[decodifyChannelId(message.id)];
+        if (channel) {
+            message.id = decodifyId(message.id);
+            data = JSON.stringify(message);
+            channel.callMessageCallbacks(data);
+        } else {
+            throwCriticalError(`Didn't find channel for message with id: ${message.id} and data: <${data}>`);
+        }
+    }
+
+    private onDomainNotification(message: {method: string}, data: string): void {
+        // The message is a notification, so it should go to all channels. The channels itself will filter based on the enabled domains
+        const domain = extractDomain(message.method);
+        for (const channel of this._channels) {
+            channel.callDomainMessageCallbacks(domain, data);
+        }
+    }
+
+    constructor(private _wrappedLikeSocket: LikeSocket) {
+        this._wrappedLikeSocket.on('message', data => this.onMessage(data));
+    }
+
+    public addChannel(channelName: string): CRDPChannel {
+        if (this._channels.length >= 10) {
+            throw new Error(`Only 10 channels are supported`);
+        }
+
+        const channel = new CRDPChannel(channelName, this._channels.length, this);
+        this._channels.push(channel);
+        return channel;
+    }
+
+    public send(channel: CRDPChannel, data: string): void {
+        const message = JSON.parse(data);
+        if (message.id !== undefined) {
+            message.id = encodifyChannel(channel.id, message.id);
+            data = JSON.stringify(message);
+        } else {
+            throwCriticalError(`Channel [${channel.name}] sent a message without an id: ${data}`);
+        }
+        this._wrappedLikeSocket.send(data);
+    }
+
+    public addListenerOfNonMultiplexedEvent(event: string, cb: Function): void {
+        this._wrappedLikeSocket.on(event, cb);
+    }
+
+    public removeListenerOfNonMultiplexedEvent(event: string, cb: Function): void {
+        this._wrappedLikeSocket.removeListener(event, cb);
+    }
+}
+
+export class CRDPChannel implements LikeSocket {
+    private static timeToPreserveMessagesInMillis = 60 * 1000;
+
+    private _messageCallbacks: Function[] = [];
+    private _enabledDomains: { [domain: string]: boolean } = {};
+    private _pendingMessagesForDomain: { [domain: string]: string[] } = {};
+
+    public callMessageCallbacks(messageData: string): void {
+        this._messageCallbacks.forEach(callback => callback(messageData));
+    }
+
+    public callDomainMessageCallbacks(domain: string, messageData: string): void {
+        if (this._enabledDomains[domain]) {
+            this.callMessageCallbacks(messageData);
+        } else if (this._pendingMessagesForDomain !== null) {
+            // We give clients 60 seconds after they connect to the channel to enable domains and receive all messages
+            this.storeMessageForLater(domain, messageData);
+        }
+    }
+
+    private storeMessageForLater(domain: string, messageData: string): void {
+        let messagesForDomain = this._pendingMessagesForDomain[domain];
+        if (messagesForDomain === undefined) {
+            this._pendingMessagesForDomain[domain] = [];
+            messagesForDomain = this._pendingMessagesForDomain[domain];
+        }
+
+        // Usually this is too much logging, but we might use it while debugging
+        // logger.log(`CRDP Multiplexor - Storing message to channel ${this.name} for ${domain} for later: ${messageData}`);
+        messagesForDomain.push(messageData);
+    }
+
+    constructor(public name: string, public id: number, private _multiplexor: CRDPMultiplexor) { }
+
+    public send(messageData: string): void {
+        const message = JSON.parse(messageData);
+        const method = message.method;
+        const isEnableMethod = method && method.indexOf(".enable") >= 0;
+        let domain;
+
+        if (isEnableMethod) {
+            domain = extractDomain(method);
+            this._enabledDomains[domain] = true;
+        }
+
+        this._multiplexor.send(this, messageData);
+
+        if (isEnableMethod) {
+            this.sendUnsentPendingMessages(domain);
+        }
+    }
+
+    private sendUnsentPendingMessages(domain: string): void {
+        const pendingMessagesData = this._pendingMessagesForDomain[domain];
+        if (pendingMessagesData !== undefined && this._messageCallbacks.length) {
+            logger.log(`CRDP Multiplexor - Sending pending messages of domain ${domain}(Count = ${pendingMessagesData.length})`);
+            delete this._pendingMessagesForDomain[domain];
+            pendingMessagesData.forEach(pendingMessageData => {
+                this.callDomainMessageCallbacks(domain, pendingMessageData);
+            });
+        }
+    }
+
+    private discardUnsentPendingMessages(): void {
+        logger.log(`CRDP Multiplexor - Discarding unsent pending messages for domains: ${Object.keys(this._pendingMessagesForDomain).join(", ")}`);
+        this._pendingMessagesForDomain = null;
+    }
+
+    public on(event: string, cb: Function): void;
+    public on(event: "open", cb: (ws: LikeSocket) => void): void;
+    public on(event: "message", cb: (data: string) => void): void;
+    public on(event: string, cb: Function): void {
+        if (event === 'message') {
+            if (this._messageCallbacks.length === 0) {
+                setTimeout(() => this.discardUnsentPendingMessages(), CRDPChannel.timeToPreserveMessagesInMillis);
+            }
+
+            this._messageCallbacks.push(cb);
+        } else {
+            this._multiplexor.addListenerOfNonMultiplexedEvent(event, cb);
+        }
+    }
+
+    public removeListener(event: string, cb: Function): void {
+        if (event === 'message') {
+            const index = this._messageCallbacks.indexOf(cb);
+            this._messageCallbacks.splice(index, 1);
+        } else {
+            this._multiplexor.removeListenerOfNonMultiplexedEvent(event, cb);
+        }
+    }
+}

--- a/src/chrome/crdpMultiplexing/webSocketToLikeSocketProxy.ts
+++ b/src/chrome/crdpMultiplexing/webSocketToLikeSocketProxy.ts
@@ -21,7 +21,7 @@ export class WebSocketToLikeSocketProxy {
             logger.log("CRDP Proxy shutting down");
             this._server.close(() => {
                 if (this._currentlyOpenedWebSocket !== null) {
-                    this._currentlyOpenedWebSocket.terminate();
+                    this._currentlyOpenedWebSocket.close();
                     logger.log("CRDP Proxy succesfully shut down");
                 }
 
@@ -31,7 +31,7 @@ export class WebSocketToLikeSocketProxy {
 
         this._server.on('connection', openedWebSocket => {
             if (this._currentlyOpenedWebSocket !== null) {
-                openedWebSocket.terminate();
+                openedWebSocket.close();
                 throw Error(`CRDP Proxy: Only one websocket is supported by the server on port ${this._port}`);
             } else {
                 this._currentlyOpenedWebSocket = openedWebSocket;

--- a/src/chrome/crdpMultiplexing/webSocketToLikeSocketProxy.ts
+++ b/src/chrome/crdpMultiplexing/webSocketToLikeSocketProxy.ts
@@ -8,6 +8,7 @@ import { LikeSocket } from 'noice-json-rpc';
 
 export class WebSocketToLikeSocketProxy {
     private _server: WebSocket.Server;
+    private _currentlyOpenedWebSocket: WebSocket = null;
 
     constructor(private _port: number, private _socket: LikeSocket) { }
 
@@ -16,11 +17,34 @@ export class WebSocketToLikeSocketProxy {
             logger.log(`CRDP Proxy listening on: ${this._port}`);
         });
 
+        this._socket.on('close', () => {
+            logger.log("CRDP Proxy shutting down");
+            this._server.close(() => {
+                if (this._currentlyOpenedWebSocket !== null) {
+                    this._currentlyOpenedWebSocket.terminate();
+                    logger.log("CRDP Proxy succesfully shut down");
+                }
+
+                return {};
+            });
+        });
+
         this._server.on('connection', openedWebSocket => {
-            logger.log(`CRDP Proxy accepted a new connection`);
+            if (this._currentlyOpenedWebSocket !== null) {
+                throw Error(`CRDP Proxy: Only one websocket is supported by the server on port ${this._port}`);
+            } else {
+                this._currentlyOpenedWebSocket = openedWebSocket;
+                logger.log(`CRDP Proxy accepted a new connection`);
+            }
+
             openedWebSocket.on('message', data => {
                 logger.log(`CRDP Proxy - Client to Target: ${data}`);
                 this._socket.send(data);
+            });
+
+            openedWebSocket.on('close', () => {
+                logger.log("CRDP Proxy - Client closed the connection");
+                this._currentlyOpenedWebSocket = null;
             });
 
             this._socket.on('message', data => {

--- a/src/chrome/crdpMultiplexing/webSocketToLikeSocketProxy.ts
+++ b/src/chrome/crdpMultiplexing/webSocketToLikeSocketProxy.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { logger } from 'vscode-debugadapter';
+import * as WebSocket from 'ws';
+import { LikeSocket } from 'noice-json-rpc';
+
+export class WebSocketToLikeSocketProxy {
+    private _server: WebSocket.Server;
+
+    constructor(private _port: number, private _socket: LikeSocket) { }
+
+    public start(): void {
+        this._server = new WebSocket.Server({ port: this._port }, () => {
+            logger.log(`CRDP Proxy listening on: ${this._port}`);
+        });
+
+        this._server.on('connection', openedWebSocket => {
+            logger.log(`CRDP Proxy accepted a new connection`);
+            openedWebSocket.on('message', data => {
+                logger.log(`CRDP Proxy - Client to Target: ${data}`);
+                this._socket.send(data);
+            });
+
+            this._socket.on('message', data => {
+                logger.log(`CRDP Proxy - Target to Client: ${data}`);
+                openedWebSocket.send(data);
+            });
+        });
+    }
+}

--- a/src/chrome/crdpMultiplexing/webSocketToLikeSocketProxy.ts
+++ b/src/chrome/crdpMultiplexing/webSocketToLikeSocketProxy.ts
@@ -31,6 +31,7 @@ export class WebSocketToLikeSocketProxy {
 
         this._server.on('connection', openedWebSocket => {
             if (this._currentlyOpenedWebSocket !== null) {
+                openedWebSocket.terminate();
                 throw Error(`CRDP Proxy: Only one websocket is supported by the server on port ${this._port}`);
             } else {
                 this._currentlyOpenedWebSocket = openedWebSocket;

--- a/src/debugAdapterInterfaces.d.ts
+++ b/src/debugAdapterInterfaces.d.ts
@@ -51,6 +51,9 @@ export interface IAttachRequestArgs extends DebugProtocol.AttachRequestArguments
 
     /** Private undocumented property to attach directly to a known websocket url */
     websocketUrl?: string;
+
+    /** Private undocumented property to multiplex the CRDP connection into an additional channel */
+    extraCRDPChannelPort?: number;
 }
 
 export interface IToggleSkipFileStatusArgs {

--- a/src/debugAdapterInterfaces.d.ts
+++ b/src/debugAdapterInterfaces.d.ts
@@ -29,6 +29,9 @@ export interface ICommonRequestArgs {
     skipFileRegExps?: string[]; // a supplemental array of library code regex patterns
     timeout?: number;
     showAsyncStacks?: boolean;
+
+    /** Private undocumented property to multiplex the CRDP connection into an additional channel */
+    extraCRDPChannelPort?: number;
 }
 
 export interface IRestartRequestArgs {
@@ -51,9 +54,6 @@ export interface IAttachRequestArgs extends DebugProtocol.AttachRequestArguments
 
     /** Private undocumented property to attach directly to a known websocket url */
     websocketUrl?: string;
-
-    /** Private undocumented property to multiplex the CRDP connection into an additional channel */
-    extraCRDPChannelPort?: number;
 }
 
 export interface IToggleSkipFileStatusArgs {

--- a/test/chrome/chromeDebugAdapter.test.ts
+++ b/test/chrome/chromeDebugAdapter.test.ts
@@ -51,7 +51,7 @@ suite('ChromeDebugAdapter', () => {
         // Create a ChromeConnection mock with .on and .attach. Tests can fire events via mockEventEmitter
         mockChromeConnection = Mock.ofType(ChromeConnection, MockBehavior.Strict);
         mockChromeConnection
-            .setup(x => x.attach(It.isValue(undefined), It.isValue(ATTACH_SUCCESS_PORT), It.isValue(undefined), It.isValue(undefined)))
+            .setup(x => x.attach(It.isValue(undefined), It.isValue(ATTACH_SUCCESS_PORT), It.isValue(undefined), It.isValue(undefined), It.isValue(undefined)))
             .returns(() => Promise.resolve());
         mockChromeConnection
             .setup(x => x.attach(It.isValue(undefined), It.isValue(ATTACH_FAIL_PORT), It.isValue(undefined), It.isValue(undefined)))


### PR DESCRIPTION
The multiplexer will let us attach other components that use the CRDP protocol to the debugger, such as a DOM Explorer.