### PR TITLE
add pathMappingOverrides configuration

### DIFF
--- a/src/debugAdapterInterfaces.d.ts
+++ b/src/debugAdapterInterfaces.d.ts
@@ -21,6 +21,7 @@ export interface ICommonRequestArgs {
     remoteRoot?: string;
     localRoot?: string;
     pathMapping?: {[url: string]: string};
+    pathMappingOverrides?: {[find: string]: string};
     outDir?: string;
     outFiles?: string[];
     sourceMaps?: boolean;

--- a/src/transformers/urlPathTransformer.ts
+++ b/src/transformers/urlPathTransformer.ts
@@ -20,16 +20,19 @@ export class UrlPathTransformer extends BasePathTransformer {
     private _pathMapping: {[url: string]: string} = {};
     private _clientPathToTargetUrl = new Map<string, string>();
     private _targetUrlToClientPath = new Map<string, string>();
+    private _pathMappingOverrides: {[find: string]: string};
 
     public launch(args: ILaunchRequestArgs): Promise<void> {
         this._webRoot = args.webRoot;
         this._pathMapping = args.pathMapping || {};
+        this._pathMappingOverrides = args.pathMappingOverrides;
         return super.launch(args);
     }
 
     public attach(args: IAttachRequestArgs): Promise<void> {
         this._webRoot = args.webRoot;
         this._pathMapping = args.pathMapping || {};
+        this._pathMappingOverrides = args.pathMappingOverrides;
         return super.attach(args);
     }
 
@@ -64,7 +67,7 @@ export class UrlPathTransformer extends BasePathTransformer {
     }
 
     public async scriptParsed(scriptUrl: string): Promise<string> {
-        let clientPath = ChromeUtils.targetUrlToClientPathByPathMappings(scriptUrl, this._pathMapping);
+        let clientPath = ChromeUtils.targetUrlToClientPathByPathMappings(scriptUrl, this._pathMapping, this._pathMappingOverrides);
 
         if (!clientPath) {
             clientPath = await this.targetUrlToClientPath(this._webRoot, scriptUrl);


### PR DESCRIPTION
Rather than implement wildcards, which seems too complex, I added a new "pathMappingOverrides" block to do a simple find/replace on mapped file paths. It seems to work for my case, which is to enable Sprockets 3 support:  https://github.com/Microsoft/vscode-chrome-debug/issues/598

Basically with this launch.json:

```json
"pathMapping": {
  "/assets": "${workspaceFolder}/app/assets/javascripts"
},
"pathMappingOverrides": {
  ".self": ""
}
```

I can debug assets like: `http://localhost:3000/assets/session.self.js` mapped to `~\my-rails-app\app\assets\javascripts\session.js`

### todo

- design approval?
- tests?