### PR TITLE
Add public interface to set targetFilter on connection at runtime.

### DIFF
--- a/src/chrome/chromeConnection.ts
+++ b/src/chrome/chromeConnection.ts
@@ -115,6 +115,10 @@ export class ChromeConnection implements IObservableEvents<IStepStartedEventsEmi
         return this._attachedTarget;
     }
 
+    public setTargetFilter(targetFilter?: ITargetFilter) {
+        this._targetFilter = targetFilter;
+    }
+
     /**
      * Attach the websocket to the first available tab in the chrome instance with the given remote debugging port number.
      */

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -400,6 +400,11 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         args.sourceMaps = typeof args.sourceMaps === 'undefined' || args.sourceMaps;
 
         this._smartStepEnabled = this._launchAttachArgs.smartStep;
+
+        // Use hasOwnProperty to explicitly permit setting a falsy targetFilter.
+        if (args.hasOwnProperty('targetFilter')) {
+            this._chromeConnection.setTargetFilter(args.targetFilter);
+        }
     }
 
     public shutdown(): void {

--- a/src/debugAdapterInterfaces.d.ts
+++ b/src/debugAdapterInterfaces.d.ts
@@ -10,6 +10,7 @@ import { DebugProtocol } from 'vscode-debugprotocol';
 import { Protocol as Crdp } from 'devtools-protocol';
 import { ITelemetryPropertyCollector } from './telemetry';
 import { IStringDictionary } from './utils';
+import { ITargetFilter } from './chrome/chromeConnection';
 
 export type ISourceMapPathOverrides = IStringDictionary<string>;
 export type IPathMapping = IStringDictionary<string>;
@@ -35,6 +36,7 @@ export interface ICommonRequestArgs {
     skipFileRegExps?: string[]; // a supplemental array of library code regex patterns
     timeout?: number;
     showAsyncStacks?: boolean;
+    targetFilter?: ITargetFilter;
 
     /** Private undocumented property to multiplex the CRDP connection into an additional channel */
     extraCRDPChannelPort?: number;


### PR DESCRIPTION
Please see [`vscode-chrome-debug` #713](https://github.com/Microsoft/vscode-chrome-debug/pull/713) for original (rejected) proposal for this feature.

I wanted to emphasize backward compatibility when designing the API, so I opted to leave `targetFilter` alone (it's not broken and might be useful for other extensions of `vscode-chrome-debug-core`). Instead, where necessary, I:
 - Added `targetTypes` as the last optional argument at the tail end of existing chains of optional arguments.
 - Exposed `setTargetTypes(targetTypes: string[])` as a public method on `ChromeConnection`. This felt like a good alternative to rewiring the whole mechanism by which `ChromeConnection` receives `targetFilter` for consistency. (Note: I would have used an ES6 setter here, but apparently TypeMoq has some trouble with setters in strict mode.)

A corresponding `vscode-chrome-debug` pull request is blocked by this PR, but already done/tested in my fork [here](https://github.com/stristr/vscode-chrome-debug/commit/a97bb09e6a22936ac1ea91541966dfc6ee67cc5f). If this checks out, would you please let me know the instructions for contributing sibling PRs for projects that use `vscode-chrome-debug-core`? Despite the backward-compatible API, other packages that mock `ChromeConnection` in strict mode will probably need something like:

```
        mockChromeConnection
            .setup(x => x.setTargetTypes(It.isValue(undefined)))
            .verifiable(Times.atLeast(0));
```