### PR TITLE
Updated code so now we resolve pending breakpoints onScriptParsed instead onScriptPaused when using break on load

### DIFF
--- a/src/chrome/breakOnLoadHelper.ts
+++ b/src/chrome/breakOnLoadHelper.ts
@@ -74,7 +74,7 @@ export class BreakOnLoadHelper {
 
             const pausedScriptId = notification.callFrames[0].location.scriptId;
             // Now we wait for all the pending breakpoints to be resolved and then continue
-            await this._chromeDebugAdapter.breakpointsResolvedDefer(pausedScriptId).promise;
+            await this._chromeDebugAdapter.getBreakpointsResolvedDefer(pausedScriptId).promise;
             return true;
         }
         return false;
@@ -90,7 +90,7 @@ export class BreakOnLoadHelper {
 
         // Important: For the logic that verifies if a user breakpoint is set in the paused location, we need to resolve pending breakpoints, and commit them, before
         // using committedBreakpointsByUrl for our logic.
-        await this._chromeDebugAdapter.breakpointsResolvedDefer(pausedLocation.scriptId).promise;
+        await this._chromeDebugAdapter.getBreakpointsResolvedDefer(pausedLocation.scriptId).promise;
 
         const pausedScriptUrl = this.getScriptUrlFromId(pausedLocation.scriptId);
         // Important: We need to get the committed breakpoints only after all the pending breakpoints for this file have been resolved. If not this logic won't work
@@ -98,7 +98,7 @@ export class BreakOnLoadHelper {
         const anyBreakpointsAtPausedLocation = committedBps.filter(bp =>
             bp.actualLocation.lineNumber === pausedLocation.lineNumber && bp.actualLocation.columnNumber === pausedLocation.columnNumber).length > 0;
 
-        // If there were any breakpoints at (1,1) we shouldn't continue
+        // If there were any breakpoints at this location (Which generally should be (1,1)) we shouldn't continue
         if (anyBreakpointsAtPausedLocation) {
             // Here we need to store this information per file, but since we can safely assume that scriptParsed would immediately be followed by onPaused event
             // for the breakonload files, this implementation should be fine

--- a/src/chrome/breakOnLoadHelper.ts
+++ b/src/chrome/breakOnLoadHelper.ts
@@ -52,55 +52,8 @@ export class BreakOnLoadHelper {
         return this._instrumentationBreakpointSet;
     }
 
-    /**
-     * Checks and resolves the pending breakpoints of a script given it's source. If any breakpoints were resolved returns true, else false.
-     * Used when break on load active, either through Chrome's Instrumentation Breakpoint API or the regex approach
-     */
-    private async resolvePendingBreakpoints(source: string): Promise<boolean> {
-        const normalizedSource = this._chromeDebugAdapter.fixPathCasing(source);
-        const pendingBreakpoints = this._chromeDebugAdapter.pendingBreakpointsByUrl.get(normalizedSource);
-        // If the file has unbound breakpoints, resolve them and return true
-        if (pendingBreakpoints !== undefined) {
-            await this._chromeDebugAdapter.resolvePendingBreakpoint(pendingBreakpoints);
-            if (!this._chromeDebugAdapter.pendingBreakpointsByUrl.delete(normalizedSource)) {
-                logger.log(`Expected to delete ${normalizedSource} from the list of pending breakpoints, but it wasn't there`);
-            }
-            return true;
-        } else {
-            // If no pending breakpoints, return false
-            return false;
-        }
-    }
-
     private getScriptUrlFromId(scriptId: string): string {
         return this._chromeDebugAdapter.scriptsById.get(scriptId).url;
-    }
-
-    /**
-     * Checks and resolves the pending breakpoints given a script Id. If any breakpoints were resolved returns true, else false.
-     * Used when break on load active, either through Chrome's Instrumentation Breakpoint API or the regex approach
-     */
-    private async resolvePendingBreakpointsOfPausedScript(scriptId: string): Promise<boolean> {
-        const pausedScriptUrl = this.getScriptUrlFromId(scriptId);
-        const sourceMapUrl = this._chromeDebugAdapter.scriptsById.get(scriptId).sourceMapURL;
-        const mappedUrl = await this._chromeDebugAdapter.pathTransformer.scriptParsed(pausedScriptUrl);
-        let breakpointsResolved = false;
-
-        let sources = await this._chromeDebugAdapter.sourceMapTransformer.scriptParsed(mappedUrl, sourceMapUrl);
-
-        // If user breakpoint was put in a typescript file, pendingBreakpoints would store the typescript file in the mapping, so we need to hit those
-        if (sources) {
-            for (let source of sources) {
-                let anySourceBPResolved = await this.resolvePendingBreakpoints(source);
-                // If any of the source files had breakpoints resolved, we should return true
-                breakpointsResolved = breakpointsResolved || anySourceBPResolved;
-            }
-        }
-        // If sources is not present or user breakpoint was put in a compiled javascript file
-        let scriptBPResolved = await this.resolvePendingBreakpoints(mappedUrl);
-        breakpointsResolved = breakpointsResolved || scriptBPResolved;
-
-        return breakpointsResolved;
     }
 
     /**
@@ -120,8 +73,8 @@ export class BreakOnLoadHelper {
             // This is fired when Chrome stops on the first line of a script when using the setInstrumentationBreakpoint API
 
             const pausedScriptId = notification.callFrames[0].location.scriptId;
-            // Now we should resolve all the pending breakpoints and then continue
-            await this.resolvePendingBreakpointsOfPausedScript(pausedScriptId);
+            // Now we wait for all the pending breakpoints to be resolved and then continue
+            await this._chromeDebugAdapter.breakpointsResolvedDefer(pausedScriptId).promise;
             return true;
         }
         return false;
@@ -137,16 +90,16 @@ export class BreakOnLoadHelper {
 
         // Important: For the logic that verifies if a user breakpoint is set in the paused location, we need to resolve pending breakpoints, and commit them, before
         // using committedBreakpointsByUrl for our logic.
-        let anyPendingBreakpointsResolved = await this.resolvePendingBreakpointsOfPausedScript(pausedLocation.scriptId);
+        await this._chromeDebugAdapter.breakpointsResolvedDefer(pausedLocation.scriptId).promise;
 
         const pausedScriptUrl = this.getScriptUrlFromId(pausedLocation.scriptId);
         // Important: We need to get the committed breakpoints only after all the pending breakpoints for this file have been resolved. If not this logic won't work
-        const committedBps = this._chromeDebugAdapter.committedBreakpointsByUrl.get(pausedScriptUrl);
+        const committedBps = this._chromeDebugAdapter.committedBreakpointsByUrl.get(pausedScriptUrl) || [];
         const anyBreakpointsAtPausedLocation = committedBps.filter(bp =>
             bp.actualLocation.lineNumber === pausedLocation.lineNumber && bp.actualLocation.columnNumber === pausedLocation.columnNumber).length > 0;
 
-        // If there were any pending breakpoints resolved and any of them was at (1,1) we shouldn't continue
-        if (anyPendingBreakpointsResolved && anyBreakpointsAtPausedLocation) {
+        // If there were any breakpoints at (1,1) we shouldn't continue
+        if (anyBreakpointsAtPausedLocation) {
             // Here we need to store this information per file, but since we can safely assume that scriptParsed would immediately be followed by onPaused event
             // for the breakonload files, this implementation should be fine
             shouldContinue = false;

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -727,8 +727,8 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
 
             if (this._initialSourceMapsP) {
                 this._initialSourceMapsP = <Promise<any>>Promise.all([this._initialSourceMapsP, sourceMapsP]);
-                await sourceMapsP;
             }
+            await sourceMapsP;
 
             breakpointsAreResolvedDefer.resolve(); // By now no matter which code path we choose, resolving pending breakpoints should be finished, so trigger the defer
         } catch (exception) {

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -34,6 +34,7 @@ import {BreakOnLoadHelper} from './breakOnLoadHelper';
 import * as path from 'path';
 
 import * as nls from 'vscode-nls';
+import { PromiseDefer, promiseDefer } from '../utils';
 let localize = nls.config(process.env.VSCODE_NLS_CONFIG)();
 
 interface IPropCount {
@@ -139,6 +140,9 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
     // Queue to synchronize new source loaded and source removed events so that 'remove' script events
     // won't be send before the corresponding 'new' event has been sent
     private _sourceLoadedQueue: Promise<void> = Promise.resolve(null);
+
+    // Promises so ScriptPaused events can wait for ScriptParsed events to finish resolving breakpoints
+    private _scriptIdToBreakpointsAreResolvedDefer = new Map<string, PromiseDefer<void>>();
 
     public constructor({ chromeConnection, lineColTransformer, sourceMapTransformer, pathTransformer, targetFilter, enableSourceMapCaching }: IChromeDebugAdapterOpts, session: ChromeDebugSession) {
         telemetry.setupEventHandler(e => session.sendEvent(e));
@@ -646,75 +650,88 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         this._lineColTransformer.columnBreakpointsEnabled = this._columnBreakpointsEnabled;
     }
 
-    protected async onScriptParsed(script: Crdp.Debugger.ScriptParsedEvent): Promise<void> {
-        this.doAfterProcessingSourceEvents(async () => { // This will block future 'removed' source events, until this processing has been completed
-            if (typeof this._columnBreakpointsEnabled === 'undefined') {
-                await this.detectColumnBreakpointSupport(script.scriptId).then(async () => {
-                    await this.sendInitializedEvent();
-                });
-            }
-
-            if (this._earlyScripts) {
-                this._earlyScripts.push(script);
-            } else {
-                await this.sendLoadedSourceEvent(script);
-            }
-        });
-
-        if (script.url) {
-            script.url = utils.fixDriveLetter(script.url);
+    public breakpointsResolvedDefer(scriptId: string): PromiseDefer<void> {
+        const existingValue =  this._scriptIdToBreakpointsAreResolvedDefer.get(scriptId);
+        if (existingValue) {
+            return existingValue;
         } else {
-            script.url = ChromeDebugAdapter.EVAL_NAME_PREFIX + script.scriptId;
+            const newValue = promiseDefer<void>();
+            this._scriptIdToBreakpointsAreResolvedDefer.set(scriptId, newValue);
+            return newValue;
         }
+    }
 
-        this._scriptsById.set(script.scriptId, script);
-        this._scriptsByUrl.set(this.fixPathCasing(script.url), script);
+    protected async onScriptParsed(script: Crdp.Debugger.ScriptParsedEvent): Promise<void> {
+        const breakpointsAreResolvedDefer = this.breakpointsResolvedDefer(script.scriptId);
+        try {
+            this.doAfterProcessingSourceEvents(async () => { // This will block future 'removed' source events, until this processing has been completed
+                if (typeof this._columnBreakpointsEnabled === 'undefined') {
+                    await this.detectColumnBreakpointSupport(script.scriptId).then(async () => {
+                        await this.sendInitializedEvent();
+                    });
+                }
 
-        const resolvePendingBPs = (source: string) => {
-            source = source && this.fixPathCasing(source);
-            const pendingBP = this._pendingBreakpointsByUrl.get(source);
-            if (pendingBP && !pendingBP.bpsSet) {
-                this.resolvePendingBreakpoint(pendingBP)
-                    .then(() => this._pendingBreakpointsByUrl.delete(source));
-            }
-        };
-
-        const mappedUrl = await this._pathTransformer.scriptParsed(script.url);
-
-        const sourceMapsP = this._sourceMapTransformer.scriptParsed(mappedUrl, script.sourceMapURL).then(sources => {
-            if (this._hasTerminated) {
-                return undefined;
-            }
-
-            if (sources) {
-                // If break on load is active, check whether we should call resolvePendingBPs
-                if (this.breakOnLoadActive) {
-                    sources
-                        .filter(source => source !== mappedUrl && this._breakOnLoadHelper.shouldResolvePendingBPs(source)) // Tools like babel-register will produce sources with the same path as the generated script
-                        .forEach(resolvePendingBPs);
+                if (this._earlyScripts) {
+                    this._earlyScripts.push(script);
                 } else {
+                    await this.sendLoadedSourceEvent(script);
+                }
+            });
+
+            if (script.url) {
+                script.url = utils.fixDriveLetter(script.url);
+            } else {
+                script.url = ChromeDebugAdapter.EVAL_NAME_PREFIX + script.scriptId;
+            }
+
+            this._scriptsById.set(script.scriptId, script);
+            this._scriptsByUrl.set(this.fixPathCasing(script.url), script);
+
+            const mappedUrl = await this._pathTransformer.scriptParsed(script.url);
+
+            const resolvePendingBPs = (source: string) => {
+                source = source && this.fixPathCasing(source);
+                const pendingBP = this._pendingBreakpointsByUrl.get(source);
+                if (pendingBP) { // DIEGO: Why did this say  && !pendingBP.bpsSet? Can I remove that?
+                    this.resolvePendingBreakpoint(pendingBP)
+                        .then(() => {
+                            this._pendingBreakpointsByUrl.delete(source);
+                            breakpointsAreResolvedDefer.resolve();
+                        });
+                } else {
+                    breakpointsAreResolvedDefer.resolve();
+                }
+            };
+
+            const sourceMapsP = this._sourceMapTransformer.scriptParsed(mappedUrl, script.sourceMapURL).then(async sources => {
+                if (this._hasTerminated) {
+                    return undefined;
+                }
+
+                if (sources) {
                     sources
                         .filter(source => source !== mappedUrl) // Tools like babel-register will produce sources with the same path as the generated script
                         .forEach(resolvePendingBPs);
                 }
-            }
 
-            if (script.url === mappedUrl && this._pendingBreakpointsByUrl.has(mappedUrl) && this._pendingBreakpointsByUrl.get(mappedUrl).bpsSet) {
-                // If the pathTransformer had no effect, and we attempted to set the BPs with that path earlier, then assume that they are about
-                // to be resolved in this loaded script, and remove the pendingBP.
-                this._pendingBreakpointsByUrl.delete(mappedUrl);
-            } else {
-                // If break on load is active, check whether we should call resolvePendingBPs
-                if (!this.breakOnLoadActive || (this._breakOnLoadHelper && !sources && this._breakOnLoadHelper.shouldResolvePendingBPs(mappedUrl))) {
+                if (script.url === mappedUrl && this._pendingBreakpointsByUrl.has(mappedUrl) && this._pendingBreakpointsByUrl.get(mappedUrl).bpsSet) {
+                    // If the pathTransformer had no effect, and we attempted to set the BPs with that path earlier, then assume that they are about
+                    // to be resolved in this loaded script, and remove the pendingBP.
+                    this._pendingBreakpointsByUrl.delete(mappedUrl);
+                } else {
                     resolvePendingBPs(mappedUrl);
                 }
+
+                await this.resolveSkipFiles(script, mappedUrl, sources);
+                breakpointsAreResolvedDefer.resolve(); // Make sure that the defer was resolved (this might be the second time we are calling resolve, if it is, it'll be ignored)
+            });
+
+            if (this._initialSourceMapsP) {
+                this._initialSourceMapsP = <Promise<any>>Promise.all([this._initialSourceMapsP, sourceMapsP]);
             }
 
-            return this.resolveSkipFiles(script, mappedUrl, sources);
-        });
-
-        if (this._initialSourceMapsP) {
-            this._initialSourceMapsP = <Promise<any>>Promise.all([this._initialSourceMapsP, sourceMapsP]);
+        } catch (exception) {
+            breakpointsAreResolvedDefer.reject(exception);
         }
     }
 

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -697,7 +697,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
                 source = source && this.fixPathCasing(source);
                 const pendingBP = this._pendingBreakpointsByUrl.get(source);
                 if (pendingBP && !pendingBP.bpsSet) {
-                    await this.resolvePendingBreakpoint(pendingBP)
+                    await this.resolvePendingBreakpoint(pendingBP);
                     this._pendingBreakpointsByUrl.delete(source);
                     breakpointsAreResolvedDefer.resolve();
                 } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -558,7 +558,8 @@ export interface PromiseDefer<T> {
 }
 
 export function promiseDefer<T>(): PromiseDefer<T> {
-    let resolveCallback, rejectCallback;
+    let resolveCallback;
+    let rejectCallback;
     const promise = new Promise<void>((resolve, reject) => {
         resolveCallback = resolve;
         rejectCallback = reject;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -550,3 +550,19 @@ export function isNumber(num: number): boolean {
 export function toVoidP(p: Promise<any>): Promise<void> {
     return p.then(() => { });
 }
+
+export interface PromiseDefer<T> {
+    promise: Promise<void>;
+    resolve: (value?: T | PromiseLike<T>) => void;
+    reject: (reason?: any) => void;
+}
+
+export function promiseDefer<T>(): PromiseDefer<T> {
+    let resolveCallback, rejectCallback;
+    const promise = new Promise<void>((resolve, reject) => {
+        resolveCallback = resolve;
+        rejectCallback = reject;
+    });
+
+    return { promise, resolve: resolveCallback, reject: rejectCallback };
+}


### PR DESCRIPTION
The general idea of this code change is that now all the pending breakpoints will get resolved onScriptParsed. Because we don't know in which order things will be executed, we'll have a defer used as a semaphore. The break-on-load logic inside onScriptPaused won't continue until the associated onScriptParsed has finished resolving all the pending breakpoints.

We need to make this change because of files that start with a function declaration, 0,0 is inside the function, so the break-on-load breakpoint is sometimes never hit, so then even after we refresh the page, no breakpoints are hit in that file because they are all still pending.

Is there a better way to solve this issue?

Some specific question:
I had to remove: "&& !pendingBP.bpsSet?" from line 697 to make this work. I'm not sure how that code was being used. It removing that code the right thing to do?
How should I handle the refresh case? Do we need to do anything special for that case? Should I call      this._scriptIdToBreakpointsAreResolvedDefer.clear(); inside clearTargetContext?