### PR TITLE
 Fix breakpoint logic for multiple authored files sourcemapped to a single js bundle

### DIFF
--- a/src/chrome/breakOnLoadHelper.ts
+++ b/src/chrome/breakOnLoadHelper.ts
@@ -113,7 +113,7 @@ export class BreakOnLoadHelper {
         // Important: We need to get the committed breakpoints only after all the pending breakpoints for this file have been resolved. If not this logic won't work
         const committedBps = this._chromeDebugAdapter.committedBreakpointsByUrl.get(pausedScriptUrl) || [];
         const anyBreakpointsAtPausedLocation = committedBps.filter(bp =>
-            bp.actualLocation.lineNumber === pausedLocation.lineNumber && bp.actualLocation.columnNumber === pausedLocation.columnNumber).length > 0;
+            bp.breakpoint.actualLocation.lineNumber === pausedLocation.lineNumber && bp.breakpoint.actualLocation.columnNumber === pausedLocation.columnNumber).length > 0;
 
         // If there were any breakpoints at this location (Which generally should be (1,1)) we shouldn't continue
         if (anyBreakpointsAtPausedLocation) {

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -1461,13 +1461,18 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
                     targetScriptUrl = args.source.path;
                 }
 
+                let authoredPath: string;
+                if (args.authoredPath) {
+                    authoredPath = utils.canonicalizeUrl(args.authoredPath);
+                }
+
                 if (targetScriptUrl) {
                     // DebugProtocol sends all current breakpoints for the script. Clear all breakpoints for the script then add all of them
                     const internalBPs = args.breakpoints.map(bp => new InternalSourceBreakpoint(bp));
                     const setBreakpointsPFailOnError = this._setBreakpointsRequestQ
-                        .then(() => this.clearAllBreakpoints(targetScriptUrl, args.authoredPath))
+                        .then(() => this.clearAllBreakpoints(targetScriptUrl, authoredPath))
                         .then(() => this.addBreakpoints(targetScriptUrl, internalBPs))
-                        .then(responses => ({ breakpoints: this.targetBreakpointResponsesToBreakpointSetResults(targetScriptUrl, args.authoredPath, responses, internalBPs, ids) }));
+                        .then(responses => ({ breakpoints: this.targetBreakpointResponsesToBreakpointSetResults(targetScriptUrl, authoredPath, responses, internalBPs, ids) }));
 
                     const setBreakpointsPTimeout = utils.promiseTimeout(setBreakpointsPFailOnError, ChromeDebugAdapter.SET_BREAKPOINTS_TIMEOUT, localize('setBPTimedOut', 'Set breakpoints request timed out'));
 

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -87,6 +87,11 @@ export interface IOnPausedResult {
     didPause: boolean;
 }
 
+export interface CommittedBreakpoint {
+    breakpoint: ISetBreakpointResult;
+    authoredPath?: string;
+}
+
 export abstract class ChromeDebugAdapter implements IDebugAdapter {
     public static EVAL_NAME_PREFIX = ChromeUtils.EVAL_NAME_PREFIX;
     public static EVAL_ROOT = '<eval>';
@@ -101,7 +106,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
     protected _domains = new Map<CrdpDomain, Crdp.Schema.Domain>();
     private _clientAttached: boolean;
     private _currentPauseNotification: Crdp.Debugger.PausedEvent;
-    private _committedBreakpointsByUrl: Map<string, ISetBreakpointResult[]>;
+    private _committedBreakpointsByUrl: Map<string, CommittedBreakpoint[]>;
     private _exception: Crdp.Runtime.RemoteObject;
     private _setBreakpointsRequestQ: Promise<any>;
     private _expectingResumedEvent: boolean;
@@ -202,8 +207,24 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         return this._pendingBreakpointsByUrl;
     }
 
-    public get committedBreakpointsByUrl(): Map<string, ISetBreakpointResult[]> {
+    public get committedBreakpointsByUrl(): Map<string, CommittedBreakpoint[]> {
         return this._committedBreakpointsByUrl;
+    }
+
+    public addCommittedBreakpointByUrl(url: string, toAdd: CommittedBreakpoint): void {
+        const committedBps = this._committedBreakpointsByUrl.get(url) || [];
+        if (!committedBps.find(committedBp => committedBp.breakpoint.breakpointId === toAdd.breakpoint.breakpointId)) {
+            committedBps.push(toAdd);
+        }
+        this._committedBreakpointsByUrl.set(url, committedBps);
+    }
+
+    public removeCommittedBreakpointByUrl(url: string, toRemove: CommittedBreakpoint): void {
+        const committedBps = this._committedBreakpointsByUrl.get(url);
+        const index = committedBps.findIndex(committedBp => committedBp.breakpoint.breakpointId === toRemove.breakpoint.breakpointId);
+        if (index >= 0) {
+            this._committedBreakpointsByUrl.get(url).splice(index, 1);
+        }
     }
 
     public get sourceMapTransformer(): BaseSourceMapTransformer {
@@ -219,7 +240,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         this._scriptsById = new Map<Crdp.Runtime.ScriptId, Crdp.Debugger.ScriptParsedEvent>();
         this._scriptsByUrl = new Map<string, Crdp.Debugger.ScriptParsedEvent>();
 
-        this._committedBreakpointsByUrl = new Map<string, ISetBreakpointResult[]>();
+        this._committedBreakpointsByUrl = new Map<string, CommittedBreakpoint[]>();
         this._setBreakpointsRequestQ = Promise.resolve();
 
         this._pathTransformer.clearTargetContext();
@@ -1178,7 +1199,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         });
     }
 
