### PR TITLE
fix: handle is undefined

### DIFF
--- a/src/transformers/baseSourceMapTransformer.ts
+++ b/src/transformers/baseSourceMapTransformer.ts
@@ -91,7 +91,7 @@ export class BaseSourceMapTransformer {
             // If the source contents were inlined, then args.source has no path, but we
             // stored it in the handle
             const handle = this._sourceHandles.get(args.source.sourceReference);
-            if (handle.mappedPath) {
+            if (handle && handle.mappedPath) {
                 args.source.path = handle.mappedPath;
             }
         }


### PR DESCRIPTION
Debugging on macOS with node 8.7, receiving the error that is originating from `handle is undefined`. I'm not sure about the reasons but simple check fixes the debug support for me.