### PR TITLE
Shennie issue68on edge

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -2487,9 +2487,9 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
 
         // Convert to a Variable object then just copy the relevant fields off
         const variable = await this.remoteObjectToVariable(args.expression, evalResponse.result, /*parentEvaluateName=*/undefined, /*stringify=*/undefined, <VariableContext>args.context);
-        if (evalResponse.exceptionDetails) {
+        if (evalResponse.exceptionDetails || !variable.value) {
             let resultValue = variable.value;
-            if (resultValue && (resultValue.startsWith('ReferenceError: ') || resultValue.startsWith('TypeError: ')) && args.context !== 'repl') {
+            if (resultValue === "" || resultValue && (resultValue.startsWith('ReferenceError: ') || resultValue.startsWith('TypeError: ')) && args.context !== 'repl' ) {
                 resultValue = errors.evalNotAvailableMsg;
             }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import { NullLogger } from './nullLogger';
 import * as executionTimingsReporter from './executionTimingsReporter';
 
 import { Protocol as Crdp } from 'devtools-protocol';
-import { Version } from './chrome/chromeTargetDiscoveryStrategy';
+import { Version, TargetVersions } from './chrome/chromeTargetDiscoveryStrategy';
 
 export {
     chromeConnection,
@@ -56,6 +56,7 @@ export {
     executionTimingsReporter,
 
     Version,
+    TargetVersions,
 
     Crdp
 };


### PR DESCRIPTION
- exporting TargetVersions class so that vscode-edge-debug-adapter can properly load messages
- putting a check so that properties without display values show up as "not available", as opposed to "" (in reference to this issue: https://github.com/Microsoft/vscode-edge-debug2/issues/68) 