-    protected onBreakpointResolved(params: Crdp.Debugger.BreakpointResolvedEvent): void {
+    protected async onBreakpointResolved(params: Crdp.Debugger.BreakpointResolvedEvent): Promise<void> {
         const script = this._scriptsById.get(params.location.scriptId);
         const breakpointId = this._breakpointIdHandles.lookup(params.breakpointId);
         if (!script || !breakpointId) {
@@ -1191,12 +1212,6 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
             return;
         }
 
-        const committedBps = this._committedBreakpointsByUrl.get(script.url) || [];
-        if (!committedBps.find(committedBp => committedBp.breakpointId === params.breakpointId)) {
-            committedBps.push({breakpointId: params.breakpointId, actualLocation: params.location});
-        }
-        this._committedBreakpointsByUrl.set(script.url, committedBps);
-
         const bp = <DebugProtocol.Breakpoint>{
             id: breakpointId,
             verified: true,
@@ -1204,6 +1219,11 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
             column: params.location.columnNumber
         };
         const scriptPath = this._pathTransformer.breakpointResolved(bp, script.url);
+
+        const authoredPosition = await this._sourceMapTransformer.mapToAuthored(scriptPath, bp.line, bp.column);
+        const authoredPath = authoredPosition ? authoredPosition.source : null;
+        const committedBp = {breakpoint: {breakpointId: params.breakpointId, actualLocation: params.location}, authoredPath: authoredPath};
+        this.addCommittedBreakpointByUrl(script.url, committedBp);
 
         if (this._pendingBreakpointsByUrl.has(scriptPath)) {
             // If we set these BPs before the script was loaded, remove from the pending list
@@ -1445,9 +1465,9 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
                     // DebugProtocol sends all current breakpoints for the script. Clear all breakpoints for the script then add all of them
                     const internalBPs = args.breakpoints.map(bp => new InternalSourceBreakpoint(bp));
                     const setBreakpointsPFailOnError = this._setBreakpointsRequestQ
-                        .then(() => this.clearAllBreakpoints(targetScriptUrl))
+                        .then(() => this.clearAllBreakpoints(targetScriptUrl, args.authoredPath))
                         .then(() => this.addBreakpoints(targetScriptUrl, internalBPs))
-                        .then(responses => ({ breakpoints: this.targetBreakpointResponsesToBreakpointSetResults(targetScriptUrl, responses, internalBPs, ids) }));
+                        .then(responses => ({ breakpoints: this.targetBreakpointResponsesToBreakpointSetResults(targetScriptUrl, args.authoredPath, responses, internalBPs, ids) }));
 
                     const setBreakpointsPTimeout = utils.promiseTimeout(setBreakpointsPFailOnError, ChromeDebugAdapter.SET_BREAKPOINTS_TIMEOUT, localize('setBPTimedOut', 'Set breakpoints request timed out'));
 
@@ -1557,7 +1577,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         return { breakpoints };
     }
 
-    private clearAllBreakpoints(url: string): Promise<void> {
+    private clearAllBreakpoints(url: string, authoredPath: string): Promise<void> {
         if (!this._committedBreakpointsByUrl.has(url)) {
             return Promise.resolve();
         }
@@ -1567,10 +1587,16 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         // state where later adds on the same line will fail with 'breakpoint already exists' even though it
         // does not break there.
         return this._committedBreakpointsByUrl.get(url).reduce((p, bp) => {
-            return p.then(() => this.chrome.Debugger.removeBreakpoint({ breakpointId: bp.breakpointId })).then(() => { });
-        }, Promise.resolve()).then(() => {
-            this._committedBreakpointsByUrl.delete(url);
-        });
+            // If we are clearing breakpoints with an authored path, skip any breakpoints that do not match
+            // the authored path.
+            if (authoredPath && authoredPath !== bp.authoredPath) {
+                return Promise.resolve();
+            }
+
+            return p
+                .then(() => this.chrome.Debugger.removeBreakpoint({ breakpointId: bp.breakpoint.breakpointId }))
+                .then(() => this.removeCommittedBreakpointByUrl(url, bp));
+        }, Promise.resolve());
     }
 
     /**
@@ -1649,13 +1675,16 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         };
     }
 
-    private targetBreakpointResponsesToBreakpointSetResults(url: string, responses: ISetBreakpointResult[], requestBps: InternalSourceBreakpoint[], ids?: number[]): BreakpointSetResult[] {
+    private targetBreakpointResponsesToBreakpointSetResults(url: string, authoredPath: string, responses: ISetBreakpointResult[], requestBps: InternalSourceBreakpoint[], ids?: number[]): BreakpointSetResult[] {
         // Don't cache errored responses
-        const committedBps = responses
+        const successfulResponses = responses
             .filter(response => response && response.breakpointId);
 
         // Cache successfully set breakpoint ids from chrome in committedBreakpoints set
-        this._committedBreakpointsByUrl.set(url, committedBps);
+        successfulResponses.forEach(response => {
+            const committedBp = {breakpoint: response, authoredPath: authoredPath};
+            this.addCommittedBreakpointByUrl(url, committedBp);
+        });
 
         // Map committed breakpoints to DebugProtocol response breakpoints
         return responses

--- a/test/chrome/chromeDebugAdapter.test.ts
+++ b/test/chrome/chromeDebugAdapter.test.ts
@@ -214,12 +214,12 @@ suite('ChromeDebugAdapter', () => {
             });
         }
 
-        function expectRemoveBreakpoint(indicies: number[]): void {
+        function expectRemoveBreakpoint(indicies: number[], times: Times = Times.atLeastOnce()): void {
             indicies.forEach(i => {
                 mockChrome.Debugger
                     .setup(x => x.removeBreakpoint(It.isValue({ breakpointId: BP_ID + i })))
                     .returns(() => Promise.resolve())
-                    .verifiable(Times.atLeastOnce());
+                    .verifiable(times);
             });
         }
 
@@ -390,15 +390,17 @@ suite('ChromeDebugAdapter', () => {
                 .then(response => assertExpectedResponse(response, breakpoints));
         });
 
-        function setBp_emitScriptParsedWithSourcemaps(generatedScriptPath: string, authoredSourcePath: string): void {
+        function setBp_emitScriptParsedWithSourcemaps(generatedScriptPath: string, authoredSourcePaths: string[]): void {
             mockSourceMapTransformer.setup(m => m.mapToAuthored(It.isAnyString(), It.isAnyNumber(), It.isAnyNumber()))
                 .returns(somePath => Promise.resolve(somePath));
 
             mockSourceMapTransformer.setup(m => m.allSources(It.isAnyString()))
                 .returns(() => Promise.resolve([]));
 
-            mockSourceMapTransformer.setup(x => x.getGeneratedPathFromAuthoredPath(It.isValue(authoredSourcePath)))
+            authoredSourcePaths.forEach((authoredSourcePath) => {
+                mockSourceMapTransformer.setup(x => x.getGeneratedPathFromAuthoredPath(It.isValue(authoredSourcePath)))
                 .returns(() => Promise.resolve(generatedScriptPath));
+            });
 
             mockSourceMapTransformer.setup(x => x.setBreakpoints(It.isAny(), It.isAnyNumber(), It.isAny()))
                 .returns(( args: ISetBreakpointsArgs, ids: number[]) => {
@@ -406,7 +408,7 @@ suite('ChromeDebugAdapter', () => {
                     return { args, ids };
                 });
 
-            setBp_emitScriptParsed(generatedScriptPath, undefined, [authoredSourcePath]);
+            setBp_emitScriptParsed(generatedScriptPath, undefined, authoredSourcePaths);
         }
 
         function expectBreakpointEvent(bpId: number): Promise<void> {
@@ -446,7 +448,7 @@ suite('ChromeDebugAdapter', () => {
             mockSourceMapTransformer.reset();
 
             expectSetBreakpoint(breakpoints, generatedScriptPath);
-            setBp_emitScriptParsedWithSourcemaps(generatedScriptPath, authoredSourcePath);
+            setBp_emitScriptParsedWithSourcemaps(generatedScriptPath, [authoredSourcePath]);
             await expectBreakpointEvent(bpId);
         });
 
@@ -472,8 +474,72 @@ suite('ChromeDebugAdapter', () => {
             mockSourceMapTransformer.reset();
 
             expectSetBreakpoint(breakpoints, generatedScriptPath);
-            setBp_emitScriptParsedWithSourcemaps(generatedScriptPath, authoredSourcePath);
+            setBp_emitScriptParsedWithSourcemaps(generatedScriptPath, [authoredSourcePath]);
             await expectBreakpointEvent(bpId);
+        });
+
+        test('breakpoints are set in multiple .ts scripts that are sourcemapped to the same .js bundle', async () => {
+            const breakpoints1: DebugProtocol.SourceBreakpoint[] = [
+                { line: 2, column: 3 },
+                { line: 3, column: 4 }
+            ];
+            const breakpoints2: DebugProtocol.SourceBreakpoint[] = [
+                { line: 5, column: 6 },
+                { line: 7, column: 8 }
+            ];
+
+            const authoredSourcePath1 = '/project/authored1.ts';
+            const authoredSourcePath2 = '/project/authored2.ts';
+            const generatedScriptPath = '/project/bundle.js';
+
+            await chromeDebugAdapter.attach(ATTACH_ARGS)
+                .then(() => setBp_emitScriptParsedWithSourcemaps(generatedScriptPath, [authoredSourcePath1, authoredSourcePath2]))
+                .then(() => {
+                    expectSetBreakpoint(breakpoints1, generatedScriptPath);
+                    return chromeDebugAdapter.setBreakpoints({ source: { path: authoredSourcePath1 }, breakpoints: breakpoints1 }, null, 0);
+                })
+                .then(response => assertExpectedResponse(response, breakpoints1))
+                .then(() => {
+                    expectSetBreakpoint(breakpoints2, generatedScriptPath);
+                    expectRemoveBreakpoint([0, 1, 2, 3], Times.never());
+                    return chromeDebugAdapter.setBreakpoints({ source: { path: authoredSourcePath2 }, breakpoints: breakpoints2 }, null, 0);
+                })
+                .then(response => assertExpectedResponse(response, breakpoints2));
+        });
+
+        test('breakpoints are cleared properly in multiple .ts scripts that are sourcemapped to the same .js bundle', async () => {
+            const breakpoints1: DebugProtocol.SourceBreakpoint[] = [
+                { line: 2, column: 3 },
+                { line: 3, column: 4 }
+            ];
+            const breakpoints2: DebugProtocol.SourceBreakpoint[] = [
+                { line: 5, column: 6 },
+                { line: 7, column: 8 }
+            ];
+
+            const authoredSourcePath1 = '/project/authored1.ts';
+            const authoredSourcePath2 = '/project/authored2.ts';
+            const generatedScriptPath = '/project/bundle.js';
+
+            await chromeDebugAdapter.attach(ATTACH_ARGS)
+                .then(() => setBp_emitScriptParsedWithSourcemaps(generatedScriptPath, [authoredSourcePath1, authoredSourcePath2]))
+                .then(() => {
+                    expectSetBreakpoint(breakpoints1, generatedScriptPath);
+                    return chromeDebugAdapter.setBreakpoints({ source: { path: authoredSourcePath1 }, breakpoints: breakpoints1 }, null, 0);
+                })
+                .then(response => assertExpectedResponse(response, breakpoints1))
+                .then(() => {
+                    expectSetBreakpoint(breakpoints2, generatedScriptPath);
+                    return chromeDebugAdapter.setBreakpoints({ source: { path: authoredSourcePath2 }, breakpoints: breakpoints2 }, null, 0);
+                })
+                .then(response => assertExpectedResponse(response, breakpoints2))
+                .then(() => {
+                    expectSetBreakpoint(breakpoints1, generatedScriptPath);
+                    expectRemoveBreakpoint([0, 1], Times.once());
+                    expectRemoveBreakpoint([2, 3], Times.never());
+                    return chromeDebugAdapter.setBreakpoints({ source: { path: authoredSourcePath1 }, breakpoints: breakpoints1 }, null, 0);
+                })
+                .then(response => assertExpectedResponse(response, breakpoints1));
         });
     });
 

--- a/test/chrome/chromeDebugAdapter.test.ts
+++ b/test/chrome/chromeDebugAdapter.test.ts
@@ -404,6 +404,7 @@ suite('ChromeDebugAdapter', () => {
 
             mockSourceMapTransformer.setup(x => x.setBreakpoints(It.isAny(), It.isAnyNumber(), It.isAny()))
                 .returns(( args: ISetBreakpointsArgs, ids: number[]) => {
+                    args.authoredPath = args.source.path;
                     args.source.path = generatedScriptPath;
                     return { args, ids };
                 });


### PR DESCRIPTION
When multiple authored files are compiled to a single js bundle, the set breakpoint logic is broken.

Current broken logic: When setting breakpoints we clear all existing breakpoints in the target url (in this case, the js bundle), and then we apply the incoming breakpoints for the authored file. This wipes out any breakpoints for all other authored files that are sourcemapped to the same js bundle.

Proposed fix: Track the authored path for all breakpoints if it is available and only remove breakpoints that exist for that authored file.