### PR TITLE
Clearing the context immediately to avoid sending multiple remove eve…

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -533,13 +533,12 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
      */
     protected onExecutionContextsCleared(): Promise<void> {
         const cachedScriptParsedEvents = Array.from(this._scriptsById.values());
+        this.clearTargetContext();
         return this.doAfterProcessingSourceEvents(async () => { // This will not execute until all the on-flight 'new' source events have been processed
             for (let scriptedParseEvent of cachedScriptParsedEvents) {
                 const scriptEvent = await this.scriptToLoadedSourceEvent('removed', scriptedParseEvent);
                 this._session.sendEvent(scriptEvent);
             }
-
-            this.clearTargetContext();
         });
     }
 


### PR DESCRIPTION
…nts in case of quick refreshes

When we have a case of multiple refreshes in the browser in a quick succession, sometimes we have a case where we don't reach the point of clearing the context and, in turn _scriptById, while sending out 'remove' events from the previous refresh. 
In this scenario, the subsequent refresh gets the _scriptsById of the previous state and we end up sending multiple remove events for the same script causing PineZorro to throw an error.

We should clear the context as soon as we populate the cachedScriptParsedEvents array.