### PR TITLE
cannonicalizing url so that it can find the matching script when resolving breakpoint

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -101,6 +101,9 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
     protected _domains = new Map<CrdpDomain, Crdp.Schema.Domain>();
     private _clientAttached: boolean;
     private _currentPauseNotification: Crdp.Debugger.PausedEvent;
+
+    // when working with _committedBreakpointsByUrl, we want to keep the url keys canonicalized for consistency
+    // use methods getValueFromCommittedBreakpointsByUrl and setValueForCommittedBreakpointsByUrl
     private _committedBreakpointsByUrl: Map<string, ISetBreakpointResult[]>;
     private _exception: Crdp.Runtime.RemoteObject;
     private _setBreakpointsRequestQ: Promise<any>;
@@ -1204,7 +1207,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         }
 
         // committed breakpoints (this._committedBreakpointsByUrl) should always have url keys in canonicalized form
-        const committedBps = this.getValueFromCommittedBreakpointsByUrl(script.url);
+        const committedBps = this.getValueFromCommittedBreakpointsByUrl(script.url) || [];
 
         if (!committedBps.find(committedBp => committedBp.breakpointId === params.breakpointId)) {
             committedBps.push({breakpointId: params.breakpointId, actualLocation: params.location});

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -1204,7 +1204,7 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         }
 
         // committed breakpoints (this._committedBreakpointsByUrl) should always have url keys in canonicalized form
-        let committedBps = this.getValueFromCommittedBreakpointsByUrl(script.url);
+        const committedBps = this.getValueFromCommittedBreakpointsByUrl(script.url);
 
         if (!committedBps.find(committedBp => committedBp.breakpointId === params.breakpointId)) {
             committedBps.push({breakpointId: params.breakpointId, actualLocation: params.location});

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -1203,6 +1203,8 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
             return;
         }
 
+        script.url = utils.canonicalizeUrl(script.url);
+
         const committedBps = this._committedBreakpointsByUrl.get(script.url) || [];
         if (!committedBps.find(committedBp => committedBp.breakpointId === params.breakpointId)) {
             committedBps.push({breakpointId: params.breakpointId, actualLocation: params.location});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,6 +118,9 @@ export function setCaseSensitivePaths(useCaseSensitivePaths: boolean) {
  * http://site.com/ => http://site.com
  */
 export function canonicalizeUrl(urlOrPath: string): string {
+    if (urlOrPath == null) {
+        return urlOrPath;
+    }
     urlOrPath = fileUrlToPath(urlOrPath);
 
     // Remove query params


### PR DESCRIPTION
the breakpoint is moving b/c it cannot match authored to generated path in node scenario: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/685518