### PR TITLE
Fix build error due to on properties not being compatible in WebSocket and LikeSocket

### DIFF
--- a/src/chrome/chromeConnection.ts
+++ b/src/chrome/chromeConnection.ts
@@ -10,7 +10,8 @@ import * as utils from '../utils';
 import {logger} from 'vscode-debugadapter';
 import {ChromeTargetDiscovery} from './chromeTargetDiscoveryStrategy';
 
-import {Client} from 'noice-json-rpc';
+import {Client, LikeSocket} from 'noice-json-rpc';
+
 import Crdp from '../../crdp/crdp';
 
 import {CRDPMultiplexor} from './crdpMultiplexing/crdpMultiplexor';
@@ -112,7 +113,7 @@ export class ChromeConnection {
     public attachToWebsocketUrl(wsUrl: string, extraCRDPChannelPort?: number): void {
         this._socket = new LoggingSocket(wsUrl);
         if (extraCRDPChannelPort) {
-            this._crdpSocketMultiplexor = new CRDPMultiplexor(this._socket);
+            this._crdpSocketMultiplexor = new CRDPMultiplexor(this._socket as any as LikeSocket);
             new WebSocketToLikeSocketProxy(extraCRDPChannelPort, this._crdpSocketMultiplexor.addChannel('extraCRDPEndpoint')).start();
             this._client = new Client(this._crdpSocketMultiplexor.addChannel('debugger'));
         } else {


### PR DESCRIPTION
Fixes build error: https://travis-ci.org/Microsoft/vscode-chrome-debug-core/builds/251319920#L759

  Types of property 'on' are incompatible.
    Type '{ (event: "error", cb: (err: Error) => void): WebSocket; (event: "close", cb: (code: number, mess...' is not assignable to type '{ (event: string, cb: Function): any; (event: "open", cb: (ws: LikeSocket) => void): any; (event:...'.
      Types of parameters 'event' and 'event' are incompatible.
        Type '"open"' is not assignable to type '"error"'.

It doesn't seem to be able to map the property to:
on(event: string, cb: Function): any;