### PR TITLE
Block while parsing scripts to prevent sending 'removes' before 'adds'

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "tslint-eslint-rules": "^1.5.0",
     "tslint-microsoft-contrib": "^2.0.10",
     "typemoq": "^0.3.3",
-    "typescript": "^2.4.1",
+    "typescript": "2.6.2",
     "vscode-nls-dev": "^2.1.6"
   },
   "scripts": {


### PR DESCRIPTION
We were running into an issue where we send 'remove' myscript.js before we sent the 'add' myscript.js when we went into a page, and quickly redirected into another page.

That happened because we have some async code in how we process onScriptParsed, so that processing can be on-flight, and onExecutionContextsCleared very quickly sends the 'remove' events, and we weren't waiting for the onScriptParsed events to be completed.
This fixes solve part of the issue.

I think there is another unrelated reason that I'm investigating after this.