### PR TITLE
Batch sending telemetry for some of the event notifications.

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -21,7 +21,7 @@ import {StoppedEvent2, ReasonType} from './stoppedEvent';
 
 import * as errors from '../errors';
 import * as utils from '../utils';
-import {telemetry} from '../telemetry';
+import {telemetry, BatchTelemetryReporter, IExecutionResultTelemetryProperties} from '../telemetry';
 
 import {LineColTransformer} from '../transformers/lineNumberTransformer';
 import {BasePathTransformer} from '../transformers/basePathTransformer';
@@ -150,8 +150,11 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
     // Promises so ScriptPaused events can wait for ScriptParsed events to finish resolving breakpoints
     private _scriptIdToBreakpointsAreResolvedDefer = new Map<string, PromiseDefer<void>>();
 
+    private _batchTelemetryReporter: BatchTelemetryReporter;
+
     public constructor({ chromeConnection, lineColTransformer, sourceMapTransformer, pathTransformer, targetFilter, enableSourceMapCaching }: IChromeDebugAdapterOpts, session: ChromeDebugSession) {
         telemetry.setupEventHandler(e => session.sendEvent(e));
+        this._batchTelemetryReporter = new BatchTelemetryReporter(telemetry);
         this._session = session;
         this._chromeConnection = new (chromeConnection || ChromeConnection)(undefined, targetFilter);
 
@@ -341,6 +344,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
     }
 
     public shutdown(): void {
+        this._batchTelemetryReporter.finalize();
         this._inShutdown = true;
         this._session.shutdown();
     }
@@ -375,7 +379,11 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
      * Hook up all connection events
      */
     protected hookConnectionEvents(): void {
-        this.chrome.Debugger.onPaused(params => this.onPaused(params));
+        this.chrome.Debugger.onPaused((params) => {
+            this.runAndMeasureProcessingTime('target/notification/onPaused', () => {
+                return this.onPaused(params);
+            });
+        });
         this.chrome.Debugger.onResumed(() => this.onResumed());
         this.chrome.Debugger.onScriptParsed(params => this.onScriptParsed(params));
         this.chrome.Debugger.onBreakpointResolved(params => this.onBreakpointResolved(params));
@@ -386,6 +394,27 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         this.chrome.Runtime.onExecutionContextsCleared(() => this.onExecutionContextsCleared());
 
         this._chromeConnection.onClose(() => this.terminateSession('websocket closed'));
+    }
+
+    private async runAndMeasureProcessingTime(notificationName: string, procedure: () => Promise<void>): Promise<void> {
+        const startTime = Date.now();
+        const startTimeMark = process.hrtime();
+        let properties: IExecutionResultTelemetryProperties = {
+            startTime: startTime.toString()
+        };
+
+        try {
+            await procedure();
+            properties.successful = 'true';
+        } catch (e) {
+            properties.successful = 'false';
+            properties.exceptionType = 'firstChance';
+            utils.fillErrorDetails(properties, e);
+        }
+
+        const elapsedTime = utils.calculateElapsedTime(startTimeMark);
+        properties.timeTakenInMilliseconds = elapsedTime.toString();
+        this._batchTelemetryReporter.reportEvent(notificationName, properties);
     }
 
     /**

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -385,7 +385,11 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
             });
         });
         this.chrome.Debugger.onResumed(() => this.onResumed());
-        this.chrome.Debugger.onScriptParsed(params => this.onScriptParsed(params));
+        this.chrome.Debugger.onScriptParsed((params) => {
+            this.runAndMeasureProcessingTime('target/notification/onScriptParsed', () => {
+                return this.onScriptParsed(params);
+            });
+        });
         this.chrome.Debugger.onBreakpointResolved(params => this.onBreakpointResolved(params));
 
         this.chrome.Console.onMessageAdded(params => this.onMessageAdded(params));
@@ -596,7 +600,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
 
         this._expectingStopReason = undefined;
 
-        smartStepP.then(should => {
+        await smartStepP.then(should => {
             if (should) {
                 this._smartStepCount++;
                 return this.stepIn(false);

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -5,6 +5,19 @@
 import {DebugProtocol} from 'vscode-debugprotocol';
 import {OutputEvent} from 'vscode-debugadapter';
 
+export type ExceptionType = "uncaughtException" | "unhandledRejection" | "firstChance";
+export interface  IExecutionResultTelemetryProperties {
+    // There is an issue on some clients and reportEvent only currently accept strings properties,
+    // hence all the following properties must be strings.
+    successful?: "true" | "false";
+    exceptionType?: ExceptionType;
+    exceptionMessage?: string;
+    exceptionName?: string;
+    exceptionStack?: string;
+    startTime?: string;
+    timeTakenInMilliseconds?: string;
+}
+
 export interface ITelemetryReporter {
     reportEvent(name: string, data?: any): void;
     setupEventHandler(_sendEvent: (event: DebugProtocol.Event) => void): void;
@@ -34,6 +47,120 @@ export class NullTelemetryReporter implements ITelemetryReporter {
         // no-op
     }
 
+}
+
+export const DefaultTelemetryIntervalInMilliseconds = 10000;
+
+export class BatchTelemetryReporter {
+    private _eventBuckets: {[eventName: string]: any};
+    private _timer: NodeJS.Timer;
+
+    public constructor(private _telemetryReporter: TelemetryReporter, private _cadenceInMilliseconds: number = DefaultTelemetryIntervalInMilliseconds) {
+        this.reset();
+        this.setup();
+    }
+
+    public reportEvent(name: string, data?: any): void {
+        if (!this._eventBuckets[name]) {
+            this._eventBuckets[name] = [];
+        }
+
+        this._eventBuckets[name].push(data);
+    }
+
+    public finalize(): void {
+        this.send();
+        clearInterval(this._timer);
+    }
+
+    private setup(): void {
+        this._timer = setInterval(() => this.send(), this._cadenceInMilliseconds);
+    }
+
+    private reset(): void {
+        this._eventBuckets = {};
+    }
+
+    private send(): void {
+        for (const eventName in this._eventBuckets) {
+            const bucket = this._eventBuckets[eventName];
+            let properties = BatchTelemetryReporter.transfromBucketData(bucket);
+            this._telemetryReporter.reportEvent(eventName, properties);
+        }
+
+        this.reset();
+    }
+    /**
+     * Transfrom the bucket of events data from the form:
+     * [{
+     *  p1: v1,
+     *  p2: v2
+     * },
+     * {
+     *  p1: w1,
+     *  p2: w2
+     *  p3: w3
+     * }]
+     *
+     * to
+     * {
+     *   p1: [v1,   w1],
+     *   p2: [v2,   w2],
+     *   p3: [null, w3]
+     * }
+     *
+     *
+     * The later form is easier for downstream telemetry analysis.
+     */
+    private static transfromBucketData(bucketForEventType: any[]): {[groupedPropertyValue: string]: string} {
+        const allPropertyNamesInTheBucket = BatchTelemetryReporter.collectPropertyNamesFromAllEvents(bucketForEventType);
+        let properties = {};
+
+        // Create a holder for all potential property names.
+        for (const key of allPropertyNamesInTheBucket) {
+            properties[`aggregated.${key}`] = [];
+        }
+
+        // Run through all the events in the bucket, collect the values for each property name.
+        for (const event of bucketForEventType) {
+            for (const propertyName of allPropertyNamesInTheBucket) {
+                properties[`aggregated.${propertyName}`].push(event[propertyName] === undefined ? null : event[propertyName]);
+            }
+        }
+
+        // Serialize each array as the final aggregated property value.
+        for (const propertyName of allPropertyNamesInTheBucket) {
+            properties[`aggregated.${propertyName}`] = JSON.stringify(properties[`aggregated.${propertyName}`]);
+        }
+
+        return properties;
+    }
+
+    /**
+     * Get the property keys from all the entries of a event bucket:
+     *
+     * So
+     * [{
+     *  p1: v1,
+     *  p2: v2
+     * },
+     * {
+     *  p1: w1,
+     *  p2: w2
+     *  p3: w3
+     * }]
+     *
+     * will return ['p1', 'p2', 'p3']
+     */
+    private static collectPropertyNamesFromAllEvents(bucket: any[]): string[] {
+        let propertyNamesSet = {};
+        for (const entry of bucket) {
+            for (const key of Object.keys(entry)) {
+                propertyNamesSet[key] = true;
+            }
+        }
+        return Object.keys(propertyNamesSet);
+    }
 }
 
 export const telemetry = new TelemetryReporter();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,6 +11,8 @@ import {Handles, logger} from 'vscode-debugadapter';
 import * as http from 'http';
 import * as https from 'https';
 
