### PR TITLE
Make reporting loadedScource event customizable.

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -72,6 +72,8 @@ export type CrdpScript = Crdp.Debugger.ScriptParsedEvent;
 
 export type CrdpDomain = keyof Crdp.CrdpClient;
 
+export type LoadedSourceEventReason = 'new' | 'changed' | 'removed';
+
 export abstract class ChromeDebugAdapter implements IDebugAdapter {
     public static EVAL_NAME_PREFIX = ChromeUtils.EVAL_NAME_PREFIX;
     public static EVAL_ROOT = '<eval>';
@@ -700,8 +702,8 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         }
     }
 
-    private async sendLoadedSourceEvent(script: Crdp.Debugger.ScriptParsedEvent): Promise<void> {
-        const scriptEvent = await this.scriptToLoadedSourceEvent('new', script);
+    protected async sendLoadedSourceEvent(script: Crdp.Debugger.ScriptParsedEvent, loadedSourceEventReason: LoadedSourceEventReason = 'new'): Promise<void> {
+        const scriptEvent = await this.scriptToLoadedSourceEvent(loadedSourceEventReason, script);
         this._session.sendEvent(scriptEvent);
     }
 
@@ -1582,7 +1584,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         };
     }
 
-    private async scriptToLoadedSourceEvent(reason: 'new' | 'changed' | 'removed', script: Crdp.Debugger.ScriptParsedEvent): Promise<LoadedSourceEvent> {
+    private async scriptToLoadedSourceEvent(reason: LoadedSourceEventReason, script: Crdp.Debugger.ScriptParsedEvent): Promise<LoadedSourceEvent> {
         const source = await this.scriptToSource(script);
         return new LoadedSourceEvent(reason, source as any);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
 import {logger} from 'vscode-debugadapter';
 
 import * as chromeConnection from './chrome/chromeConnection';
-import {ChromeDebugAdapter} from './chrome/chromeDebugAdapter';
+import {ChromeDebugAdapter, LoadedSourceEventReason} from './chrome/chromeDebugAdapter';
 import {ChromeDebugSession, IChromeDebugSessionOpts} from './chrome/chromeDebugSession';
 import * as chromeTargetDiscoveryStrategy from './chrome/chromeTargetDiscoveryStrategy';
 import * as chromeUtils from './chrome/chromeUtils';
@@ -34,6 +34,7 @@ export {
     chromeUtils,
     logger,
     stoppedEvent,
+    LoadedSourceEventReason,
 
     UrlPathTransformer,
     BasePathTransformer,


### PR DESCRIPTION
So the subclass can override the implementation of `sendLoadedSourceEvent()` and decide what the reason is.