### PR TITLE
Treat Breakpoint logMessage as expression

### DIFF
--- a/src/chrome/internalSourceBreakpoint.ts
+++ b/src/chrome/internalSourceBreakpoint.ts
@@ -16,7 +16,7 @@ export class InternalSourceBreakpoint {
         this.hitCondition = breakpoint.hitCondition;
 
         if (breakpoint.logMessage) {
-            this.condition = `console.log('${breakpoint.logMessage}')`;
+            this.condition = `console.log(${breakpoint.logMessage})`;
             if (breakpoint.condition) {
                 this.condition = `(${breakpoint.condition}) && ${this.condition}`;
             }


### PR DESCRIPTION
Change LogPoints's logMessage to be evaluated as an expression and not a string, so LogPoints like `LogPoint('products', products)` can be set.