+import {IExecutionResultTelemetryProperties} from './telemetry';
+
 export const enum Platform {
     Windows, OSX, Linux
 }
@@ -566,4 +568,25 @@ export function promiseDefer<T>(): PromiseDefer<T> {
     });
 
     return { promise, resolve: resolveCallback, reject: rejectCallback };
+}
+
+export type HighResTimer = [number, number];
+
+export function calculateElapsedTime(startProcessingTime: HighResTimer): number {
+    const NanoSecondsPerMillisecond = 1000000;
+    const NanoSecondsPerSecond = 1e9;
+
+    const ellapsedTime = process.hrtime(startProcessingTime);
+    const ellapsedMilliseconds = (ellapsedTime[0] * NanoSecondsPerSecond + ellapsedTime[1]) / NanoSecondsPerMillisecond;
+    return ellapsedMilliseconds;
+}
+
+export function fillErrorDetails(properties: IExecutionResultTelemetryProperties, e: any): void {
+    properties.exceptionMessage = e.message || e.toString();
+    if (e.name) {
+        properties.exceptionName = e.name;
+    }
+    if (e.stack) {
+        properties.exceptionStack = e.stack;
+    }
 }


### PR DESCRIPTION
Batch-sending telemetry is necessary because some notifications from debuggee might be too frequent for the telemetry infrastructure to handle. Take VS as an example, it throttles telemetry events if there are two many within a short period of time. We will lose some important telemetry when that happens.
The BatchTelemetryReporter will cache the received telemetry events and sends them out every 10 seconds.

This PR also refactors some code and migrates some general telemetry handling code from DebugSession.ts to utils.ts or telemetry.ts.

This PR also enables telemetry for debugger.paused and debugger.onScriptParsed notification events.

This PR retargets the change to master branch.