### PR TITLE
Export target versions class

### DIFF
--- a/src/chrome/chromeConnection.ts
+++ b/src/chrome/chromeConnection.ts
@@ -9,7 +9,7 @@ import { StepProgressEventsEmitter, IObservableEvents, IStepStartedEventsEmitter
 import * as errors from '../errors';
 import * as utils from '../utils';
 import { logger } from 'vscode-debugadapter';
-import { ChromeTargetDiscovery, TargetVersions } from './chromeTargetDiscoveryStrategy';
+import { ChromeTargetDiscovery, TargetVersions, Version } from './chromeTargetDiscoveryStrategy';
 
 import { Client, LikeSocket } from 'noice-json-rpc';
 
@@ -187,6 +187,14 @@ export class ChromeConnection implements IObservableEvents<IStepStartedEventsEmi
     }
 
     public get version(): Promise<TargetVersions> {
-        return this._attachedTarget.version;
+        return this._attachedTarget.version
+            .then(version => {
+                if (version === undefined) {
+                    return new TargetVersions(Version.unknownVersion(), Version.unknownVersion());
+                }
+                let protocolVersion: Version = (version.protocol === undefined) ? Version.unknownVersion() : version.protocol;
+                let browserVersion: Version = (version.browser === undefined) ? Version.unknownVersion() : version.browser;
+                return new TargetVersions(protocolVersion, browserVersion);
+            });
     }
 }

--- a/src/chrome/chromeConnection.ts
+++ b/src/chrome/chromeConnection.ts
@@ -189,12 +189,7 @@ export class ChromeConnection implements IObservableEvents<IStepStartedEventsEmi
     public get version(): Promise<TargetVersions> {
         return this._attachedTarget.version
             .then(version => {
-                if (version === undefined) {
-                    return new TargetVersions(Version.unknownVersion(), Version.unknownVersion());
-                }
-                let protocolVersion: Version = (version.protocol === undefined) ? Version.unknownVersion() : version.protocol;
-                let browserVersion: Version = (version.browser === undefined) ? Version.unknownVersion() : version.browser;
-                return new TargetVersions(protocolVersion, browserVersion);
+                return (version) ? version : new TargetVersions(Version.unknownVersion(), Version.unknownVersion());
             });
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import { NullLogger } from './nullLogger';
 import * as executionTimingsReporter from './executionTimingsReporter';
 
 import { Protocol as Crdp } from 'devtools-protocol';
-import { Version } from './chrome/chromeTargetDiscoveryStrategy';
+import { Version, TargetVersions } from './chrome/chromeTargetDiscoveryStrategy';
 
 export {
     chromeConnection,
@@ -56,6 +56,7 @@ export {
     executionTimingsReporter,
 
     Version,
+    TargetVersions,
 
     Crdp
 };


### PR DESCRIPTION
With the change in classes from ProtocolSchema to Version and TargetVersions, the TargetVersions class needs to be exported in order to maintain compatibility with edge-debug-adapter, which used to work with ProtocolSchema. 

Adding a then handler to version getter allows for "isAtLeast" version comparisons in case ._attachedTarget.version is null or undefined