### PR TITLE
fix undefined variable exception

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -1083,7 +1083,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
                 let targetScriptUrl: string;
                 if (args.source.sourceReference) {
                     const handle = this._sourceHandles.get(args.source.sourceReference);
-                    if (!handle.scriptId && args.source.path) {
+                    if ((!handle || !handle.scriptId) && args.source.path) {
                         // A sourcemapped script with inline sources won't have a scriptId here, but the
                         // source.path has been fixed.
                         targetScriptUrl = args.source.path;


### PR DESCRIPTION
Exception appears after editing breakpoints list from the editor. I don't have a concrete way to repro but submitting this fix after having the same problem for the third time. Simply, `handle` is `undefined` hence reaching out `scriptId` throws an exception.