### PR TITLE
Introduces a mechanism to batch-sending telemetry events.

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -5,6 +5,19 @@
 import {DebugProtocol} from 'vscode-debugprotocol';
 import {OutputEvent} from 'vscode-debugadapter';
 
+export type ExceptionType = "uncaughtException" | "unhandledRejection" | "firstChance";
+export interface  IExecutionResultTelemetryProperties {
+    // There is an issue on some clients and reportEvent only currently accept strings properties,
+    // hence all the following properties must be strings.
+    successful?: "true" | "false";
+    exceptionType?: ExceptionType;
+    exceptionMessage?: string;
+    exceptionName?: string;
+    exceptionStack?: string;
+    startTime?: string;
+    timeTakenInMilliseconds?: string;
+}
+
 export interface ITelemetryReporter {
     reportEvent(name: string, data?: any): void;
     setupEventHandler(_sendEvent: (event: DebugProtocol.Event) => void): void;
@@ -34,6 +47,120 @@ export class NullTelemetryReporter implements ITelemetryReporter {
         // no-op
     }
 
+}
+
+export const DefaultTelemetryIntervalInMilliseconds = 10000;
+
+export class BatchTelemetryReporter {
+    private _eventBuckets: {[eventName: string]: any};
+    private _timer: NodeJS.Timer;
+
+    public constructor(private _telemetryReporter: TelemetryReporter, private _cadenceInMilliseconds: number = DefaultTelemetryIntervalInMilliseconds) {
+        this.reset();
+        this.setup();
+    }
+
+    public reportEvent(name: string, data?: any): void {
+        if (!this._eventBuckets[name]) {
+            this._eventBuckets[name] = [];
+        }
+
+        this._eventBuckets[name].push(data);
+    }
+
+    public finalize(): void {
+        this.send();
+        clearInterval(this._timer);
+    }
+
+    private setup(): void {
+        this._timer = setInterval(() => this.send(), this._cadenceInMilliseconds);
+    }
+
+    private reset(): void {
+        this._eventBuckets = {};
+    }
+
+    private send(): void {
+        for (const eventName in this._eventBuckets) {
+            const bucket = this._eventBuckets[eventName];
+            let properties = BatchTelemetryReporter.transfromBucketData(bucket);
+            this._telemetryReporter.reportEvent(eventName, properties);
+        }
+
+        this.reset();
+    }
+    /**
+     * Transfrom the bucket of events data from the form:
+     * [{
+     *  p1: v1,
+     *  p2: v2
+     * },
+     * {
+     *  p1: w1,
+     *  p2: w2
+     *  p3: w3
+     * }]
+     *
+     * to
+     * {
+     *   p1: [v1,   w1],
+     *   p2: [v2,   w2],
+     *   p3: [null, w3]
+     * }
+     *
+     *
+     * The later form is easier for downstream telemetry analysis.
+     */
+    private static transfromBucketData(bucketForEventType: any[]): {[groupedPropertyValue: string]: string} {
+        const allPropertyNamesInTheBucket = BatchTelemetryReporter.collectPropertyNamesFromAllEvents(bucketForEventType);
+        let properties = {};
+
+        // Create a holder for all potential property names.
+        for (const key of allPropertyNamesInTheBucket) {
+            properties[`aggregated.${key}`] = [];
+        }
+
+        // Run through all the events in the bucket, collect the values for each property name.
+        for (const event of bucketForEventType) {
+            for (const propertyName of allPropertyNamesInTheBucket) {
+                properties[`aggregated.${propertyName}`].push(event[propertyName] === undefined ? null : event[propertyName]);
+            }
+        }
+
+        // Serialize each array as the final aggregated property value.
+        for (const propertyName of allPropertyNamesInTheBucket) {
+            properties[`aggregated.${propertyName}`] = JSON.stringify(properties[`aggregated.${propertyName}`]);
+        }
+
+        return properties;
+    }
+
+    /**
+     * Get the property keys from all the entries of a event bucket:
+     *
+     * So
+     * [{
+     *  p1: v1,
+     *  p2: v2
+     * },
+     * {
+     *  p1: w1,
+     *  p2: w2
+     *  p3: w3
+     * }]
+     *
+     * will return ['p1', 'p2', 'p3']
+     */
+    private static collectPropertyNamesFromAllEvents(bucket: any[]): string[] {
+        let propertyNamesSet = {};
+        for (const entry of bucket) {
+            for (const key of Object.keys(entry)) {
+                propertyNamesSet[key] = true;
+            }
+        }
+        return Object.keys(propertyNamesSet);
+    }
 }
 
 export const telemetry = new TelemetryReporter();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,6 +11,8 @@ import {Handles, logger} from 'vscode-debugadapter';
 import * as http from 'http';
 import * as https from 'https';
 
+import {IExecutionResultTelemetryProperties} from './telemetry';
+
 export const enum Platform {
     Windows, OSX, Linux
 }
@@ -549,4 +551,25 @@ export function isNumber(num: number): boolean {
 
 export function toVoidP(p: Promise<any>): Promise<void> {
     return p.then(() => { });
+}
+
+export type HighResTimer = [number, number];
+
+export function calculateElapsedTime(startProcessingTime: HighResTimer): number {
+    const NanoSecondsPerMillisecond = 1000000;
+    const NanoSecondsPerSecond = 1e9;
+
+    const ellapsedTime = process.hrtime(startProcessingTime);
+    const ellapsedMilliseconds = (ellapsedTime[0] * NanoSecondsPerSecond + ellapsedTime[1]) / NanoSecondsPerMillisecond;
+    return ellapsedMilliseconds;
+}
+
+export function fillErrorDetails(properties: IExecutionResultTelemetryProperties, e: any): void {
+    properties.exceptionMessage = e.message || e.toString();
+    if (e.name) {
+        properties.exceptionName = e.name;
+    }
+    if (e.stack) {
+        properties.exceptionStack = e.stack;
+    }
 }


### PR DESCRIPTION
Batch-sending telemetry is necessary because some notifications from debuggee might be too frequent for the telemetry infrastructure to handle. Take VS as an example, it throttles telemetry events if there are two many within a short period of time. We will lose some important telemetry when that happens.

The `BatchTelemetryReporter` will cache the received telemetry events and sends them out every 10 seconds.

This PR also refactors some code and migrates some general telemetry handling code from DebugSession.ts to utils.ts or telemetry.ts.