### PR TITLE
Fix site.js appearing in the call stack instead of site.ts

### DIFF
--- a/src/transformers/baseSourceMapTransformer.ts
+++ b/src/transformers/baseSourceMapTransformer.ts
@@ -186,7 +186,9 @@ export class BaseSourceMapTransformer {
     public async stackTraceResponse(response: IInternalStackTraceResponseBody): Promise<void> {
         if (this._sourceMaps) {
             await this._processingNewSourceMap;
-            response.stackFrames.forEach(stackFrame => this.fixSourceLocation(stackFrame));
+            for (let stackFrame of response.stackFrames) {
+                await this.fixSourceLocation(stackFrame);
+            }
         }
     }
 


### PR DESCRIPTION
The code wasn't awaiting, so part of the code to create the response run before resolving the source maps, and the other part after it so we ended up with part saying site.js and part saying site.ts