### PR TITLE
Now the start-up timings events can include a failure reason

### DIFF
--- a/src/executionTimingsReporter.ts
+++ b/src/executionTimingsReporter.ts
@@ -41,9 +41,14 @@ export interface IStepStartedEventsEmitter {
     removeListener(event: 'milestoneReached', listener: (args: IMilestoneReachedEventArguments) => void): this;
 }
 
+export interface FinishedStartingUpEventArguments {
+    requestedContentWasDetected: boolean;
+    reasonForNotDetected: string;
+}
+
 export interface IFinishedStartingUpEventsEmitter {
-    on(event: 'finishedStartingUp', listener: () => void): this;
-    once(event: 'finishedStartingUp', listener: () => void): this;
+    on(event: 'finishedStartingUp', listener: (args: FinishedStartingUpEventArguments) => void): this;
+    once(event: 'finishedStartingUp', listener: (args: FinishedStartingUpEventArguments) => void): this;
     removeListener(event: 'finishedStartingUp', listener: () => void): this;
     removeListener(event: 'finishedStartingUp', listener: () => void): this;
 }


### PR DESCRIPTION
When we detect that the user requests for an unreachable url, we'll put that in the reason.

This change will break the debug adapters until we update them to use the new parameter required for the new signature.
This is related to this chrome-debug PR: https://github.com/Microsoft/vscode-chrome-debug/pull/630