### PR TITLE
Fix first line bp chrome 69

### DIFF
--- a/src/chrome/breakOnLoadHelper.ts
+++ b/src/chrome/breakOnLoadHelper.ts
@@ -59,6 +59,8 @@ export class BreakOnLoadHelper {
     }
 
     public async setBrowserVersion(version: Version): Promise<void> {
+        // On version 69 Chrome stopped sending an extra event for DOM Instrumentation: See https://bugs.chromium.org/p/chromium/issues/detail?id=882909
+        // On Chrome 68 we were relying on that event to make Break on load work on breakpoints on the first line of a file. On Chrome 69 we need an alternative way to make it work.
         this._doesDOMInstrumentationRecieveExtraEvent = !version.isAtLeastVersion(69, 0);
     }
 

--- a/src/chrome/breakOnLoadHelper.ts
+++ b/src/chrome/breakOnLoadHelper.ts
@@ -20,10 +20,6 @@ export interface UrlRegexAndFileSet {
 export class BreakOnLoadHelper {
     private _doesDOMInstrumentationRecieveExtraEvent = false;
 
-    public async setBrowserVersion(version: Version): Promise<void> {
-        this._doesDOMInstrumentationRecieveExtraEvent = !version.isAtLeastVersion(69, 0);
-    }
-
     private _instrumentationBreakpointSet = false;
 
     // Break on load: Store some mapping between the requested file names, the regex for the file, and the chrome breakpoint id to perform lookup operations efficiently
@@ -60,6 +56,10 @@ export class BreakOnLoadHelper {
 
     private getScriptUrlFromId(scriptId: string): string {
         return this._chromeDebugAdapter.scriptsById.get(scriptId).url;
+    }
+
+    public async setBrowserVersion(version: Version): Promise<void> {
+        this._doesDOMInstrumentationRecieveExtraEvent = !version.isAtLeastVersion(69, 0);
     }
 
     /**

--- a/src/chrome/chromeConnection.ts
+++ b/src/chrome/chromeConnection.ts
@@ -9,7 +9,7 @@ import { StepProgressEventsEmitter, IObservableEvents, IStepStartedEventsEmitter
 import * as errors from '../errors';
 import * as utils from '../utils';
 import { logger } from 'vscode-debugadapter';
-import { ChromeTargetDiscovery, ProtocolSchema } from './chromeTargetDiscoveryStrategy';
+import { ChromeTargetDiscovery, TargetVersions } from './chromeTargetDiscoveryStrategy';
 
 import { Client, LikeSocket } from 'noice-json-rpc';
 
@@ -27,7 +27,7 @@ export interface ITarget {
     type: string;
     url?: string;
     webSocketDebuggerUrl: string;
-    version: Promise<ProtocolSchema>;
+    version: Promise<TargetVersions>;
 }
 
 export type ITargetFilter = (target: ITarget) => boolean;
@@ -169,7 +169,7 @@ export class ChromeConnection implements IObservableEvents<IStepStartedEventsEmi
             this.api.Runtime.runIfWaitingForDebugger(),
             (<any>this.api.Runtime).run()
         ])
-        .then(() => { }, e => { });
+        .then(() => { }, () => { });
     }
 
     public close(): void {
@@ -180,7 +180,7 @@ export class ChromeConnection implements IObservableEvents<IStepStartedEventsEmi
         this._socket.on('close', handler);
     }
 
-    public get version(): Promise<ProtocolSchema> {
+    public get version(): Promise<TargetVersions> {
         return this._attachedTarget.version;
     }
 }

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -586,6 +586,10 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
             } catch (e) {
                 // Not supported by older runtimes, ignore it.
             }
+
+            if (this._breakOnLoadHelper) {
+                this._breakOnLoadHelper.setBrowserVersion((await this._chromeConnection.version).browser);
+            }
         }
     }
 

--- a/src/chrome/chromeTargetDiscoveryStrategy.ts
+++ b/src/chrome/chromeTargetDiscoveryStrategy.ts
@@ -90,7 +90,7 @@ export class ChromeTargetDiscovery implements ITargetDiscoveryStrategy, IObserva
             if (jsonResponse) {
                 const response = JSON.parse(jsonResponse);
                 const protocolVersionString = response['Protocol-Version'] as string;
-                const browserWithPrefixVersionString = response['Browser'] as string;
+                const browserWithPrefixVersionString = response.Browser as string;
                 this.logger.log(`Got browser version: ${browserWithPrefixVersionString }`);
                 this.logger.log(`Got debug protocol version: ${protocolVersionString}`);
 

--- a/src/chrome/chromeTargetDiscoveryStrategy.ts
+++ b/src/chrome/chromeTargetDiscoveryStrategy.ts
@@ -14,9 +14,16 @@ import { ITargetDiscoveryStrategy, ITargetFilter, ITarget } from './chromeConnec
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
 
-export class ProtocolSchema {
-    public static unknownVersion(): ProtocolSchema {
-        return new ProtocolSchema(0, 0); // Using 0.0 will make behave isAtLeastVersion as if this was the oldest possible version
+export class Version {
+    static parse(versionString: string): Version {
+        const majorAndMinor = versionString.split('.');
+        const major = parseInt(majorAndMinor[0], 10);
+        const minor = parseInt(majorAndMinor[1], 10);
+        return new Version(major, minor);
+    }
+
+    public static unknownVersion(): Version {
+        return new Version(0, 0); // Using 0.0 will make behave isAtLeastVersion as if this was the oldest possible version
     }
 
     constructor(private _major: number, private _minor: number) {}
@@ -24,6 +31,10 @@ export class ProtocolSchema {
     public isAtLeastVersion(major: number, minor: number): boolean {
         return this._major > major || (this._major === major && this._minor >= minor);
     }
+}
+
+export class TargetVersions {
+    constructor(public readonly protocol: Version, public readonly browser: Version) {}
 }
 
 export class ChromeTargetDiscovery implements ITargetDiscoveryStrategy, IObservableEvents<IStepStartedEventsEmitter> {
@@ -67,7 +78,7 @@ export class ChromeTargetDiscovery implements ITargetDiscoveryStrategy, IObserva
         return this._getMatchingTargets(targets, targetFilter, targetUrl);
     }
 
-    private async _getVersionData(address: string, port: number): Promise<ProtocolSchema> {
+    private async _getVersionData(address: string, port: number): Promise<TargetVersions> {
 
         const url = `http://${address}:${port}/json/version`;
         this.logger.log(`Getting browser and debug protocol version via ${url}`);
@@ -78,9 +89,10 @@ export class ChromeTargetDiscovery implements ITargetDiscoveryStrategy, IObserva
         try {
             if (jsonResponse) {
                 const response = JSON.parse(jsonResponse);
-                const versionString = response['Protocol-Version'] as string;
-                this.logger.log(`Got browser version: ${response.Browser}`);
-                this.logger.log(`Got debug protocol version: ${versionString}`);
+                const protocolVersionString = response['Protocol-Version'] as string;
+                const browserWithPrefixVersionString = response['Browser'] as string;
+                this.logger.log(`Got browser version: ${browserWithPrefixVersionString }`);
+                this.logger.log(`Got debug protocol version: ${protocolVersionString}`);
 
                 /* __GDPR__
                    "targetDebugProtocolVersion" : {
@@ -88,16 +100,21 @@ export class ChromeTargetDiscovery implements ITargetDiscoveryStrategy, IObserva
                        "${include}": [ "${DebugCommonProperties}" ]
                    }
                  */
+
+                const chromePrefix = 'Chrome/';
+                let browserVersion = Version.unknownVersion();
+                if (browserWithPrefixVersionString.startsWith(chromePrefix)) {
+                    const browserVersionString = browserWithPrefixVersionString.substr(chromePrefix.length);
+                    browserVersion = Version.parse(browserVersionString);
+                }
+
                 this.telemetry.reportEvent('targetDebugProtocolVersion', { debugProtocolVersion: response['Protcol-Version'] });
-                const majorAndMinor = versionString.split('.');
-                const major = parseInt(majorAndMinor[0], 10);
-                const minor = parseInt(majorAndMinor[1], 10);
-                return new ProtocolSchema(major, minor);
+                return new TargetVersions(Version.parse(protocolVersionString), browserVersion);
             }
         } catch (e) {
             this.logger.log(`Didn't get a valid response for /json/version call. Error: ${e.message}. Response: ${jsonResponse}`);
         }
-        return ProtocolSchema.unknownVersion();
+        return new TargetVersions(Version.unknownVersion(), Version.unknownVersion());
     }
 
     private async _getTargets(address: string, port: number): Promise<ITarget[]> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import { NullLogger } from './nullLogger';
 import * as executionTimingsReporter from './executionTimingsReporter';
 
 import { Protocol as Crdp } from 'devtools-protocol';
