### PR TITLE
Fix breakpoint not hitting in refresh because it's being set on a negative line

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -1096,8 +1096,9 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
 
         return this.validateBreakpointsPath(args)
             .then(() => {
-                // Deep copy args to originalArgs
-                const originalArgs: ISetBreakpointsArgs = JSON.parse(JSON.stringify(args));
+                // Deep copy the args that we are going to modify, and keep the original values in originalArgs
+                const originalArgs = args;
+                args = JSON.parse(JSON.stringify(args));
                 this._lineColTransformer.setBreakpoints(args);
                 this._sourceMapTransformer.setBreakpoints(args, requestSeq);
                 this._pathTransformer.setBreakpoints(args);


### PR DESCRIPTION
Breakpoints weren't being hit after refresh because BreakOnLoadHelper.resolvePendingBreakpoints was passing a value from inside this._chromeDebugAdapter.pendingBreakpointsByUrl to chromeDebugAdapter.setBreakpoints, and setBreakpoints was calling LineColTransformer and substracting 1 to the line number again.

The deep copy on args prevents setBreakpoints from modifying the original args...