### PR TITLE
Fix bug in protocol schema

### DIFF
--- a/src/chrome/chromeTargetDiscoveryStrategy.ts
+++ b/src/chrome/chromeTargetDiscoveryStrategy.ts
@@ -22,7 +22,7 @@ export class ProtocolSchema {
     constructor(private _major: number, private _minor: number) {}
 
     public isAtLeastVersion(major: number, minor: number): boolean {
-        return major > this._major || (major === this._major && minor >= this._minor);
+        return this._major > major || (this._major === major && this._minor >= minor);
     }
 }
 

--- a/test/chrome/chromeTargetDiscoveryStrategy.test.ts
+++ b/test/chrome/chromeTargetDiscoveryStrategy.test.ts
@@ -10,6 +10,7 @@ import { ITargetDiscoveryStrategy } from '../../src/chrome/chromeConnection';
 
 import { NullLogger } from '../../src/nullLogger';
 import { NullTelemetryReporter } from '../../src/telemetry';
+import { ProtocolSchema } from '../../src';
 
 const MODULE_UNDER_TEST = '../../src/chrome/chromeTargetDiscoveryStrategy';
 suite('ChromeTargetDiscoveryStrategy', () => {
@@ -177,5 +178,31 @@ suite('ChromeTargetDiscoveryStrategy', () => {
                 assert.deepEqual(target.webSocketDebuggerUrl, expectedWebSockerDebuggerUrl);
             });
         });
+
+        test('ProtocolSchema return if the version is at least', function () {
+            const schema0dot1 = new ProtocolSchema(0, 1);
+            assert.ok(schema0dot1.isAtLeastVersion(0, 0));
+            assert.ok(schema0dot1.isAtLeastVersion(0, 1));
+            assert.ok(!schema0dot1.isAtLeastVersion(0, 2));
+            assert.ok(!schema0dot1.isAtLeastVersion(1, 0));
+            assert.ok(!schema0dot1.isAtLeastVersion(1, 1));
+            assert.ok(!schema0dot1.isAtLeastVersion(1, 2));
+
+            const schema0dot2 = new ProtocolSchema(0, 2);
+            assert.ok(schema0dot2.isAtLeastVersion(0, 0));
+            assert.ok(schema0dot2.isAtLeastVersion(0, 1));
+            assert.ok(schema0dot2.isAtLeastVersion(0, 2));
+            assert.ok(!schema0dot2.isAtLeastVersion(1, 0));
+            assert.ok(!schema0dot2.isAtLeastVersion(1, 1));
+            assert.ok(!schema0dot2.isAtLeastVersion(1, 2));
+
+            const schema1dot0 = new ProtocolSchema(1, 0);
+            assert.ok(schema1dot0.isAtLeastVersion(0, 0));
+            assert.ok(schema1dot0.isAtLeastVersion(0, 1));
+            assert.ok(schema1dot0.isAtLeastVersion(0, 2));
+            assert.ok(schema1dot0.isAtLeastVersion(1, 0));
+            assert.ok(!schema1dot0.isAtLeastVersion(1, 1));
+            assert.ok(!schema1dot0.isAtLeastVersion(1, 2));
+        })
     });
 });

--- a/test/chrome/chromeTargetDiscoveryStrategy.test.ts
+++ b/test/chrome/chromeTargetDiscoveryStrategy.test.ts
@@ -179,7 +179,7 @@ suite('ChromeTargetDiscoveryStrategy', () => {
             });
         });
 
-        test('ProtocolSchema return if the version is at least', function () {
+        test('ProtocolSchema return if the version is at least', () => {
             const schema0dot1 = new ProtocolSchema(0, 1);
             assert.ok(schema0dot1.isAtLeastVersion(0, 0));
             assert.ok(schema0dot1.isAtLeastVersion(0, 1));
@@ -203,6 +203,6 @@ suite('ChromeTargetDiscoveryStrategy', () => {
             assert.ok(schema1dot0.isAtLeastVersion(1, 0));
             assert.ok(!schema1dot0.isAtLeastVersion(1, 1));
             assert.ok(!schema1dot0.isAtLeastVersion(1, 2));
-        })
+        });
     });
 });


### PR DESCRIPTION
Fix bug in protocol schema

I was doing needed_for_feature >= os
I should've been doing os >= needed_for_feature