### PR TITLE
Allow child-class to customize the creation of IVariableContainer .

### DIFF
--- a/testSupport/package.json
+++ b/testSupport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-chrome-debug-core-testsupport",
-  "version": "3.21.0",
+  "version": "4.0.0",
   "description": "Tools for tests that use vscode-debugadapter-testsupport and vscode-chrome-debug-core",
   "main": "out/index.js",
   "typings": "out/index.d.ts",


### PR DESCRIPTION
This allows another Debug Adapter implementation to decide what will happen when an object is expanded and its properties are shown, and how to change value for each of the properties it owns. 

We need this, because EDP uses a different way of changing an object's property. The current logic in [setPropertyValue](https://github.com/Microsoft/vscode-chrome-debug-core/blob/61b6124f081af95d3668fe8e57f2973d09b9ac0d/src/chrome/chromeDebugAdapter.ts#L2163) does not work for EDP.

After this override point is enabled. We are able to create and use another IVariableContainer like this: [MSPropertyContainer](https://github.com/Microsoft/vscode-edge-debug2/pull/6/files#diff-319696e7982018f374e2588fced7229eR16). There we capture the needed metadata when an object is expanded. And use that metadata to change an object property value when `setValue()` method is called.

