### PR TITLE
Add workaround for the ASP.NET webRoot being incorrectly configured

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
             "request": "launch",
             "protocol": "inspector",
             "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-            "args": [ "--no-timeouts", "${workspaceFolder}/out/**/*.js", "--ui", "tdd",  "--grep", "SourceMapFactory" ],
+            "args": [ "--no-timeouts", "${workspaceFolder}/out/**/*.js", "--ui", "tdd",  "--grep", "<tests to grep for>" ],
             "cwd": "${workspaceFolder}",
             "smartStep": true,
             "skipFiles": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
             "request": "launch",
             "protocol": "inspector",
             "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-            "args": [ "--no-timeouts", "${workspaceFolder}/out/**/*.js", "--ui", "tdd",  "--grep", "<tests to grep for>" ],
+            "args": [ "--no-timeouts", "${workspaceFolder}/out/**/*.js", "--ui", "tdd",  "--grep", "SourceMapFactory" ],
             "cwd": "${workspaceFolder}",
             "smartStep": true,
             "skipFiles": [

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -33,6 +33,7 @@ import { BaseSourceMapTransformer } from '../transformers/baseSourceMapTransform
 import { EagerSourceMapTransformer } from '../transformers/eagerSourceMapTransformer';
 import { FallbackToClientPathTransformer } from '../transformers/fallbackToClientPathTransformer';
 import { BreakOnLoadHelper } from './breakOnLoadHelper';
+import * as sourceMapUtils from '../sourceMaps/sourceMapUtils';
 
 import * as path from 'path';
 
@@ -1336,6 +1337,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         }
     */
     public disconnect(args: DebugProtocol.DisconnectArguments): void {
+        telemetry.reportEvent('FullSessionStatistics/SourceMaps/Overrides', { aspNetClientAppFallbackCount: sourceMapUtils.getAspNetFallbackCount() });
         this.shutdown();
         this.terminateSession('Got disconnect request', args);
     }

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -161,6 +161,8 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
 
     private _loadedSourcesByScriptId = new Map<Crdp.Runtime.ScriptId, CrdpScript>();
 
+    private _isVSClient: boolean;
+
     public constructor({ chromeConnection, lineColTransformer, sourceMapTransformer, pathTransformer, targetFilter, enableSourceMapCaching }: IChromeDebugAdapterOpts,
         session: ChromeDebugSession) {
         telemetry.setupEventHandler(e => session.sendEvent(e));
@@ -235,7 +237,9 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
             this._pathTransformer = new FallbackToClientPathTransformer(this._session);
         }
 
