### PR TITLE
Add property to get version of chrome debug protocol

### DIFF
--- a/src/chrome/chromeConnection.ts
+++ b/src/chrome/chromeConnection.ts
@@ -9,7 +9,7 @@ import { StepProgressEventsEmitter, IObservableEvents, IStepStartedEventsEmitter
 import * as errors from '../errors';
 import * as utils from '../utils';
 import { logger } from 'vscode-debugadapter';
-import { ChromeTargetDiscovery } from './chromeTargetDiscoveryStrategy';
+import { ChromeTargetDiscovery, ChromeDebugProtocolVersion } from './chromeTargetDiscoveryStrategy';
 
 import { Client, LikeSocket } from 'noice-json-rpc';
 
@@ -31,6 +31,8 @@ export interface ITarget {
 
 export type ITargetFilter = (target: ITarget) => boolean;
 export interface ITargetDiscoveryStrategy {
+    version: Promise<ChromeDebugProtocolVersion>;
+
     getTarget(address: string, port: number, targetFilter?: ITargetFilter, targetUrl?: string): Promise<ITarget>;
     getAllTargets(address: string, port: number, targetFilter?: ITargetFilter, targetUrl?: string): Promise<ITarget[]>;
 }
@@ -173,5 +175,9 @@ export class ChromeConnection implements IObservableEvents<IStepStartedEventsEmi
 
     public onClose(handler: () => void): void {
         this._socket.on('close', handler);
+    }
+
+    public get version(): Promise<ChromeDebugProtocolVersion> {
+        return this._targetDiscoveryStrategy.version;
     }
 }

--- a/src/chrome/chromeConnection.ts
+++ b/src/chrome/chromeConnection.ts
@@ -9,7 +9,7 @@ import { StepProgressEventsEmitter, IObservableEvents, IStepStartedEventsEmitter
 import * as errors from '../errors';
 import * as utils from '../utils';
 import { logger } from 'vscode-debugadapter';
-import { ChromeTargetDiscovery, ChromeDebugProtocolVersion } from './chromeTargetDiscoveryStrategy';
+import { ChromeTargetDiscovery, ProtocolSchema } from './chromeTargetDiscoveryStrategy';
 
 import { Client, LikeSocket } from 'noice-json-rpc';
 
@@ -31,7 +31,7 @@ export interface ITarget {
 
 export type ITargetFilter = (target: ITarget) => boolean;
 export interface ITargetDiscoveryStrategy {
-    version: Promise<ChromeDebugProtocolVersion>;
+    version: Promise<ProtocolSchema>;
 
     getTarget(address: string, port: number, targetFilter?: ITargetFilter, targetUrl?: string): Promise<ITarget>;
     getAllTargets(address: string, port: number, targetFilter?: ITargetFilter, targetUrl?: string): Promise<ITarget[]>;
@@ -177,7 +177,7 @@ export class ChromeConnection implements IObservableEvents<IStepStartedEventsEmi
         this._socket.on('close', handler);
     }
 
-    public get version(): Promise<ChromeDebugProtocolVersion> {
+    public get version(): Promise<ProtocolSchema> {
         return this._targetDiscoveryStrategy.version;
     }
 }

--- a/src/chrome/chromeConnection.ts
+++ b/src/chrome/chromeConnection.ts
@@ -27,12 +27,11 @@ export interface ITarget {
     type: string;
     url?: string;
     webSocketDebuggerUrl: string;
+    version: Promise<ProtocolSchema>;
 }
 
 export type ITargetFilter = (target: ITarget) => boolean;
 export interface ITargetDiscoveryStrategy {
-    version: Promise<ProtocolSchema>;
-
     getTarget(address: string, port: number, targetFilter?: ITargetFilter, targetUrl?: string): Promise<ITarget>;
     getAllTargets(address: string, port: number, targetFilter?: ITargetFilter, targetUrl?: string): Promise<ITarget[]>;
 }
@@ -178,6 +177,6 @@ export class ChromeConnection implements IObservableEvents<IStepStartedEventsEmi
     }
 
     public get version(): Promise<ProtocolSchema> {
-        return this._targetDiscoveryStrategy.version;
+        return this._attachedTarget.version;
     }
 }

--- a/src/chrome/chromeTargetDiscoveryStrategy.ts
+++ b/src/chrome/chromeTargetDiscoveryStrategy.ts
@@ -16,7 +16,7 @@ const localize = nls.loadMessageBundle();
 
 export class ProtocolSchema {
     public static unknownVersion(): ProtocolSchema {
-        return new this(0, 0); // Using 0.0 will make behave isAtLeastVersion as if this was the oldest possible version
+        return new ProtocolSchema(0, 0); // Using 0.0 will make behave isAtLeastVersion as if this was the oldest possible version
     }
 
     constructor(private _major: number, private _minor: number) {}

--- a/src/chrome/chromeTargetDiscoveryStrategy.ts
+++ b/src/chrome/chromeTargetDiscoveryStrategy.ts
@@ -14,7 +14,7 @@ import { ITargetDiscoveryStrategy, ITargetFilter, ITarget } from './chromeConnec
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
 
-export class ChromeDebugProtocolVersion {
+export class ProtocolSchema {
     public static unkownVersion(): any {
         return new this(0, 0); // Using 0.0 will make behave isAtLeastVersion as if this was the oldest possible version
     }
@@ -30,7 +30,7 @@ export class ChromeTargetDiscovery implements ITargetDiscoveryStrategy, IObserva
     private logger: Logger.ILogger;
     private telemetry: telemetry.ITelemetryReporter;
     public readonly events = new StepProgressEventsEmitter();
-    _version: Promise<ChromeDebugProtocolVersion>;
+    _version: Promise<ProtocolSchema>;
 
     constructor(_logger: Logger.ILogger, _telemetry: telemetry.ITelemetryReporter) {
         this.logger = _logger;
@@ -68,7 +68,7 @@ export class ChromeTargetDiscovery implements ITargetDiscoveryStrategy, IObserva
         return this._getMatchingTargets(targets, targetFilter, targetUrl);
     }
 
-    private async _getVersionData(address: string, port: number): Promise<ChromeDebugProtocolVersion> {
+    private async _getVersionData(address: string, port: number): Promise<ProtocolSchema> {
 
         const url = `http://${address}:${port}/json/version`;
         this.logger.log(`Getting browser and debug protocol version via ${url}`);
@@ -93,12 +93,12 @@ export class ChromeTargetDiscovery implements ITargetDiscoveryStrategy, IObserva
                 const majorAndMinor = versionString.split('.');
                 const major = parseInt(majorAndMinor[0], 10);
                 const minor = parseInt(majorAndMinor[1], 10);
-                return new ChromeDebugProtocolVersion(major, minor);
+                return new ProtocolSchema(major, minor);
             }
         } catch (e) {
             this.logger.log(`Didn't get a valid response for /json/version call. Error: ${e.message}. Response: ${jsonResponse}`);
         }
-        return ChromeDebugProtocolVersion.unkownVersion();
+        return ProtocolSchema.unkownVersion();
     }
 
     private async _getTargets(address: string, port: number): Promise<ITarget[]> {
@@ -176,7 +176,7 @@ export class ChromeTargetDiscovery implements ITargetDiscoveryStrategy, IObserva
         return target;
     }
 
-    public get version(): Promise<ChromeDebugProtocolVersion> {
+    public get version(): Promise<ProtocolSchema> {
         return this._version;
     }
 }

--- a/src/chrome/chromeTargetDiscoveryStrategy.ts
+++ b/src/chrome/chromeTargetDiscoveryStrategy.ts
@@ -15,7 +15,7 @@ import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
 
 export class ProtocolSchema {
-    public static unkownVersion(): any {
+    public static unknownVersion(): ProtocolSchema {
         return new this(0, 0); // Using 0.0 will make behave isAtLeastVersion as if this was the oldest possible version
     }
 
@@ -98,7 +98,7 @@ export class ChromeTargetDiscovery implements ITargetDiscoveryStrategy, IObserva
         } catch (e) {
             this.logger.log(`Didn't get a valid response for /json/version call. Error: ${e.message}. Response: ${jsonResponse}`);
         }
-        return ProtocolSchema.unkownVersion();
+        return ProtocolSchema.unknownVersion();
     }
 
     private async _getTargets(address: string, port: number): Promise<ITarget[]> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { NullLogger } from './nullLogger';
 import * as executionTimingsReporter from './executionTimingsReporter';
 
 import { Protocol as Crdp } from 'devtools-protocol';
+import { ChromeDebugProtocolVersion } from './chrome/chromeTargetDiscoveryStrategy';
 
 export {
     chromeConnection,
@@ -53,6 +54,8 @@ export {
     variables,
     NullLogger,
     executionTimingsReporter,
+
+    ChromeDebugProtocolVersion,
 
     Crdp
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import { NullLogger } from './nullLogger';
 import * as executionTimingsReporter from './executionTimingsReporter';
 
 import { Protocol as Crdp } from 'devtools-protocol';
-import { ChromeDebugProtocolVersion } from './chrome/chromeTargetDiscoveryStrategy';
+import { ProtocolSchema } from './chrome/chromeTargetDiscoveryStrategy';
 
 export {
     chromeConnection,
@@ -55,7 +55,7 @@ export {
     NullLogger,
     executionTimingsReporter,
 
-    ChromeDebugProtocolVersion,
+    ProtocolSchema,
 
     Crdp
 };


### PR DESCRIPTION
Add property to get version of chrome debug protocol.

We need to do some version-checking on edge-debug ( https://github.com/Microsoft/vscode-edge-debug2/pull/100 )