### PR TITLE
catching when watch variables don't exist

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -2729,7 +2729,10 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
             } else {
                 propCountP = this.getCollectionNumPropsByEval(object.objectId);
             }
-        } else {
+        } else if (context === 'watch' && object.subtype && object.subtype === 'error') {
+            propCountP = Promise.reject(new Error(errors.evalNotAvailableMsg));
+        }
+        else {
             propCountP = Promise.resolve({
                 indexedVariables: undefined,
                 namedVariables: undefined

--- a/test/chrome/chromeDebugAdapter.test.ts
+++ b/test/chrome/chromeDebugAdapter.test.ts
@@ -754,6 +754,18 @@ suite('ChromeDebugAdapter', () => {
             });
         });
 
+        test('returns error with localized message when watch variable is missing', () => {
+            const expression = 'zzz';
+            const context = 'watch';
+            const result: Crdp.Runtime.RemoteObject = { type: 'object', description: '', subtype: 'error' };
+            setupEvalMock(expression, result);
+
+            return chromeDebugAdapter.evaluate({ expression, context }).then(
+                () => Promise.reject(new Error('Expected method to reject')),
+                () => {}
+            );
+        });
+
         test('calls Debugger.evaluateOnCallFrame when paused', () => {
             const callFrameId = '1';
             const expression = '1+1';


### PR DESCRIPTION
This pull request is for the following issue that was posted to vscode-edge-debug2: https://github.com/Microsoft/vscode-edge-debug2/issues/68

If watch variable is not found, it will return error with message string instead of empty string.