-        utils.setCaseSensitivePaths(args.clientID !== 'visualstudio');
+        this._isVSClient = args.clientID === 'visualstudio';
+        utils.setCaseSensitivePaths(!this._isVSClient);
+        this._sourceMapTransformer.isVSClient = this._isVSClient;
 
         if (args.pathFormat !== 'path') {
             throw errors.pathFormat();

--- a/src/sourceMaps/sourceMap.ts
+++ b/src/sourceMaps/sourceMap.ts
@@ -74,7 +74,7 @@ export class SourceMap {
      * generatedPath: an absolute local path or a URL
      * json: sourcemap contents as string
      */
-    public constructor(generatedPath: string, json: string, pathMapping?: IPathMapping, sourceMapPathOverrides?: utils.IStringDictionary<string>) {
+    public constructor(generatedPath: string, json: string, pathMapping?: IPathMapping, sourceMapPathOverrides?: utils.IStringDictionary<string>, isVSClient: boolean = false) {
         this._generatedPath = generatedPath;
 
         const sm = JSON.parse(json);
@@ -103,7 +103,7 @@ export class SourceMap {
         this._sources = sm.sources.map(sourcePath => {
             if (sourceMapPathOverrides) {
                 const fullSourceEntry = sourceMapUtils.getFullSourceEntry(this._originalSourceRoot, sourcePath);
-                const mappedFullSourceEntry = sourceMapUtils.applySourceMapPathOverrides(fullSourceEntry, sourceMapPathOverrides);
+                const mappedFullSourceEntry = sourceMapUtils.applySourceMapPathOverrides(fullSourceEntry, sourceMapPathOverrides, isVSClient);
                 if (fullSourceEntry !== mappedFullSourceEntry) {
                     return utils.canonicalizeUrl(mappedFullSourceEntry);
                 }

--- a/src/sourceMaps/sourceMap.ts
+++ b/src/sourceMaps/sourceMap.ts
@@ -74,7 +74,7 @@ export class SourceMap {
      * generatedPath: an absolute local path or a URL
      * json: sourcemap contents as string
      */
-    public constructor(generatedPath: string, json: string, pathMapping?: IPathMapping, sourceMapPathOverrides?: utils.IStringDictionary<string>, isVSClient: boolean = false) {
+    public constructor(generatedPath: string, json: string, pathMapping?: IPathMapping, sourceMapPathOverrides?: utils.IStringDictionary<string>, isVSClient = false) {
         this._generatedPath = generatedPath;
 
         const sm = JSON.parse(json);

--- a/src/sourceMaps/sourceMapFactory.ts
+++ b/src/sourceMaps/sourceMapFactory.ts
@@ -24,7 +24,7 @@ export class SourceMapFactory {
      * pathToGenerated - an absolute local path or a URL.
      * mapPath - a path relative to pathToGenerated.
      */
-    getMapForGeneratedPath(pathToGenerated: string, mapPath: string): Promise<SourceMap> {
+    getMapForGeneratedPath(pathToGenerated: string, mapPath: string, isVSClient: boolean = false): Promise<SourceMap> {
         let msg = `SourceMaps.getMapForGeneratedPath: Finding SourceMap for ${pathToGenerated} by URI: ${mapPath}`;
         if (this._pathMapping) {
             msg += ` and webRoot/pathMapping: ${JSON.stringify(this._pathMapping)}`;
@@ -47,7 +47,7 @@ export class SourceMapFactory {
             if (contents) {
                 try {
                     // Throws for invalid JSON
-                    return new SourceMap(pathToGenerated, contents, this._pathMapping, this._sourceMapPathOverrides);
+                    return new SourceMap(pathToGenerated, contents, this._pathMapping, this._sourceMapPathOverrides, isVSClient);
                 } catch (e) {
                     logger.error(`SourceMaps.getMapForGeneratedPath: exception while processing path: ${pathToGenerated}, sourcemap: ${mapPath}\n${e.stack}`);
                     return null;

--- a/src/sourceMaps/sourceMapFactory.ts
+++ b/src/sourceMaps/sourceMapFactory.ts
@@ -24,7 +24,7 @@ export class SourceMapFactory {
      * pathToGenerated - an absolute local path or a URL.
      * mapPath - a path relative to pathToGenerated.
      */
-    getMapForGeneratedPath(pathToGenerated: string, mapPath: string, isVSClient: boolean = false): Promise<SourceMap> {
+    getMapForGeneratedPath(pathToGenerated: string, mapPath: string, isVSClient = false): Promise<SourceMap> {
         let msg = `SourceMaps.getMapForGeneratedPath: Finding SourceMap for ${pathToGenerated} by URI: ${mapPath}`;
         if (this._pathMapping) {
             msg += ` and webRoot/pathMapping: ${JSON.stringify(this._pathMapping)}`;

--- a/src/sourceMaps/sourceMapUtils.ts
+++ b/src/sourceMaps/sourceMapUtils.ts
@@ -73,7 +73,7 @@ export function getAspNetFallbackCount(): number {
  * Applies a set of path pattern mappings to the given path. See tests for examples.
  * Returns something validated to be an absolute path.
  */
-export function applySourceMapPathOverrides(sourcePath: string, sourceMapPathOverrides: ISourceMapPathOverrides, isVSClient: boolean = false): string {
+export function applySourceMapPathOverrides(sourcePath: string, sourceMapPathOverrides: ISourceMapPathOverrides, isVSClient = false): string {
     const forwardSlashSourcePath = sourcePath.replace(/\\/g, '/');
 
     // Sort the overrides by length, large to small
@@ -112,9 +112,9 @@ export function applySourceMapPathOverrides(sourcePath: string, sourceMapPathOve
         const wildcardValue = overridePatternMatches[1];
         let mappedPath = rightPattern.replace(/\*/g, wildcardValue);
         mappedPath = path.join(mappedPath); // Fix any ..
-        if (isVSClient && leftPattern === "webpack:///./*" && !utils.existsSync(mappedPath)) {
+        if (isVSClient && leftPattern === 'webpack:///./*' && !utils.existsSync(mappedPath)) {
             // This is a workaround for a bug in ASP.NET debugging in VisualStudio because the wwwroot is not properly configured
-            const pathFixingASPNETBug = path.join(rightPattern.replace(/\*/g, path.join("../ClientApp", wildcardValue)));
+            const pathFixingASPNETBug = path.join(rightPattern.replace(/\*/g, path.join('../ClientApp', wildcardValue)));
             if (utils.existsSync(pathFixingASPNETBug)) {
                 ++aspNetFallbackCount;
                 mappedPath = pathFixingASPNETBug;

--- a/src/sourceMaps/sourceMapUtils.ts
+++ b/src/sourceMaps/sourceMapUtils.ts
@@ -68,7 +68,7 @@ export function getComputedSourceRoot(sourceRoot: string, generatedPath: string,
  * Applies a set of path pattern mappings to the given path. See tests for examples.
  * Returns something validated to be an absolute path.
  */
-export function applySourceMapPathOverrides(sourcePath: string, sourceMapPathOverrides: ISourceMapPathOverrides): string {
+export function applySourceMapPathOverrides(sourcePath: string, sourceMapPathOverrides: ISourceMapPathOverrides, isVSClient: boolean = false): string {
     const forwardSlashSourcePath = sourcePath.replace(/\\/g, '/');
 
     // Sort the overrides by length, large to small
@@ -107,6 +107,14 @@ export function applySourceMapPathOverrides(sourcePath: string, sourceMapPathOve
         const wildcardValue = overridePatternMatches[1];
         let mappedPath = rightPattern.replace(/\*/g, wildcardValue);
         mappedPath = path.join(mappedPath); // Fix any ..
+        if (isVSClient && leftPattern === "webpack:///./*" && !utils.existsSync(mappedPath)) {
+            // This is a workaround for a bug in ASP.NET debugging in VisualStudio because the wwwroot is not properly configured
+            const pathFixingASPNETBug = path.join(rightPattern.replace(/\*/g, path.join("../ClientApp", wildcardValue)));
+            if (utils.existsSync(pathFixingASPNETBug)) {
+                mappedPath = pathFixingASPNETBug;
+            }
+        }
+
         logger.log(`SourceMap: mapping ${sourcePath} => ${mappedPath}, via sourceMapPathOverrides entry - ${entryStr}`);
         return mappedPath;
     }

--- a/src/sourceMaps/sourceMapUtils.ts
+++ b/src/sourceMaps/sourceMapUtils.ts
@@ -64,6 +64,11 @@ export function getComputedSourceRoot(sourceRoot: string, generatedPath: string,
     return absSourceRoot;
 }
 
+let aspNetFallbackCount = 0;
+export function getAspNetFallbackCount(): number {
+    return aspNetFallbackCount;
+}
+
 /**
  * Applies a set of path pattern mappings to the given path. See tests for examples.
  * Returns something validated to be an absolute path.
@@ -111,6 +116,7 @@ export function applySourceMapPathOverrides(sourcePath: string, sourceMapPathOve
             // This is a workaround for a bug in ASP.NET debugging in VisualStudio because the wwwroot is not properly configured
             const pathFixingASPNETBug = path.join(rightPattern.replace(/\*/g, path.join("../ClientApp", wildcardValue)));
             if (utils.existsSync(pathFixingASPNETBug)) {
+                ++aspNetFallbackCount;
                 mappedPath = pathFixingASPNETBug;
             }
         }

--- a/src/sourceMaps/sourceMaps.ts
+++ b/src/sourceMaps/sourceMaps.ts
@@ -69,7 +69,7 @@ export class SourceMaps {
     /**
      * Given a new path to a new script file, finds and loads the sourcemap for that file
      */
-    public async processNewSourceMap(pathToGenerated: string, sourceMapURL: string, isVSClient: boolean = false): Promise<void> {
+    public async processNewSourceMap(pathToGenerated: string, sourceMapURL: string, isVSClient = false): Promise<void> {
         const sourceMap = await this._sourceMapFactory.getMapForGeneratedPath(pathToGenerated, sourceMapURL, isVSClient);
         if (sourceMap) {
             this._generatedPathToSourceMap.set(pathToGenerated.toLowerCase(), sourceMap);

--- a/src/sourceMaps/sourceMaps.ts
+++ b/src/sourceMaps/sourceMaps.ts
@@ -69,8 +69,8 @@ export class SourceMaps {
     /**
      * Given a new path to a new script file, finds and loads the sourcemap for that file
      */
-    public async processNewSourceMap(pathToGenerated: string, sourceMapURL: string): Promise<void> {
-        const sourceMap = await this._sourceMapFactory.getMapForGeneratedPath(pathToGenerated, sourceMapURL);
+    public async processNewSourceMap(pathToGenerated: string, sourceMapURL: string, isVSClient: boolean = false): Promise<void> {
+        const sourceMap = await this._sourceMapFactory.getMapForGeneratedPath(pathToGenerated, sourceMapURL, isVSClient);
         if (sourceMap) {
             this._generatedPathToSourceMap.set(pathToGenerated.toLowerCase(), sourceMap);
             sourceMap.authoredSources.forEach(authoredSource => this._authoredPathToSourceMap.set(authoredSource.toLowerCase(), sourceMap));

--- a/src/transformers/baseSourceMapTransformer.ts
+++ b/src/transformers/baseSourceMapTransformer.ts
@@ -47,6 +47,8 @@ export class BaseSourceMapTransformer {
 
     public caseSensitivePaths: boolean;
 
+    protected _isVSClient = false;
+
     constructor(sourceHandles: utils.ReverseHandles<ISourceContainer>, enableSourceMapCaching?: boolean) {
         this._sourceHandles = sourceHandles;
         this._enableSourceMapCaching = enableSourceMapCaching;
@@ -54,6 +56,10 @@ export class BaseSourceMapTransformer {
 
     public get sourceMaps(): SourceMaps {
         return this._sourceMaps;
+    }
+
+    public set isVSClient(newValue: boolean) {
+        this._isVSClient = newValue;
     }
 
     public launch(args: ILaunchRequestArgs): void {
@@ -261,7 +267,7 @@ export class BaseSourceMapTransformer {
             if (!sourceMapURL) return null;
 
             // Load the sourcemap for this new script and log its sources
-            const processNewSourceMapP = this._sourceMaps.processNewSourceMap(pathToGenerated, sourceMapURL);
+            const processNewSourceMapP = this._sourceMaps.processNewSourceMap(pathToGenerated, sourceMapURL, this._isVSClient);
             this._processingNewSourceMap = Promise.all([this._processingNewSourceMap, processNewSourceMapP]);
             await processNewSourceMapP;
 

--- a/src/transformers/eagerSourceMapTransformer.ts
+++ b/src/transformers/eagerSourceMapTransformer.ts
@@ -46,7 +46,7 @@ export class EagerSourceMapTransformer extends BaseSourceMapTransformer {
             .then(uri => {
                 if (uri) {
                     logger.log(`SourceMaps: sourcemap url parsed from end of generated content: ${uri}`);
-                    return this._sourceMaps.processNewSourceMap(generatedScriptPath, uri);
+                    return this._sourceMaps.processNewSourceMap(generatedScriptPath, uri, this._isVSClient);
                 } else {
                     logger.log(`SourceMaps: no sourcemap url found in generated script: ${generatedScriptPath}`);
                     return undefined;

--- a/test/sourceMaps/sourceMapFactory.test.ts
+++ b/test/sourceMaps/sourceMapFactory.test.ts
@@ -39,8 +39,8 @@ suite('SourceMapFactory', () => {
      * Should take the same args as the SourceMap constructor, but you can't enforce that with TS.
      * Mocks need to be registered before calling this.
      */
-    function setExpectedConstructorArgs(generatedPath: string, json: string, pathMapping: IPathMapping = undefined): void {
-        const expectedArgs = [generatedPath, json, pathMapping, undefined]; // arguments doesn't have the default param
+    function setExpectedConstructorArgs(generatedPath: string, json: string, pathMapping: IPathMapping = undefined, isVSClient = false): void {
+        const expectedArgs = [generatedPath, json, pathMapping, undefined, isVSClient]; // arguments doesn't have the default param
         function mockSourceMapConstructor(): void {
             assert.deepEqual(
                 Array.prototype.slice.call(arguments),

--- a/test/sourceMaps/sourceMapUtils.test.ts
+++ b/test/sourceMaps/sourceMapUtils.test.ts
@@ -5,6 +5,7 @@
 import * as assert from 'assert';
 import * as mockery from 'mockery';
 import * as os from 'os';
+import * as path from 'path';
 
 import * as testUtils from '../testUtils';
 
@@ -109,13 +110,15 @@ suite('SourceMapUtils', () => {
                 testUtils.pathResolve('/project/src/app.js'));
         });
 
-        function normalized(path: string) {
-            return utils.canonicalizeUrl(testUtils.pathResolve(path.toLowerCase()));
+        function normalized(filePath: string) {
+            return utils.canonicalizeUrl(path.join(filePath.toLowerCase()));
         }
+
+        const projectFolder = testUtils.pathResolve('/project');
 
         test('Adds ClientApp to the path in VisualStudio as a fallback to the ASP.NET Angular Template in 2.1', () => {
             mockery.resetCache();
-            const tsFileCanonicalized = normalized('/project/ClientApp/src/app/counter/counter.component.ts');
+            const tsFileCanonicalized = normalized(`${projectFolder}/ClientApp/src/app/counter/counter.component.ts`);
             mockery.registerMock('fs', { statSync: (path: string) => {
                 if (normalized(path) === tsFileCanonicalized) {
                     return true;
@@ -124,8 +127,8 @@ suite('SourceMapUtils', () => {
             }});
 
             assert.deepEqual(
-                normalized(getSourceMapUtils().applySourceMapPathOverrides('webpack:///./src/app/counter/counter.component.ts', { 'webpack:///./*': testUtils.pathResolve('/project/webRoot/*') }, true)),
-                normalized('/project/ClientApp/src/app/counter/counter.component.ts'));
+                normalized(getSourceMapUtils().applySourceMapPathOverrides('webpack:///./src/app/counter/counter.component.ts', { 'webpack:///./*': testUtils.pathResolve(`${projectFolder}/webRoot/*`) }, true)),
+                normalized(`${projectFolder}/ClientApp/src/app/counter/counter.component.ts`));
         });
 
         test('Does not add ClientApp to the path in VisualStudio as a fallback to the ASP.NET Angular Template in 2.1 when the original method finds a file', () => {
@@ -135,8 +138,8 @@ suite('SourceMapUtils', () => {
             }});
 
             assert.deepEqual(
-                normalized(getSourceMapUtils().applySourceMapPathOverrides('webpack:///./src/app/counter/counter.component.ts', { 'webpack:///./*': testUtils.pathResolve('/project/webRoot/*') }, true)),
-                normalized('/project/webRoot/src/app/counter/counter.component.ts'));
+                normalized(getSourceMapUtils().applySourceMapPathOverrides('webpack:///./src/app/counter/counter.component.ts', { 'webpack:///./*': testUtils.pathResolve(`${projectFolder}/webRoot/*`) }, true)),
+                normalized(`${projectFolder}/webRoot/src/app/counter/counter.component.ts`));
         });
 
         test('works using the laptop emoji', () => {

--- a/test/sourceMaps/sourceMapUtils.test.ts
+++ b/test/sourceMaps/sourceMapUtils.test.ts
@@ -109,19 +109,23 @@ suite('SourceMapUtils', () => {
                 testUtils.pathResolve('/project/src/app.js'));
         });
 
+        function normalized(path: string) {
+            return utils.canonicalizeUrl(testUtils.pathResolve(path.toLowerCase()));
+        }
+
         test('Adds ClientApp to the path in VisualStudio as a fallback to the ASP.NET Angular Template in 2.1', () => {
             mockery.resetCache();
-            const tsFileCanonicalized = utils.canonicalizeUrl(testUtils.pathResolve('/project/ClientApp/src/app/counter/counter.component.ts'));
+            const tsFileCanonicalized = normalized('/project/ClientApp/src/app/counter/counter.component.ts');
             mockery.registerMock('fs', { statSync: (path: string) => {
-                if (utils.canonicalizeUrl(path) === tsFileCanonicalized) {
+                if (normalized(path) === tsFileCanonicalized) {
                     return true;
                 }
                 throw new Error(`File doesn't exist: ${path}`);
             }});
 
             assert.deepEqual(
-                utils.canonicalizeUrl(getSourceMapUtils().applySourceMapPathOverrides('webpack:///./src/app/counter/counter.component.ts', { 'webpack:///./*': testUtils.pathResolve('/project/webRoot/*') }, true)),
-                utils.canonicalizeUrl(testUtils.pathResolve('/project/ClientApp/src/app/counter/counter.component.ts')));
+                normalized(getSourceMapUtils().applySourceMapPathOverrides('webpack:///./src/app/counter/counter.component.ts', { 'webpack:///./*': testUtils.pathResolve('/project/webRoot/*') }, true)),
+                normalized('/project/ClientApp/src/app/counter/counter.component.ts'));
         });
 
         test('Does not add ClientApp to the path in VisualStudio as a fallback to the ASP.NET Angular Template in 2.1 when the original method finds a file', () => {
@@ -131,8 +135,8 @@ suite('SourceMapUtils', () => {
             }});
 
             assert.deepEqual(
-                utils.canonicalizeUrl(getSourceMapUtils().applySourceMapPathOverrides('webpack:///./src/app/counter/counter.component.ts', { 'webpack:///./*': testUtils.pathResolve('/project/webRoot/*') }, true)),
-                utils.canonicalizeUrl(testUtils.pathResolve('/project/webRoot/src/app/counter/counter.component.ts')));
+                normalized(getSourceMapUtils().applySourceMapPathOverrides('webpack:///./src/app/counter/counter.component.ts', { 'webpack:///./*': testUtils.pathResolve('/project/webRoot/*') }, true)),
+                normalized('/project/webRoot/src/app/counter/counter.component.ts'));
         });
 
         test('works using the laptop emoji', () => {

--- a/test/sourceMaps/sourceMapUtils.test.ts
+++ b/test/sourceMaps/sourceMapUtils.test.ts
@@ -12,6 +12,7 @@ import { getComputedSourceRoot, applySourceMapPathOverrides, resolveMapPath, get
 
 /** sourceMapUtils without mocks - use for type only */
 import * as _SourceMapUtils from '../../src/sourceMaps/sourceMapUtils';
+import { utils } from '../../src';
 const MODULE_UNDER_TEST = '../../src/sourceMaps/sourceMapUtils';
 
 suite('SourceMapUtils', () => {
@@ -110,16 +111,17 @@ suite('SourceMapUtils', () => {
 
         test('Adds ClientApp to the path in VisualStudio as a fallback to the ASP.NET Angular Template in 2.1', () => {
             mockery.resetCache();
+            const tsFileCanonicalized = utils.canonicalizeUrl(testUtils.pathResolve('/project/ClientApp/src/app/counter/counter.component.ts'));
             mockery.registerMock('fs', { statSync: (path: string) => {
-                if (path.toLowerCase() === testUtils.pathResolve('/project/ClientApp/src/app/counter/counter.component.ts').toLowerCase()) {
+                if (utils.canonicalizeUrl(path) === tsFileCanonicalized) {
                     return true;
                 }
                 throw new Error(`File doesn't exist: ${path}`);
             }});
 
             assert.deepEqual(
-                getSourceMapUtils().applySourceMapPathOverrides('webpack:///./src/app/counter/counter.component.ts', { 'webpack:///./*': testUtils.pathResolve('/project/webRoot/*') }, true),
-                testUtils.pathResolve('/project/ClientApp/src/app/counter/counter.component.ts'));
+                utils.canonicalizeUrl(getSourceMapUtils().applySourceMapPathOverrides('webpack:///./src/app/counter/counter.component.ts', { 'webpack:///./*': testUtils.pathResolve('/project/webRoot/*') }, true)),
+                utils.canonicalizeUrl(testUtils.pathResolve('/project/ClientApp/src/app/counter/counter.component.ts')));
         });
 
         test('Does not add ClientApp to the path in VisualStudio as a fallback to the ASP.NET Angular Template in 2.1 when the original method finds a file', () => {
@@ -129,8 +131,8 @@ suite('SourceMapUtils', () => {
             }});
 
             assert.deepEqual(
-                getSourceMapUtils().applySourceMapPathOverrides('webpack:///./src/app/counter/counter.component.ts', { 'webpack:///./*': testUtils.pathResolve('/project/webRoot/*') }, true),
-                testUtils.pathResolve('/project/webRoot/src/app/counter/counter.component.ts'));
+                utils.canonicalizeUrl(getSourceMapUtils().applySourceMapPathOverrides('webpack:///./src/app/counter/counter.component.ts', { 'webpack:///./*': testUtils.pathResolve('/project/webRoot/*') }, true)),
+                utils.canonicalizeUrl(testUtils.pathResolve('/project/webRoot/src/app/counter/counter.component.ts')));
         });
 
         test('works using the laptop emoji', () => {

--- a/test/sourceMaps/sourceMapUtils.test.ts
+++ b/test/sourceMaps/sourceMapUtils.test.ts
@@ -111,7 +111,7 @@ suite('SourceMapUtils', () => {
         });
 
         function normalized(filePath: string) {
-            return utils.canonicalizeUrl(path.join(filePath.toLowerCase()));
+            return utils.canonicalizeUrl(path.join(filePath.toLowerCase())).replace(new RegExp(/\\/g), '/');
         }
 
         const projectFolder = testUtils.pathResolve('/project');

--- a/test/sourceMaps/sourceMapUtils.test.ts
+++ b/test/sourceMaps/sourceMapUtils.test.ts
@@ -111,7 +111,7 @@ suite('SourceMapUtils', () => {
         test('Adds ClientApp to the path in VisualStudio as a fallback to the ASP.NET Angular Template in 2.1', () => {
             mockery.resetCache();
             mockery.registerMock('fs', { statSync: (path: string) => {
-                if (path === "c:\\project\\ClientApp\\src\\app\\counter\\counter.component.ts") {
+                if (path === 'c:\\project\\ClientApp\\src\\app\\counter\\counter.component.ts') {
                     return true;
                 }
                 throw new Error(`File doesn't exist: ${path}`);

--- a/test/sourceMaps/sourceMapUtils.test.ts
+++ b/test/sourceMaps/sourceMapUtils.test.ts
@@ -111,7 +111,7 @@ suite('SourceMapUtils', () => {
         test('Adds ClientApp to the path in VisualStudio as a fallback to the ASP.NET Angular Template in 2.1', () => {
             mockery.resetCache();
             mockery.registerMock('fs', { statSync: (path: string) => {
-                if (path === 'c:\\project\\ClientApp\\src\\app\\counter\\counter.component.ts') {
+                if (path.toLowerCase() === testUtils.pathResolve('/project/ClientApp/src/app/counter/counter.component.ts').toLowerCase()) {
                     return true;
                 }
                 throw new Error(`File doesn't exist: ${path}`);


### PR DESCRIPTION
We currently can't hit breakpoints in VS with ASP.NET Core 2.1 for Angular.
The challenge is that depending on the runtime configuration of angular the webRoot folder might be : <workspace>\ClientApp or it might be <workspace>\wwwRoot and we don't have any way of figuring out which case it is before we launch the debugger.

For that reason we are implementing this fallback as a temporary workaround so we'll try the normal webRoot and if that doesn't work we'll try <workspace>\ClientApp to see if that works

P.S: After we all agree on how to implement this fix I'll add telemetry and a test for the final code