### PR TITLE
Don't send src changed events for storage sources

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -914,7 +914,12 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
             case 'new':
             case 'changed':
                 if (this._loadedSourcesByScriptId.get(script.scriptId)) {
-                    loadedSourceEventReason = 'changed';
+                    if (source.sourceReference) {
+                        // We only need to send changed events for dynamic scripts. The client tracks files on storage on it's own, so this notification is not needed
+                        loadedSourceEventReason = 'changed';
+                    } else {
+                        return; // VS is strict about the changed notifications, and it will fail if we send a changed notification for a file on storage, so we omit it on purpose
+                    }
                 } else {
                     loadedSourceEventReason = 'new';
                 }


### PR DESCRIPTION
Edge has incremental loading, so it can send several "loadsources" events for the same file.

VS is strict about the notification it receives. It tracks the changes to files on storage on it's own, so it'll show an error message if we send a changed event for a file on storage. Given that VS Code also tracks changes to files in storage on it's own, it makes sense to just filter those notifications and never send them.

This fixes an issue we were running into with Edge and VS