### PR TITLE
Added a new FallbackToClientPathTransformer that will use the UrlPathTransformer and fallback to the client if neccesary

### DIFF
--- a/src/chrome/chromeUtils.ts
+++ b/src/chrome/chromeUtils.ts
@@ -281,3 +281,9 @@ export function selectBreakpointLocation(lineNumber: number, columnNumber: numbe
 
     return locations[0];
 }
+
+export var EVAL_NAME_PREFIX = 'VM';
+
+export function isEvalScript(scriptPath: string): boolean {
+    return scriptPath.startsWith(EVAL_NAME_PREFIX);
+}

--- a/src/chrome/chromeUtils.ts
+++ b/src/chrome/chromeUtils.ts
@@ -282,7 +282,7 @@ export function selectBreakpointLocation(lineNumber: number, columnNumber: numbe
     return locations[0];
 }
 
-export var EVAL_NAME_PREFIX = 'VM';
+export const EVAL_NAME_PREFIX = 'VM';
 
 export function isEvalScript(scriptPath: string): boolean {
     return scriptPath.startsWith(EVAL_NAME_PREFIX);

--- a/src/transformers/basePathTransformer.ts
+++ b/src/transformers/basePathTransformer.ts
@@ -24,8 +24,8 @@ export class BasePathTransformer {
     public clearTargetContext(): void {
     }
 
-    public scriptParsed(scriptPath: string): string {
-        return scriptPath;
+    public scriptParsed(scriptPath: string): Promise<string> {
+        return Promise.resolve(scriptPath);
     }
 
     public breakpointResolved(bp: DebugProtocol.Breakpoint, targetPath: string): string {
@@ -35,7 +35,7 @@ export class BasePathTransformer {
     public stackTraceResponse(response: IStackTraceResponseBody): void {
     }
 
-    public fixSource(source: DebugProtocol.Source): void {
+    public async fixSource(source: DebugProtocol.Source): Promise<void> {
     }
 
     public getTargetPathFromClientPath(clientPath: string): string {

--- a/src/transformers/fallbackToClientPathTransformer.ts
+++ b/src/transformers/fallbackToClientPathTransformer.ts
@@ -22,10 +22,9 @@ export class FallbackToClientPathTransformer extends UrlPathTransformer {
         return super.targetUrlToClientPath(webRoot, scriptUrl).then(filePath => {
                 // If it returns a valid non empty file path then that should be a valid result, so we use that
                 // If it's an eval script we won't be able to map it, so we also return that
-                // In any other case we ask the client.
                 return (filePath || ChromeUtils.isEvalScript(scriptUrl))
                     ? filePath
-                    // If it doesn't, we ask the client to map it as a fallback
+                    // In any other case we ask the client to map it as a fallback, and return filePath if there is any failures
                     : this.requestClientToMapURLToFilePath(scriptUrl).catch(rejection => {
                         logger.log("The fallback transformation failed due to: " + rejection);
                         return filePath;

--- a/src/transformers/fallbackToClientPathTransformer.ts
+++ b/src/transformers/fallbackToClientPathTransformer.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+import {logger} from 'vscode-debugadapter';
+
+import * as fs from 'fs';
+import { UrlPathTransformer } from './urlPathTransformer';
+import { ChromeDebugSession} from '../chrome/chromeDebugSession';
+
+/**
+ * Converts a local path from Code to a path on the target. Uses the UrlPathTransforme logic and fallbacks to asking the client if neccesary
+ */
+export class FallbackToClientPathTransformer extends UrlPathTransformer {
+    private static ASK_CLIENT_TO_MAP_URL_TO_FILE_PATH_TIMEOUT = 500;
+
+    constructor(private _session: ChromeDebugSession) {
+        super();
+    }
+
+    protected async targetUrlToClientPath(webRoot: string, scriptUrl: string): Promise<string> {
+        // First try the default UrlPathTransformer transformation
+        return super.targetUrlToClientPath(webRoot, scriptUrl).then(filePath => {
+            // Check if the file returned by that transformation does exist
+            return new Promise<boolean>((resolve, reject) => {
+                try {
+                    fs.access(filePath, (err) => {
+                        resolve(err ? false : true);
+                    });
+                } catch (e) {
+                    resolve(false);
+                }
+            }).then(doesFilePathExist => doesFilePathExist
+                // If it does, we use that result
+                ? filePath
+                // If it doesn't, we ask the client to map it as a fallback
+                : this.requestClientToMapURLToFilePath(scriptUrl).catch(rejection => {
+                    logger.log("The fallback transformation failed due to: " + rejection);
+                    return filePath;
+                }));
+        });
+    }
+
+    private async requestClientToMapURLToFilePath(url: string): Promise<string> {
+        return new Promise<string>((resolve, reject) => {
+            this._session.sendRequest("mapURLToFilePath", {url: url}, FallbackToClientPathTransformer.ASK_CLIENT_TO_MAP_URL_TO_FILE_PATH_TIMEOUT, response => {
+                if (response.success) {
+                    logger.log(`The client responded that the url "${url}" maps to the file path "${response.body.filePath}"`);
+                    resolve(response.body.filePath);
+                } else {
+                    reject(new Error(`The client responded that the url "${url}" couldn't be mapped to a file path due to: ${response.message}`));
+                }
+            });
+        });
+    }
+}

--- a/src/transformers/remotePathTransformer.ts
+++ b/src/transformers/remotePathTransformer.ts
@@ -63,16 +63,16 @@ export class RemotePathTransformer extends BasePathTransformer {
         return super.setBreakpoints(args);
     }
 
-    public scriptParsed(scriptPath: string): string {
+    public scriptParsed(scriptPath: string): Promise<string> {
         scriptPath = this.getClientPathFromTargetPath(scriptPath);
         return super.scriptParsed(scriptPath);
     }
 
-    public stackTraceResponse(response: IStackTraceResponseBody): void {
-        response.stackFrames.forEach(stackFrame => this.fixSource(stackFrame.source));
+    public async stackTraceResponse(response: IStackTraceResponseBody): Promise<void> {
+        await Promise.all(response.stackFrames.map(stackFrame => this.fixSource(stackFrame.source)));
     }
 
-    public fixSource(source: DebugProtocol.Source): void {
+    public async fixSource(source: DebugProtocol.Source): Promise<void> {
         const remotePath = source && source.path;
         if (remotePath) {
             const localPath = this.getClientPathFromTargetPath(remotePath);

--- a/src/transformers/urlPathTransformer.ts
+++ b/src/transformers/urlPathTransformer.ts
@@ -9,7 +9,6 @@ import * as utils from '../utils';
 import {logger} from 'vscode-debugadapter';
 import {DebugProtocol} from 'vscode-debugprotocol';
 import * as ChromeUtils from '../chrome/chromeUtils';
-import {ChromeDebugAdapter} from '../chrome/chromeDebugAdapter';
 
 import * as path from 'path';
 
@@ -73,7 +72,7 @@ export class UrlPathTransformer extends BasePathTransformer {
 
         if (!clientPath) {
             // It's expected that eval scripts (eval://) won't be resolved
-            if (!scriptUrl.startsWith(ChromeDebugAdapter.EVAL_NAME_PREFIX)) {
+            if (!scriptUrl.startsWith(ChromeUtils.EVAL_NAME_PREFIX)) {
                 logger.log(`Paths.scriptParsed: could not resolve ${scriptUrl} to a file under webRoot: ${this._webRoot}. It may be external or served directly from the server's memory (and that's OK).`);
             }
         } else {

--- a/test/transformers/baseSourceMapTransformer.test.ts
+++ b/test/transformers/baseSourceMapTransformer.test.ts
@@ -142,7 +142,7 @@ suite('BaseSourceMapTransformer', () => {
         });
 
         // #106
-        test.skip(`if the source can't be mapped, waits until the runtime script is loaded`, () => {
+        test.skip(`if the source can't be mapped, waits until the runtime script is loaded`, async () => {
             const args = createArgs(AUTHORED_PATH, AUTHORED_BPS());
             const expected = createExpectedArgs(AUTHORED_PATH, RUNTIME_PATH, RUNTIME_BPS());
             const sourceMapURL = 'script.js.map';
@@ -172,7 +172,7 @@ suite('BaseSourceMapTransformer', () => {
             assert.deepEqual(args, expected);
             mock.verifyAll();
 
-            transformer.scriptParsed(RUNTIME_PATH, sourceMapURL);
+            await transformer.scriptParsed(RUNTIME_PATH, sourceMapURL);
             // return setBreakpointsP;
         });
 

--- a/test/transformers/urlPathTransformer.test.ts
+++ b/test/transformers/urlPathTransformer.test.ts
@@ -54,7 +54,7 @@ suite('UrlPathTransformer', () => {
             SET_BP_ARGS = { source: { path: CLIENT_PATH } };
         });
 
-        test('resolves correctly when it can map the client script to the target script', () => {
+        test('resolves correctly when it can map the client script to the target script', async () => {
             chromeUtilsMock
                 .setup(x => x.targetUrlToClientPathByPathMappings(It.isValue(TARGET_URL), It.isAny()))
                 .returns(() => '').verifiable();
@@ -63,7 +63,7 @@ suite('UrlPathTransformer', () => {
                 .setup(x => x.targetUrlToClientPath(It.isValue(undefined), It.isValue(TARGET_URL)))
                 .returns(() => CLIENT_PATH).verifiable();
 
-            transformer.scriptParsed(TARGET_URL);
+            await transformer.scriptParsed(TARGET_URL);
             transformer.setBreakpoints(<any>SET_BP_ARGS);
             assert.deepEqual(SET_BP_ARGS, EXPECTED_SET_BP_ARGS);
         });
@@ -82,7 +82,7 @@ suite('UrlPathTransformer', () => {
     });
 
     suite('scriptParsed', () => {
-        test('returns the client path when the file can be mapped', () => {
+        test('returns the client path when the file can be mapped', async () => {
             chromeUtilsMock
                 .setup(x => x.targetUrlToClientPathByPathMappings(It.isValue(TARGET_URL), It.isAny()))
                 .returns(() => '').verifiable();
@@ -91,10 +91,10 @@ suite('UrlPathTransformer', () => {
                 .setup(x => x.targetUrlToClientPath(It.isValue(undefined), It.isValue(TARGET_URL)))
                 .returns(() => CLIENT_PATH).verifiable();
 
-            assert.equal(transformer.scriptParsed(TARGET_URL), CLIENT_PATH);
+            assert.equal(await transformer.scriptParsed(TARGET_URL), CLIENT_PATH);
         });
 
-        test(`returns the given path when the file can't be mapped`, () => {
+        test(`returns the given path when the file can't be mapped`, async () => {
             chromeUtilsMock
                 .setup(x => x.targetUrlToClientPathByPathMappings(It.isValue(TARGET_URL), It.isAny()))
                 .returns(() => '').verifiable();
@@ -103,15 +103,19 @@ suite('UrlPathTransformer', () => {
                 .setup(x => x.targetUrlToClientPath(It.isValue(undefined), It.isValue(TARGET_URL)))
                 .returns(() => '').verifiable();
 
-            assert.equal(transformer.scriptParsed(TARGET_URL), TARGET_URL);
+            chromeUtilsMock
+                .setup(x => x.EVAL_NAME_PREFIX)
+                .returns(() => 'VM').verifiable();
+
+            assert.equal(await transformer.scriptParsed(TARGET_URL), TARGET_URL);
         });
 
-        test('ok with uncanonicalized paths', () => {
+        test('ok with uncanonicalized paths', async () => {
             chromeUtilsMock
                 .setup(x => x.targetUrlToClientPathByPathMappings(It.isValue(TARGET_URL + '?queryparam'), It.isAny()))
                 .returns(() => CLIENT_PATH).verifiable();
 
-            assert.equal(transformer.scriptParsed(TARGET_URL + '?queryparam'), CLIENT_PATH);
+            assert.equal(await transformer.scriptParsed(TARGET_URL + '?queryparam'), CLIENT_PATH);
             assert.equal(transformer.getClientPathFromTargetPath(TARGET_URL + '?queryparam'), CLIENT_PATH);
             assert.equal(transformer.getTargetPathFromClientPath(CLIENT_PATH), TARGET_URL + '?queryparam');
         });
@@ -124,7 +128,7 @@ suite('UrlPathTransformer', () => {
             { line: 8, column: 9 }
         ];
 
-        test('modifies the source path and clears sourceReference when the file can be mapped', () => {
+        test('modifies the source path and clears sourceReference when the file can be mapped', async () => {
             chromeUtilsMock
                 .setup(x => x.targetUrlToClientPath(It.isValue(undefined), It.isValue(TARGET_URL)))
                 .returns(() => CLIENT_PATH).verifiable();
@@ -132,7 +136,7 @@ suite('UrlPathTransformer', () => {
             const response = testUtils.getStackTraceResponseBody(TARGET_URL, RUNTIME_LOCATIONS, [1, 2, 3]);
             const expectedResponse = testUtils.getStackTraceResponseBody(CLIENT_PATH, RUNTIME_LOCATIONS);
 
-            transformer.stackTraceResponse(response);
+            await transformer.stackTraceResponse(response);
             assert.deepEqual(response, expectedResponse);
         });
 


### PR DESCRIPTION
For some programs the debugger might not have enough information to figure out how to map all the URLs to file paths, so we can ask the client if he knows how to do it

@roblourens @rakatyal 