### PR TITLE
Ignore some regex characters in sourcemap overrides pattern

### DIFF
--- a/src/sourceMaps/sourceMapUtils.ts
+++ b/src/sourceMaps/sourceMapUtils.ts
@@ -36,7 +36,7 @@ export function getComputedSourceRoot(sourceRoot: string, generatedPath: string,
             } else {
                 // generatedPath is a URL so runtime script is not on disk, resolve the sourceRoot location on disk
                 const genDirname = path.dirname(url.parse(generatedPath).pathname);
-                absSourceRoot =  path.join(webRoot, genDirname, sourceRoot);
+                absSourceRoot = path.join(webRoot, genDirname, sourceRoot);
             }
         }
 
@@ -48,7 +48,7 @@ export function getComputedSourceRoot(sourceRoot: string, generatedPath: string,
         // runtime script is not on disk, resolve the sourceRoot location on disk
         const urlPath = url.parse(generatedPath).pathname;
         const scriptPathDirname = urlPath ? path.dirname(urlPath) : ''; // could be debugadapter://123, no other info.
-        absSourceRoot =  path.join(webRoot, scriptPathDirname);
+        absSourceRoot = path.join(webRoot, scriptPathDirname);
         logger.log(`SourceMap: no sourceRoot specified, using webRoot + script path dirname: ${absSourceRoot}`);
     }
 
@@ -87,7 +87,7 @@ export function applySourceMapPathOverrides(sourcePath: string, sourceMapPathOve
         const patternSegment = pattern
             .replace(/\*/g, '(.*)')
             .replace(/\\/g, '/');
-        const patternRegex = new RegExp(`^${patternSegment}$`, 'i');
+        const patternRegex = new RegExp(`^${utils.escapeSomeRegExpCharacters(patternSegment)}$`, 'i');
         const overridePatternMatches = forwardSlashSourcePath.match(patternRegex);
         if (!overridePatternMatches)
             continue;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -384,7 +384,7 @@ export function multiGlob(patterns: string[], opts?: any): Promise<string[]> {
                 }
             });
         });
-    })).then(results =>  {
+    })).then(results => {
         const set = new Set<string>();
         for (let paths of results) {
             for (let p of paths) {
@@ -541,6 +541,10 @@ export function isNumber(num: number): boolean {
 
 export function escapeRegExpCharacters(value: string): string {
     return value.replace(/[\-\\\{\}\*\+\?\|\^\$\.\[\]\(\)\#]/g, '\\$&');
+}
+
+export function escapeSomeRegExpCharacters(value: string): string {
+    return value.replace(/[-[\]{}+?,^$|#\s]/g, '\\$&');
 }
 
 export function toVoidP(p: Promise<any>): Promise<void> {

--- a/test/sourceMaps/sourceMapUtils.test.ts
+++ b/test/sourceMaps/sourceMapUtils.test.ts
@@ -88,7 +88,7 @@ suite('SourceMapUtils', () => {
 
         test('works using the laptop emoji', () => {
             assert.deepEqual(
-                applySourceMapPathOverrides('meteor:///💻app/src/main.js', { 'meteor:///💻app/*': testUtils.pathResolve('/project/*')}),
+                applySourceMapPathOverrides('meteor:///💻app/src/main.js', { 'meteor:///💻app/*': testUtils.pathResolve('/project/*') }),
                 testUtils.pathResolve('/project/src/main.js'));
         });
 
@@ -125,6 +125,12 @@ suite('SourceMapUtils', () => {
         test('replaces an asterisk at the beginning', () => {
             assert.deepEqual(
                 applySourceMapPathOverrides('/src/app.js', { '*/app.js': testUtils.pathResolve('/project/*/app.js') }),
+                testUtils.pathResolve('/project/src/app.js'));
+        });
+
+        test('allows some regex characters in the pattern', () => {
+            assert.deepEqual(
+                applySourceMapPathOverrides('webpack+foo:///src/app.js', { 'webpack+foo:///*/app.js': testUtils.pathResolve('/project/*/app.js') }),
                 testUtils.pathResolve('/project/src/app.js'));
         });
 


### PR DESCRIPTION
I'm trying to setup [`vscode-chrome-debug`](https://github.com/Microsoft/vscode-chrome-debug) for our project.

The source map URLs for our projects look like this:

```
webpack+subproject:///./src/js/actions/accordion.js
```

So I tried the following 

```json
"sourceMapPathOverrides": {
  "webpack+subproject:///./*": "${webRoot}/*"
}
```

...but that didn't work because the code for the overrides treats the `+` as part of a regex, which it's not.

I've modified the code in `sourceMapUtils.ts` to ignore some regex characters in the override URLs. Not sure if that's the right solution, but I hope that at least it illustrates the problem.

(Sorry for mixing in formatting changes there!)