### PR TITLE
Fix for file path case mismatch in sourcemaps

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -1405,7 +1405,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         this.reportBpTelemetry(args);
         if (args.source.path) {
             args.source.path = this.displayPathToRealPath(args.source.path);
-            args.source.path = utils.fixDriveLetterAndSlashes(args.source.path);
+            args.source.path = utils.canonicalizeUrl(args.source.path);
         }
 
         return this.validateBreakpointsPath(args)


### PR DESCRIPTION
New and improved one-line fix, as an alternative to #360 

When the sourcemaps are processed the paths are canonicalized with utils.canonicalizeUrl(). The path being passed in with setBreakpoints needs to be canonicalized as well in order for the paths to match properly.

It turns out this is actually only an issue with Visual Studio, since the paths are changed to lowercase only when the client is detected to be Visual Studio.