### PR TITLE
Introduces a telemetry collector.

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -9,7 +9,7 @@ import { ICommonRequestArgs, ILaunchRequestArgs, ISetBreakpointsArgs, ISetBreakp
     IAttachRequestArgs, IScopesResponseBody, IVariablesResponseBody,
     ISourceResponseBody, IThreadsResponseBody, IEvaluateResponseBody, ISetVariableResponseBody, IDebugAdapter,
     ICompletionsResponseBody, IToggleSkipFileStatusArgs, IInternalStackTraceResponseBody, IGetLoadedSourcesResponseBody,
-    IExceptionInfoResponseBody, ISetBreakpointResult, TimeTravelRuntime, IRestartRequestArgs, IInitializeRequestArgs } from '../debugAdapterInterfaces';
+    IExceptionInfoResponseBody, ISetBreakpointResult, TimeTravelRuntime, IRestartRequestArgs, IInitializeRequestArgs, ITelemetryPropertyCollector } from '../debugAdapterInterfaces';
 import { IChromeDebugAdapterOpts, ChromeDebugSession } from './chromeDebugSession';
 import { ChromeConnection } from './chromeConnection';
 import * as ChromeUtils from './chromeUtils';
@@ -284,7 +284,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         return !!this._breakOnLoadHelper;
     }
 
-    public async launch(args: ILaunchRequestArgs): Promise<void> {
+    public async launch(args: ILaunchRequestArgs, telemetryPropertyCollector: ITelemetryPropertyCollector): Promise<void> {
         this.commonArgs(args);
         this._sourceMapTransformer.launch(args);
         this._pathTransformer.launch(args);

--- a/src/debugAdapterInterfaces.d.ts
+++ b/src/debugAdapterInterfaces.d.ts
@@ -8,11 +8,13 @@
 
 import { DebugProtocol } from 'vscode-debugprotocol';
 import Crdp from '../crdp/crdp';
+import { ITelemetryPropertyCollector } from './telemetry';
 
 export type ISourceMapPathOverrides = { [pattern: string]: string };
 
 export type BreakOnLoadStrategy = 'regex' | 'instrument' | 'off';
 
+export { ITelemetryPropertyCollector } from './telemetry';
 /**
  * Properties valid for both Launch and Attach
  */
@@ -179,7 +181,7 @@ export interface IDebugAdapter {
     shutdown(): void;
 
     initialize(args: DebugProtocol.InitializeRequestArguments, requestSeq?: number): PromiseOrNot<DebugProtocol.Capabilities>;
-    launch(args: ILaunchRequestArgs, requestSeq?: number): PromiseOrNot<void>;
+    launch(args: ILaunchRequestArgs, telemetryPropertyCollector: ITelemetryPropertyCollector, requestSeq?: number): PromiseOrNot<void>;
     attach(args: IAttachRequestArgs, requestSeq?: number): PromiseOrNot<void>;
     disconnect(args: DebugProtocol.DisconnectArguments): PromiseOrNot<void>;
     setBreakpoints(args: DebugProtocol.SetBreakpointsArguments, requestSeq?: number): PromiseOrNot<ISetBreakpointsResponseBody>;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -209,4 +209,21 @@ export class BatchTelemetryReporter {
     }
 }
 
+export interface ITelemetryPropertyCollector {
+    getProperties(): {[propertyName: string]: string};
+    addTelemetryProperty(propertyName: string, value: string): void;
+}
+
+export class TelemetryPropertyCollector implements ITelemetryPropertyCollector {
+    private _properties: {[propertyName: string]: string} = {};
+
+    public getProperties() {
+        return this._properties;
+    }
+
+    public addTelemetryProperty(propertyName: string, value: string) {
+        this._properties[propertyName] = value;
+    }
+}
+
 export const telemetry = new AsyncGlobalPropertiesTelemetryReporter(new TelemetryReporter());


### PR DESCRIPTION
so a request handling logic can append additional properties reported in the request telemetry.

Currently there is no easy way for a request handler to report additional properties other than the ones universally added, as success state, time spent etc. 

Returning additional fields in the return value might compromise the current semantic of the return value of each request. So I introduced an additional parameter to receive the additional telemetry properties.


This collector can also be used in the handlers for the notifications as needed.