### PR TITLE
Fix break-on-load breakpoint not hitting on the first line for Chrome

### DIFF
--- a/src/chrome/breakOnLoadHelper.ts
+++ b/src/chrome/breakOnLoadHelper.ts
@@ -66,7 +66,7 @@ export class BreakOnLoadHelper {
         }
     }
 
-    private getPausedScriptUrlFromId(scriptId: string): string {
+    private getScriptUrlFromId(scriptId: string): string {
         return this._chromeDebugAdapter.scriptsById.get(scriptId).url;
     }
 
@@ -75,7 +75,7 @@ export class BreakOnLoadHelper {
      * Used when break on load active, either through Chrome's Instrumentation Breakpoint API or the regex approach
      */
     private async resolvePendingBreakpointsOfPausedScript(scriptId: string): Promise<boolean> {
-        const pausedScriptUrl = this.getPausedScriptUrlFromId(scriptId);
+        const pausedScriptUrl = this.getScriptUrlFromId(scriptId);
         const sourceMapUrl = this._chromeDebugAdapter.scriptsById.get(scriptId).sourceMapURL;
         const mappedUrl = await this._chromeDebugAdapter.pathTransformer.scriptParsed(pausedScriptUrl);
         let breakpointsResolved = false;
@@ -133,7 +133,7 @@ export class BreakOnLoadHelper {
         // using committedBreakpointsByUrl for our logic.
         let anyPendingBreakpointsResolved = await this.resolvePendingBreakpointsOfPausedScript(pausedLocation.scriptId);
 
-        const pausedScriptUrl = this.getPausedScriptUrlFromId(pausedLocation.scriptId);
+        const pausedScriptUrl = this.getScriptUrlFromId(pausedLocation.scriptId);
         // Important: We need to get the committed breakpoints only after all the pending breakpoints for this file have been resolved. If not this logic won't work
         const committedBps = this._chromeDebugAdapter.committedBreakpointsByUrl.get(pausedScriptUrl);
         const anyBreakpointsAtPausedLocation = committedBps.filter(bp =>

--- a/src/chrome/breakOnLoadHelper.ts
+++ b/src/chrome/breakOnLoadHelper.ts
@@ -134,9 +134,9 @@ export class BreakOnLoadHelper {
         let anyPendingBreakpointsResolved = await this.resolvePendingBreakpointsOfPausedScript(pausedLocation.scriptId);
 
         const pausedScriptUrl = this.getPausedScriptUrlFromId(pausedLocation.scriptId);
-        // Important: We need to get the commited breakpoints only after all the pending breakpoints for this file have been resolved. If not this logic won't work
-        const commitedBps = this._chromeDebugAdapter.committedBreakpointsByUrl.get(pausedScriptUrl);
-        const anyBreakpointsAtPausedLocation = commitedBps.filter(bp =>
+        // Important: We need to get the committed breakpoints only after all the pending breakpoints for this file have been resolved. If not this logic won't work
+        const committedBps = this._chromeDebugAdapter.committedBreakpointsByUrl.get(pausedScriptUrl);
+        const anyBreakpointsAtPausedLocation = committedBps.filter(bp =>
             bp.actualLocation.lineNumber === pausedLocation.lineNumber && bp.actualLocation.columnNumber === pausedLocation.columnNumber).length > 0;
 
         // If there were any pending breakpoints resolved and any of them was at (1,1) we shouldn't continue

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -945,7 +945,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         }
 
         const committedBps = this._committedBreakpointsByUrl.get(script.url) || [];
-        if (committedBps.findIndex(committedBp => committedBp.breakpointId === params.breakpointId) === -1) {
+        if (!committedBps.find(committedBp => committedBp.breakpointId === params.breakpointId)) {
             committedBps.push({breakpointId: params.breakpointId, actualLocation: params.location});
         }
         this._committedBreakpointsByUrl.set(script.url, committedBps);

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -1319,7 +1319,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
     private targetBreakpointResponsesToClientBreakpoints(url: string, responses: ISetBreakpointResult[], requestBps: DebugProtocol.SourceBreakpoint[], ids?: number[]): DebugProtocol.Breakpoint[] {
         // Don't cache errored responses
         const committedBps = responses
-            .filter(response => response && response.breakpointId)
+            .filter(response => response && response.breakpointId);
 
         // Cache successfully set breakpoint ids from chrome in committedBreakpoints set
         this._committedBreakpointsByUrl.set(url, committedBps);

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -88,7 +88,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
     protected _domains = new Map<CrdpDomain, Crdp.Schema.Domain>();
     private _clientAttached: boolean;
     private _currentPauseNotification: Crdp.Debugger.PausedEvent;
-    private _committedBreakpointsByUrl: Map<string, Crdp.Debugger.BreakpointId[]>;
+    private _committedBreakpointsByUrl: Map<string, ISetBreakpointResult[]>;
     private _exception: Crdp.Runtime.RemoteObject;
     private _setBreakpointsRequestQ: Promise<any>;
     private _expectingResumedEvent: boolean;
@@ -175,6 +175,10 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         return this._pendingBreakpointsByUrl;
     }
 
+    public get committedBreakpointsByUrl(): Map<string, ISetBreakpointResult[]> {
+        return this._committedBreakpointsByUrl;
+    }
+
     public get sourceMapTransformer(): BaseSourceMapTransformer{
         return this._sourceMapTransformer;
     }
@@ -188,7 +192,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         this._scriptsById = new Map<Crdp.Runtime.ScriptId, Crdp.Debugger.ScriptParsedEvent>();
         this._scriptsByUrl = new Map<string, Crdp.Debugger.ScriptParsedEvent>();
 
-        this._committedBreakpointsByUrl = new Map<string, Crdp.Debugger.BreakpointId[]>();
+        this._committedBreakpointsByUrl = new Map<string, ISetBreakpointResult[]>();
         this._setBreakpointsRequestQ = Promise.resolve();
 
         this._pathTransformer.clearTargetContext();
@@ -923,10 +927,6 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         return this.setBreakpoints(pendingBP.args, pendingBP.requestSeq, pendingBP.ids).then(response => {
             response.breakpoints.forEach((bp, i) => {
                 bp.id = pendingBP.ids[i];
-                // If any of the unbound breakpoints in this file is on (1,1), we set userBreakpointOnLine1Col1 to true
-                if (bp.line === 1 && bp.column === 1 && this.breakOnLoadActive) {
-                    this._breakOnLoadHelper.userBreakpointOnLine1Col1 = true;
-                }
                 this._session.sendEvent(new BreakpointEvent('changed', bp));
             });
         });
@@ -945,8 +945,8 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         }
 
         const committedBps = this._committedBreakpointsByUrl.get(script.url) || [];
-        if (committedBps.indexOf(params.breakpointId) === -1) {
-            committedBps.push(params.breakpointId);
+        if (committedBps.findIndex(committedBp => committedBp.breakpointId === params.breakpointId) === -1) {
+            committedBps.push({breakpointId: params.breakpointId, actualLocation: params.location});
         }
         this._committedBreakpointsByUrl.set(script.url, committedBps);
 
@@ -1233,8 +1233,8 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         // but there is a chrome bug where when removing 5+ or so breakpoints at once, it gets into a weird
         // state where later adds on the same line will fail with 'breakpoint already exists' even though it
         // does not break there.
-        return this._committedBreakpointsByUrl.get(url).reduce((p, breakpointId) => {
-            return p.then(() => this.chrome.Debugger.removeBreakpoint({ breakpointId })).then(() => { });
+        return this._committedBreakpointsByUrl.get(url).reduce((p, bp) => {
+            return p.then(() => this.chrome.Debugger.removeBreakpoint({ breakpointId: bp.breakpointId })).then(() => { });
         }, Promise.resolve()).then(() => {
             this._committedBreakpointsByUrl.delete(url);
         });
@@ -1318,12 +1318,11 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
 
     private targetBreakpointResponsesToClientBreakpoints(url: string, responses: ISetBreakpointResult[], requestBps: DebugProtocol.SourceBreakpoint[], ids?: number[]): DebugProtocol.Breakpoint[] {
         // Don't cache errored responses
-        const committedBpIds = responses
+        const committedBps = responses
             .filter(response => response && response.breakpointId)
-            .map(response => response.breakpointId);
 
         // Cache successfully set breakpoint ids from chrome in committedBreakpoints set
-        this._committedBreakpointsByUrl.set(url, committedBpIds);
+        this._committedBreakpointsByUrl.set(url, committedBps);
 
         // Map committed breakpoints to DebugProtocol response breakpoints
         return responses


### PR DESCRIPTION
The previous userBreakpointOnLine1Col1 logic depended on parts of the ScriptParsed method executing synchronically to set that instance variable before ScriptPaused started executing. In recent changes, I added some new awaits to ScriptParsed which make it not execute synchronical any more, so the existing logic doesn't work any more.