### PR TITLE
Expose the connection object, so the derivative class can revisit the…

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -103,9 +103,8 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
     private _pendingBreakpointsByUrl: Map<string, IPendingBreakpoint>;
     private _hitConditionBreakpointsById: Map<Crdp.Debugger.BreakpointId, IHitConditionBreakpoint>;
 
-    private _chromeConnection: ChromeConnection;
-
     private _lineColTransformer: LineColTransformer;
+    protected _chromeConnection: ChromeConnection;
     protected _sourceMapTransformer: BaseSourceMapTransformer;
     protected _pathTransformer: BasePathTransformer;
 

--- a/src/chrome/chromeTargetDiscoveryStrategy.ts
+++ b/src/chrome/chromeTargetDiscoveryStrategy.ts
@@ -22,7 +22,7 @@ export class ChromeTargetDiscovery implements ITargetDiscoveryStrategy {
         this.telemetry = _telemetry;
     }
 
-    async getTarget(address: string, port: number, targetFilter?: ITargetFilter, targetUrl?: string): Promise<string> {
+    async getTarget(address: string, port: number, targetFilter?: ITargetFilter, targetUrl?: string): Promise<ITarget> {
         const targets = await this.getAllTargets(address, port, targetFilter, targetUrl);
         if (targets.length > 1) {
             this.logger.log('Warning: Found more than one valid target page. Attaching to the first one. Available pages: ' + JSON.stringify(targets.map(target => target.url)));
@@ -33,7 +33,7 @@ export class ChromeTargetDiscovery implements ITargetDiscoveryStrategy {
         this.logger.verbose(`Attaching to target: ${JSON.stringify(selectedTarget)}`);
         this.logger.verbose(`WebSocket Url: ${selectedTarget.webSocketDebuggerUrl}`);
 
-        return selectedTarget.webSocketDebuggerUrl;
+        return selectedTarget;
     }
 
     async getAllTargets(address: string, port: number, targetFilter?: ITargetFilter, targetUrl?: string): Promise<ITarget[]> {

--- a/test/chrome/chromeTargetDiscoveryStrategy.test.ts
+++ b/test/chrome/chromeTargetDiscoveryStrategy.test.ts
@@ -73,8 +73,8 @@ suite('ChromeTargetDiscoveryStrategy', () => {
                 }];
             registerTargetListContents(JSON.stringify(targets));
 
-            return getChromeTargetDiscoveryStrategy().getTarget(TARGET_ADDRESS, TARGET_PORT, target => target.url === targets[1].url).then(wsUrl => {
-                assert.deepEqual(wsUrl, targets[1].webSocketDebuggerUrl);
+            return getChromeTargetDiscoveryStrategy().getTarget(TARGET_ADDRESS, TARGET_PORT, target => target.url === targets[1].url).then(target => {
+                assert.deepEqual(target.webSocketDebuggerUrl, targets[1].webSocketDebuggerUrl);
             });
         });
 
@@ -120,8 +120,8 @@ suite('ChromeTargetDiscoveryStrategy', () => {
                 }];
             registerTargetListContents(JSON.stringify(targets));
 
-            return getChromeTargetDiscoveryStrategy().getTarget(TARGET_ADDRESS, TARGET_PORT, target => target.url === targets[1].url).then(wsUrl => {
-                assert.deepEqual(wsUrl, targets[1].webSocketDebuggerUrl);
+            return getChromeTargetDiscoveryStrategy().getTarget(TARGET_ADDRESS, TARGET_PORT, target => target.url === targets[1].url).then(target => {
+                assert.deepEqual(target.webSocketDebuggerUrl, targets[1].webSocketDebuggerUrl);
             });
         });
 
@@ -137,8 +137,8 @@ suite('ChromeTargetDiscoveryStrategy', () => {
                 }];
             registerTargetListContents(JSON.stringify(targets));
 
-            return getChromeTargetDiscoveryStrategy().getTarget(TARGET_ADDRESS, TARGET_PORT).then(wsUrl => {
-                assert.deepEqual(wsUrl, targets[0].webSocketDebuggerUrl);
+            return getChromeTargetDiscoveryStrategy().getTarget(TARGET_ADDRESS, TARGET_PORT).then(target => {
+                assert.deepEqual(target.webSocketDebuggerUrl, targets[0].webSocketDebuggerUrl);
             });
         });
 
@@ -155,8 +155,8 @@ suite('ChromeTargetDiscoveryStrategy', () => {
             registerTargetListContents(JSON.stringify(targets));
 
             const expectedWebSockerDebuggerUrl = `ws://${TARGET_ADDRESS}:${TARGET_PORT}`;
-            return getChromeTargetDiscoveryStrategy().getTarget(TARGET_ADDRESS, TARGET_PORT).then(wsUrl => {
-                assert.deepEqual(wsUrl, expectedWebSockerDebuggerUrl);
+            return getChromeTargetDiscoveryStrategy().getTarget(TARGET_ADDRESS, TARGET_PORT).then(target => {
+                assert.deepEqual(target.webSocketDebuggerUrl, expectedWebSockerDebuggerUrl);
             });
         });
 
@@ -173,8 +173,8 @@ suite('ChromeTargetDiscoveryStrategy', () => {
             registerTargetListContents(JSON.stringify(targets));
 
             const expectedWebSockerDebuggerUrl = `ws://${TARGET_ADDRESS}:${TARGET_PORT}/foo`;
-            return getChromeTargetDiscoveryStrategy().getTarget(TARGET_ADDRESS, TARGET_PORT).then(wsUrl => {
-                assert.deepEqual(wsUrl, expectedWebSockerDebuggerUrl);
+            return getChromeTargetDiscoveryStrategy().getTarget(TARGET_ADDRESS, TARGET_PORT).then(target => {
+                assert.deepEqual(target.webSocketDebuggerUrl, expectedWebSockerDebuggerUrl);
             });
         });
     });


### PR DESCRIPTION
Expose the connection object, so the derivative class can revisit the targets as needed.

Currently the series of attach() method could not surface back the debugger id from the response of calling /json/list. Instead of refactoring the code and returning that, it might be cleaner to have the downstream logic query the targets again when needed.