### PR TITLE
Fix unsafe array access in internalSourceBreakpoint

### DIFF
--- a/src/chrome/internalSourceBreakpoint.ts
+++ b/src/chrome/internalSourceBreakpoint.ts
@@ -30,7 +30,7 @@ export class InternalSourceBreakpoint {
 }
 
 function isLogpointMessage(m: Crdp.Runtime.ConsoleAPICalledEvent): boolean {
-    return m.stackTrace && m.stackTrace.callFrames[0].url === InternalSourceBreakpoint.LOGPOINT_URL;
+    return m.stackTrace && m.stackTrace.callFrames.length > 0 && m.stackTrace.callFrames[0].url === InternalSourceBreakpoint.LOGPOINT_URL;
 }
 
 export function stackTraceWithoutLogpointFrame(m: Crdp.Runtime.ConsoleAPICalledEvent): Crdp.Runtime.StackTrace {


### PR DESCRIPTION
The `stackTrace.callFrames` property of the `Protocol.Runtime.ConsoleAPICalledEvent` can be an empty array in certain conditions.

See https://github.com/Microsoft/vscode-chrome-debug-core/issues/334