### PR TITLE
Fix not hitting BPs on the first line of NTVS unit tests

### DIFF
--- a/src/chrome/breakOnLoadHelper.ts
+++ b/src/chrome/breakOnLoadHelper.ts
@@ -55,7 +55,7 @@ export class BreakOnLoadHelper {
     }
 
     private getScriptUrlFromId(scriptId: string): string {
-        return this._chromeDebugAdapter.scriptsById.get(scriptId).url;
+        return utils.canonicalizeUrl(this._chromeDebugAdapter.scriptsById.get(scriptId).url);
     }
 
     public async setBrowserVersion(version: Version): Promise<void> {


### PR DESCRIPTION
We were comparing canonicalize vs normal case, so it wasn't matching and we didn't stop on 1,1 because we didn't realize there was a breakpoint there