### PR TITLE
Persist the client ID when we reset the breakpoints in source mapped …

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -1327,7 +1327,13 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
                 const originalArgs = args;
                 args = JSON.parse(JSON.stringify(args));
                 args = this._lineColTransformer.setBreakpoints(args);
-                args = this._sourceMapTransformer.setBreakpoints(args, requestSeq);
+                const sourceMapTransformerResponse = this._sourceMapTransformer.setBreakpoints(args, requestSeq, ids);
+                if (sourceMapTransformerResponse && sourceMapTransformerResponse.args) {
+                    args = sourceMapTransformerResponse.args;
+                }
+                if (sourceMapTransformerResponse && sourceMapTransformerResponse.ids) {
+                    ids = sourceMapTransformerResponse.ids;
+                }
                 args = this._pathTransformer.setBreakpoints(args);
 
                 // Get the target url of the script

--- a/test/chrome/chromeDebugAdapter.test.ts
+++ b/test/chrome/chromeDebugAdapter.test.ts
@@ -396,9 +396,9 @@ suite('ChromeDebugAdapter', () => {
                 .returns(() => Promise.resolve(generatedScriptPath));
 
             mockSourceMapTransformer.setup(x => x.setBreakpoints(It.isAny(), It.isAnyNumber()))
-                .returns((args: ISetBreakpointsArgs) => {
-                    args.source.path = generatedScriptPath;
-                    return args;
+                .returns(( object: { args: ISetBreakpointsArgs, ids: number[] }) => {
+                    object.args.source.path = generatedScriptPath;
+                    return object;
                 });
 
             setBp_emitScriptParsed(generatedScriptPath, undefined, [authoredSourcePath]);


### PR DESCRIPTION
…files

When we clear and reset the  breakpoints in the mapped files, we don't persist the client IDs we created for them and sent to PineZorro. This specially causes a problem in Edge which returns a new breakpoint ID when we make the setBreakpointByUrl call again during resetting. Then we end up sending a 'changed' event to PZ for this breakpoint ID which causes an error since we didn't tell the client about it.

This doesn't cause an issue with Chrome currently because Chrome uses a pattern of script_url, line and column number to create the breakpoint ID which remains the same on resetting the breakpoint again. 

This change persists the client IDs during the reset process and makes sure it gets mapped to the original one.