### PR TITLE
Set `supportsValueFormatting` flag in initialize

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -223,7 +223,8 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
             supportsHitConditionalBreakpoints: true,
             supportsRestartFrame: true,
             supportsExceptionInfoRequest: true,
-            supportsDelayedStackTraceLoading: true
+            supportsDelayedStackTraceLoading: true,
+            supportsValueFormattingOptions: true
         };
     }
 


### PR DESCRIPTION
Support for stack trace formatting was added a while ago, but the Capabilities flags weren't updated to reflect this.  The VS Debug Adapter Host is being updated to only send formatting data to adapters that indicate support.