### PR TITLE
Don't add the same breakpoint id to cache.

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -755,7 +755,9 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         }
 
         const committedBps = this._committedBreakpointsByUrl.get(script.url) || [];
-        committedBps.push(params.breakpointId);
+        if (committedBps.indexOf(params.breakpointId) === -1) {
+            committedBps.push(params.breakpointId);
+        }
         this._committedBreakpointsByUrl.set(script.url, committedBps);
 
         const bp = <DebugProtocol.Breakpoint>{


### PR DESCRIPTION
Or otherwise the same breakpoint id will be registered twice. This can happen when EDP choose to send breakpointResolved event even if the response for setBreakpointByUrl already contains the information for the same bound breakpoint.