### PR TITLE
Add versions to telemetry

### DIFF
--- a/src/chrome/chromeDebugSession.ts
+++ b/src/chrome/chromeDebugSession.ts
@@ -260,5 +260,5 @@ function logVersionInfo(): void {
     logger.log(`Adapter node: ${process.version} ${process.arch}`);
     const coreVersion = require('../../../package.json').version;
     logger.log('vscode-chrome-debug-core: ' + coreVersion);
-    telemetry.addCustomGlobalProperty( { "Versions.DebugAdapterCore": coreVersion });
+    telemetry.addCustomGlobalProperty( { 'Versions.DebugAdapterCore': coreVersion });
 }

--- a/src/chrome/chromeDebugSession.ts
+++ b/src/chrome/chromeDebugSession.ts
@@ -258,5 +258,7 @@ export class ChromeDebugSession extends LoggingDebugSession implements IObservab
 function logVersionInfo(): void {
     logger.log(`OS: ${os.platform()} ${os.arch()}`);
     logger.log(`Adapter node: ${process.version} ${process.arch}`);
-    logger.log('vscode-chrome-debug-core: ' + require('../../../package.json').version);
+    const coreVersion = require('../../../package.json').version;
+    logger.log('vscode-chrome-debug-core: ' + coreVersion);
+    telemetry.addCustomGlobalProperty( { "Versions.DebugAdapterCore": coreVersion });
 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -63,7 +63,7 @@ export class AsyncGlobalPropertiesTelemetryReporter implements ITelemetryReporte
     }
 
     public addCustomGlobalProperty(additionalGlobalPropertiesPromise: Promise<any> | any): void {
-        const reportedPropertyP = additionalGlobalPropertiesPromise.then(
+        const reportedPropertyP = Promise.resolve(additionalGlobalPropertiesPromise).then(
             property => this._telemetryReporter.addCustomGlobalProperty(property),
             rejection => this.reportErrorWhileWaitingForProperty(rejection));
         this._actionsQueue = Promise.all([this._actionsQueue, reportedPropertyP]);


### PR DESCRIPTION
Add versions to telemetry

We'll use this to add the debug adapter versions, and the browser user agent to telemetry

The code to add the browser user agent is on chrome-debug added on this PR: https://github.com/Microsoft/vscode-chrome-debug/pull/621