### PR TITLE
Now we don't wait for the global telemetry properties to be ready before sending telemetry

### DIFF
--- a/src/chrome/chromeDebugSession.ts
+++ b/src/chrome/chromeDebugSession.ts
@@ -105,17 +105,18 @@ export class ChromeDebugSession extends LoggingDebugSession implements IObservab
         };
 
         process.on('uncaughtException', (err: any) => {
+            reportErrorTelemetry(err, 'uncaughtException');
+
             logger.error(`******** Unhandled error in debug adapter: ${safeGetErrDetails(err)}`);
 
-            reportErrorTelemetry(err, 'uncaughtException');
             throw err;
         });
 
         process.addListener('unhandledRejection', (err: Error|DebugProtocol.Message) => {
+            reportErrorTelemetry(err, 'unhandledRejection');
+
             // Node tests are watching for the ********, so fix the tests if it's changed
             logger.error(`******** Unhandled error in debug adapter - Unhandled promise rejection: ${safeGetErrDetails(err)}`);
-
-            reportErrorTelemetry(err, 'unhandledRejection');
         });
     }
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -54,8 +54,14 @@ export class AsyncGlobalPropertiesTelemetryReporter implements ITelemetryReporte
     }
 
     public reportEvent(name: string, data?: any): void {
+        /*
+         * TODO: Put this code back after VS stops dropping telemetry events that happen after fatal errors, and disconnecting...
+         * VS has a bug where it drops telemetry events that happen after a fatal error, or after the DA starts disconnecting. Our
+         * temporary workaround is to make telemetry sync, so it'll likely be sent before we send the fatal errors, etc...
         this._actionsQueue = this._actionsQueue.then(() => // We block the report event until all the addCustomGlobalProperty have finished
             this._telemetryReporter.reportEvent(name, data));
+         */
+        this._telemetryReporter.reportEvent(name, data);
     }
 
     public setupEventHandler(_sendEvent: (event: DebugProtocol.Event) => void): void {


### PR DESCRIPTION
VS currently is not processing/sending telemetry we generate after a fatal error, or after a disconnect request.
We are implementing this temporary workaround so we get error telemetry when there is an unhandled exception, or when a client request fails...

We'll remove this workaround after this behavior is changed on VS