### PR TITLE
Canonicalize paths to lowercase in Windows

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -122,8 +122,19 @@ export function canonicalizeUrl(urlOrPath: string): string {
 
     urlOrPath = stripTrailingSlash(urlOrPath);
     urlOrPath = fixDriveLetterAndSlashes(urlOrPath);
+    urlOrPath = normalizeIfFSIsCaseInsensitive(urlOrPath);
 
     return urlOrPath;
+}
+
+function normalizeIfFSIsCaseInsensitive(urlOrPath: string): string {
+    return (getPlatform() === Platform.Windows && isFilePath(urlOrPath))
+        ? urlOrPath.toLowerCase()
+        : urlOrPath;
+}
+
+export function isFilePath(candidate: string): boolean {
+    return !!candidate.match(/[A-z]:[\\\/][^\\\/]/);
 }
 
 export function isFileUrl(candidate: string): boolean {

--- a/test/sourceMaps/sourceMaps.test.ts
+++ b/test/sourceMaps/sourceMaps.test.ts
@@ -10,13 +10,14 @@ import * as path from 'path';
 import { fixDriveLetterAndSlashes } from '../../src/utils';
 import { SourceMaps } from '../../src/sourceMaps/sourceMaps';
 import { MappedPosition } from '../../src/sourceMaps/sourceMap';
+import { utils } from '../../src';
 
 suite('SourceMaps', () => {
     // VSCode expects lowercase windows drive names
     const DIRNAME = fixDriveLetterAndSlashes(__dirname);
     const GENERATED_PATH = path.resolve(DIRNAME, 'testData/app.js');
-    const AUTHORED_PATH = path.resolve(DIRNAME, 'testData/source1.ts');
-    const ALL_SOURCES = [AUTHORED_PATH, path.resolve(DIRNAME, 'testData/source2.ts')];
+    const AUTHORED_PATH = utils.canonicalizeUrl(path.resolve(DIRNAME, 'testData/source1.ts'));
+    const ALL_SOURCES = [AUTHORED_PATH, utils.canonicalizeUrl(path.resolve(DIRNAME, 'testData/source2.ts'))];
     const WEBROOT = 'http://localhost';
     const PATH_MAPPING = { '/': WEBROOT };
     const SOURCEMAP_URL = 'app.js.map';

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -154,6 +154,12 @@ suite('Utils', () => {
         test('strips trailing slash', () => {
             testCanUrl('http://site.com/', 'http://site.com');
         });
+
+        test('paths with different cases get canonicalized to the same string', () => {
+            const Utils = getUtils();
+            assert.equal(Utils.canonicalizeUrl("c:\\Users\\username\\source\\repos\\WebApplication77\\WebApplication77\\Scripts\\bootstrap.js"),
+                Utils.canonicalizeUrl("c:\\users\\username\\source\\repos\\WebApplication77\\WebApplication77\\Scripts\\bootstrap.js"));
+        });
     });
 
     suite('fileUrlToPath()', () => {


### PR DESCRIPTION
Canonicalize paths to lowercase in Windows

In some cases the webroot that VS sends doesn't match the case of the file paths that VS sends for the breakpoints: ("c:\users\username\source\repos\WebApplication77\WebApplication77" vs "c:\Users\username\source\repos\WebApplication77\WebApplication77\Scripts\bootstrap.js"). That results in breakpoints not being hit in those cases.