### PR TITLE
Drop some telemetry events of a homogeneous type, if they accumulated too many within the telemetry sending interval.

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -392,8 +392,13 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
             });
         });
         this.chrome.Debugger.onResumed(() => this.onResumed());
+
+        const onScriptParsedEventName = 'target/notification/onScriptParsed';
+        this._batchTelemetryReporter.configureEvent(onScriptParsedEventName, {
+            batchCap: 50
+        });
         this.chrome.Debugger.onScriptParsed((params) => {
-            this.runAndMeasureProcessingTime('target/notification/onScriptParsed', () => {
+            this.runAndMeasureProcessingTime(onScriptParsedEventName, () => {
                 return this.onScriptParsed(params);
             });
         });

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -141,14 +141,21 @@ export class BatchTelemetryReporter {
         for (const eventName in this._eventBuckets) {
             let bucket = this._eventBuckets[eventName];
             const eventConfig = this._eventConfig[eventName];
+            let properties: {[propertyName: string]: string} = {};
             if (eventConfig) {
                 const diff = bucket.length - eventConfig.batchCap;
+                let dropped: number;
                 if (diff > 0) {
                     bucket = bucket.slice(0, eventConfig.batchCap);
                     logger.log(`Truncate ${diff} ${eventName} event entries.`);
+                    dropped = diff;
+                } else {
+                    dropped = 0;
                 }
+                properties['aggregated.dropped'] = dropped.toString();
             }
-            let properties = BatchTelemetryReporter.transfromBucketData(bucket);
+
+            Object.assign(properties, BatchTelemetryReporter.transfromBucketData(bucket));
             this._telemetryReporter.reportEvent(eventName, properties);
         }
 


### PR DESCRIPTION
For a high-frequency event like onScriptParsed, we have the potential of hitting a per property size limit (1kB). So the aggregated property value (which has the form of "[v1,v2,v3,v4]") will be truncated at 1KB and become "[v1,v2,v3,". This cannot be processed correctly in the telemetry pipeline and we lose the data of the entire payload. So we truncate the data before its being sent out, hoping that the remainder is representative enough and can be formatted correctly. This can at least salvage some part of the data instead of ruining the entire payload. 

The change also allows such truncation behavior to be configured on a per-event type basis.