-import { ProtocolSchema } from './chrome/chromeTargetDiscoveryStrategy';
+import { Version } from './chrome/chromeTargetDiscoveryStrategy';
 
 export {
     chromeConnection,
@@ -55,7 +55,7 @@ export {
     NullLogger,
     executionTimingsReporter,
 
-    ProtocolSchema,
+    Version,
 
     Crdp
 };

--- a/test/chrome/chromeTargetDiscoveryStrategy.test.ts
+++ b/test/chrome/chromeTargetDiscoveryStrategy.test.ts
@@ -10,7 +10,7 @@ import { ITargetDiscoveryStrategy } from '../../src/chrome/chromeConnection';
 
 import { NullLogger } from '../../src/nullLogger';
 import { NullTelemetryReporter } from '../../src/telemetry';
-import { ProtocolSchema } from '../../src';
+import { Version } from '../../src';
 
 const MODULE_UNDER_TEST = '../../src/chrome/chromeTargetDiscoveryStrategy';
 suite('ChromeTargetDiscoveryStrategy', () => {
@@ -218,7 +218,7 @@ suite('ChromeTargetDiscoveryStrategy', () => {
         });
 
         test('ProtocolSchema return if the version is at least', () => {
-            const schema0dot1 = new ProtocolSchema(0, 1);
+            const schema0dot1 = new Version(0, 1);
             assert.ok(schema0dot1.isAtLeastVersion(0, 0));
             assert.ok(schema0dot1.isAtLeastVersion(0, 1));
             assert.ok(!schema0dot1.isAtLeastVersion(0, 2));
@@ -226,7 +226,7 @@ suite('ChromeTargetDiscoveryStrategy', () => {
             assert.ok(!schema0dot1.isAtLeastVersion(1, 1));
             assert.ok(!schema0dot1.isAtLeastVersion(1, 2));
 
-            const schema0dot2 = new ProtocolSchema(0, 2);
+            const schema0dot2 = new Version(0, 2);
             assert.ok(schema0dot2.isAtLeastVersion(0, 0));
             assert.ok(schema0dot2.isAtLeastVersion(0, 1));
             assert.ok(schema0dot2.isAtLeastVersion(0, 2));
@@ -234,7 +234,7 @@ suite('ChromeTargetDiscoveryStrategy', () => {
             assert.ok(!schema0dot2.isAtLeastVersion(1, 1));
             assert.ok(!schema0dot2.isAtLeastVersion(1, 2));
 
-            const schema1dot0 = new ProtocolSchema(1, 0);
+            const schema1dot0 = new Version(1, 0);
             assert.ok(schema1dot0.isAtLeastVersion(0, 0));
             assert.ok(schema1dot0.isAtLeastVersion(0, 1));
             assert.ok(schema1dot0.isAtLeastVersion(0, 2));


### PR DESCRIPTION
In Chrome 68 and earlier with DOM Instrumentation Chrome used to send a Debugger.Paused on line 0,0, we would resume, and then Chrome would stop again on the first line of the file

In Chrome 69 this behavior changed, and now DOM Instrumentation Chrome sends a Debugger.Paused event and if we resume we continue directly on line 2 of the file, instead of line 1. So the logic doesn't work any more if you put a breakpoint on the first line of the file.

This change uses the same strategy that we use for regexp. If we stop on the first line of the file with DOM Instrumentation, we use that paused as the breakpoint paused.