### PR TITLE
Small fixes

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -2140,9 +2140,8 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
                 } else {
                     return this.remoteObjectToVariable(propDesc.name, response.result, parentEvaluateName);
                 }
-            },
-            error => {
-                logger.error('Error evaluating getter - ' + error.toString());
+            }).catch(error => {
+                logger.error(`Error evaluating getter for '${propDesc.name}' - ${error.toString()}`);
                 return { name: propDesc.name, value: error.toString(), variablesReference: 0 };
             });
         } else if (propDesc.set) {
@@ -2541,19 +2540,19 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         error => Promise.reject<string>(errors.errorFromEvaluate(error.message)));
     }
 
-    public remoteObjectToVariable(name: string, object: Crdp.Runtime.RemoteObject, parentEvaluateName?: string, stringify = true, context: VariableContext = 'variables'): Promise<DebugProtocol.Variable> {
+    public async remoteObjectToVariable(name: string, object: Crdp.Runtime.RemoteObject, parentEvaluateName?: string, stringify = true, context: VariableContext = 'variables'): Promise<DebugProtocol.Variable> {
         name = name || '""';
 
         if (object) {
             if (object.type === 'object') {
                 return this.createObjectVariable(name, object, parentEvaluateName, context);
             } else if (object.type === 'function') {
-                return Promise.resolve(this.createFunctionVariable(name, object, context, parentEvaluateName));
+                return this.createFunctionVariable(name, object, context, parentEvaluateName);
             } else {
-                return Promise.resolve(this.createPrimitiveVariable(name, object, parentEvaluateName, stringify));
+                return this.createPrimitiveVariable(name, object, parentEvaluateName, stringify);
             }
         } else {
-            return Promise.resolve(this.createPrimitiveVariableWithValue(name, '', parentEvaluateName));
+            return this.createPrimitiveVariableWithValue(name, '', parentEvaluateName);
         }
     }
 

--- a/src/chrome/chromeDebugSession.ts
+++ b/src/chrome/chromeDebugSession.ts
@@ -113,6 +113,10 @@ export class ChromeDebugSession extends LoggingDebugSession implements IObservab
             telemetry.reportEvent(ErrorTelemetryEventName, properties);
         };
 
+        // While using the debug adapter in a debug server, we create several connections. To prevent accumulating listeners we remove existing listeners before adding new ones
+        process.removeAllListeners('uncaughtException');
+        process.removeAllListeners('unhandledRejection');
+
         process.on('uncaughtException', (err: any) => {
             reportErrorTelemetry(err, 'uncaughtException');
 


### PR DESCRIPTION
1. this.remoteObjectToVariable at line 2141 was throwing an exception in some cases for the Edge debug adapter. The .catch change is so it'll catch that kind of issues too. The change to remoteObjectToVariable is for the same reason: this.createPrimitiveVariable was throwing an exception in Edge debug adapter, and no-one was catching it.

2. The removeAllListeners change is because while using the debugServer we create one new chrome connection each time you launch, so we ended up having several listeners for these events