### PR TITLE
Make break on load protected

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -147,7 +147,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
 
     private _lastPauseState: { expecting: ReasonType; event: Crdp.Debugger.PausedEvent };
 
-    private _breakOnLoadHelper: BreakOnLoadHelper | null;
+    protected _breakOnLoadHelper: BreakOnLoadHelper | null;
 
     // Queue to synchronize new source loaded and source removed events so that 'remove' script events
     // won't be send before the corresponding 'new' event has been sent


### PR DESCRIPTION
We need to access this variable for a workaround of the /json/version failing

This change is needed for this PR: https://github.com/Microsoft/vscode-chrome-debug/pull/731