### PR TITLE
We adapt to the latest version of Node.js which uses file:/// and we don't send sourceRef for files that exist

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -2048,7 +2048,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         const properlyCasedScriptUrl = utils.canonicalizeUrl(script.url);
         const displayPath = this.realPathToDisplayPath(properlyCasedScriptUrl);
 
-        const exists = await utils.existsAsync(script.url);
+        const exists = await utils.existsAsync(properlyCasedScriptUrl); // script.url can start with file:/// so we use the canonicalized version
         return <DebugProtocol.Source>{
             name: path.basename(displayPath),
             path: displayPath,


### PR DESCRIPTION
We adapt to the latest version of Node.js which uses file:/// and we don't send sourceRef for files that exist

In Node v11 it adds file:/// to script urls. That made existAsync return false, we sent the sourceRef to VS which assumes that the file is not on disk because of that, and causes breakpoints to not be shown properly.

We use the canonicalized version which removes file:/// to fix that issue