### PR TITLE
making sure bp.actual location is not null/undefined before trying to access its line number

### DIFF
--- a/src/chrome/breakOnLoadHelper.ts
+++ b/src/chrome/breakOnLoadHelper.ts
@@ -113,7 +113,10 @@ export class BreakOnLoadHelper {
         // Important: We need to get the committed breakpoints only after all the pending breakpoints for this file have been resolved. If not this logic won't work
         const committedBps = this._chromeDebugAdapter.committedBreakpointsByUrl.get(pausedScriptUrl) || [];
         const anyBreakpointsAtPausedLocation = committedBps.filter(bp =>
-            bp.actualLocation.lineNumber === pausedLocation.lineNumber && bp.actualLocation.columnNumber === pausedLocation.columnNumber).length > 0;
+            // Important: Chrome devtools-protocol can return an empty locations array, resulting in 'undefined' for the actualLocation, so we have to check an actualLocation exists
+            bp.actualLocation &&
+            bp.actualLocation.lineNumber === pausedLocation.lineNumber &&
+            bp.actualLocation.columnNumber === pausedLocation.columnNumber).length > 0;
 
         // If there were any breakpoints at this location (Which generally should be (1,1)) we shouldn't continue
         if (anyBreakpointsAtPausedLocation) {


### PR DESCRIPTION
Chrome core has a known issue where occasionally it returns an empty locations array: https://github.com/ChromeDevTools/devtools-protocol/issues/103

When this happens, actual location is undefined and throws an error, causing the browser to hang without loading the page. Stack trace from logs:
"aggregated.exceptionStack":"[
  \"TypeError: Cannot read property 'lineNumber' of undefined\\n    
  at committedBps.filter.bp (breakOnLoadHelper.js:100:96)\\n    
  at Array.filter (<anonymous>)\\n    
  at BreakOnLoadHelper.<anonymous> (breakOnLoadHelper.js:100:65)\\n    
  at Generator.next (<anonymous>)\\n    at fulfilled (breakOnLoadHelper.js:7:58)\\n    
  at process._tickCallback (internal/process/next_tick.js:68:7)\"
]"

This change is just to make sure that the browser doesn't hang