### PR TITLE
Script Events should not send sourceReference for physical files 

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -1365,21 +1365,19 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         const sourceReference = this.getSourceReferenceForScriptId(script.scriptId);
         const origin = this.getReadonlyOrigin(script.url);
 
-        return new Promise((resolve, reject) => {
-            utils.existsAsync(script.url)
-                .then((exists) => {
-                    const source = {
-                        name: path.basename(script.url),
-                        path: script.url,
-                        // if the path exists, do not send the sourceReference
-                        sourceReference: exists ? undefined : sourceReference,
-                        origin
-                    };
+        return utils.existsAsync(script.url)
+            .then((exists) => {
+                const source = {
+                    name: path.basename(script.url),
+                    path: script.url,
+                    // if the path exists, do not send the sourceReference
+                    sourceReference: exists ? undefined : sourceReference,
+                    origin
+                };
 
-                    const clientScript: Script = new Script(source);
-                    resolve(new ScriptEvent('new', clientScript));
-                });
-        });
+                const clientScript: Script = new Script(source);
+                return new ScriptEvent('new', clientScript);
+            });
     }
 
     private callFrameToStackFrame(frame: Crdp.Debugger.CallFrame): DebugProtocol.StackFrame {

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -565,12 +565,14 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
             this._initialSourceMapsP = <Promise<any>>Promise.all([this._initialSourceMapsP, sourceMapsP]);
         }
 
-        const scriptEvent: ScriptEvent = this.scriptToScriptEvent(script);
-        if (this._scriptEventsBeforeInitializedEventFired !== null) {
-            this._scriptEventsBeforeInitializedEventFired.push(scriptEvent);
-        } else {
-            this._session.sendEvent(scriptEvent);
-        }
+        this.scriptToScriptEvent(script)
+            .then((scriptEvent: ScriptEvent) => {
+                if (this._scriptEventsBeforeInitializedEventFired !== null) {
+                    this._scriptEventsBeforeInitializedEventFired.push(scriptEvent);
+                } else {
+                    this._session.sendEvent(scriptEvent);
+                }
+            });
     }
 
     private async resolveSkipFiles(script: CrdpScript, mappedUrl: string, sources: string[], toggling?: boolean): Promise<void> {
@@ -1359,19 +1361,25 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         };
     }
 
-    private scriptToScriptEvent(script: Crdp.Debugger.ScriptParsedEvent): ScriptEvent {
+    private scriptToScriptEvent(script: Crdp.Debugger.ScriptParsedEvent): Promise<ScriptEvent> {
         const sourceReference = this.getSourceReferenceForScriptId(script.scriptId);
         const origin = this.getReadonlyOrigin(script.url);
-        const source = {
-            name: path.basename(script.url),
-            path: script.url,
-            sourceReference,
-            origin
-        };
 
-        const clientScript: Script = new Script(source);
+        return new Promise((resolve, reject) => {
+            utils.existsAsync(script.url)
+                .then((exists) => {
+                    const source = {
+                        name: path.basename(script.url),
+                        path: script.url,
+                        // if the path exists, do not send the sourceReference
+                        sourceReference: exists ? undefined : sourceReference,
+                        origin
+                    };
 
-        return new ScriptEvent('new', clientScript);
+                    const clientScript: Script = new Script(source);
+                    resolve(new ScriptEvent('new', clientScript));
+                });
+        });
     }
 
     private callFrameToStackFrame(frame: Crdp.Debugger.CallFrame): DebugProtocol.StackFrame {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,6 +36,21 @@ export function existsSync(path: string): boolean {
 }
 
 /**
+ * Checks asynchronously if a path exists on the disk.
+ */
+export function existsAsync(path: string): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+        try {
+            fs.access(path, (err) => {
+                resolve(err ? false : true);
+            });
+        } catch (e) {
+            resolve(false);
+        }
+    });
+}
+
+/**
  * Returns a reversed version of arr. Doesn't modify the input.
  */
 export function reversedArr(arr: any[]): any[] {


### PR DESCRIPTION
Fixing https://github.com/Microsoft/vscode-chrome-debug-core/issues/215
If the script url is a local path on the disk, we stop sending the sourceReference. @digeff @rakatyal 
