### PR TITLE
Created the UnresolvedSource to handle the source parameters sent via the vs code protocol that can be a path or a sourceReference

### DIFF
--- a/src/chrome/dependencyInjection.ts/types.ts
+++ b/src/chrome/dependencyInjection.ts/types.ts
@@ -1,0 +1,9 @@
+import 'reflect-metadata';
+
+// TODO: Add all necesary types so we can use inversifyjs to create our components
+
+const TYPES = {
+    EventsConsumedByConnectedCDA: Symbol.for('EventsConsumedByConnectedCDA'),
+};
+
+export { TYPES };

--- a/src/chrome/internal/features/feature.ts
+++ b/src/chrome/internal/features/feature.ts
@@ -1,0 +1,3 @@
+export interface IComponent {
+    // TODO: Implement this
+}

--- a/src/chrome/internal/sources/source.ts
+++ b/src/chrome/internal/sources/source.ts
@@ -6,23 +6,23 @@ import { SourceResolver } from './sourceResolver';
  * VS Code debug protocol sends breakpoint requests with a path?: string; or sourceReference?: number; Before we can use the path, we need to wait for the related script to be loaded so we can match it with a script id.
  * This set of classes will let us represent the information we get from either a path or a sourceReference, and then let us try to resolve it to a script id when possible.
  */
-export interface IUnresolvedSource {
+export interface ISource {
     readonly sourceIdentifier: IResourceIdentifier;
-    isEquivalent(right: IUnresolvedSource): boolean;
+    isEquivalent(right: ISource): boolean;
     tryResolving<R>(succesfulAction: (resolvedSource: ILoadedSource) => R, failedAction: (sourceIdentifier: IResourceIdentifier) => R): R;
 }
 
-abstract class UnresolvedSourceCommonLogic implements IUnresolvedSource {
+abstract class SourceCommonLogic implements ISource {
     public abstract tryResolving<R>(succesfulAction: (loadedSource: ILoadedSource) => R, failedAction: (identifier: IResourceIdentifier) => R): R;
     public abstract get sourceIdentifier(): IResourceIdentifier;
 
-    public isEquivalent(right: IUnresolvedSource): boolean {
+    public isEquivalent(right: ISource): boolean {
         return this.sourceIdentifier.isEquivalent(right.sourceIdentifier);
     }
 }
 
 // Find the related source by using the source's path
-export class SourceToBeResolvedViaPath extends UnresolvedSourceCommonLogic implements IUnresolvedSource {
+export class SourceToBeResolvedViaPath extends SourceCommonLogic implements ISource {
     public tryResolving<R>(succesfulAction: (resolvedSource: ILoadedSource) => R, failedAction: (sourceIdentifier: IResourceIdentifier) => R) {
         return this._sourceResolver.tryResolving(this.sourceIdentifier, succesfulAction, failedAction);
     }
@@ -37,7 +37,7 @@ export class SourceToBeResolvedViaPath extends UnresolvedSourceCommonLogic imple
 }
 
 // This source was already loaded, so we store it in this class
-export class SourceAlreadyResolvedToLoadedSource extends UnresolvedSourceCommonLogic implements IUnresolvedSource {
+export class SourceAlreadyResolvedToLoadedSource extends SourceCommonLogic implements ISource {
     public tryResolving<R>(succesfulAction: (resolvedSource: ILoadedSource) => R, _failedAction: (sourceIdentifier: IResourceIdentifier) => R) {
         return succesfulAction(this.loadedSource);
     }

--- a/src/chrome/internal/sources/sourceResolver.ts
+++ b/src/chrome/internal/sources/sourceResolver.ts
@@ -21,7 +21,7 @@ export class SourceResolver implements IComponent {
 
     public tryResolving<R>(sourceIdentifier: IResourceIdentifier,
         succesfulAction: (resolvedSource: ILoadedSource) => R,
-        failedAction: (sourceIdentifier: IResourceIdentifier) => R = path => { throw new Error(`Couldn't find the source at path ${path}`); }): R {
+        failedAction: (sourceIdentifier: IResourceIdentifier) => R): R {
         const source = this._pathToSource.tryGetting(sourceIdentifier);
         if (source !== undefined) {
             return succesfulAction(source);
@@ -30,7 +30,7 @@ export class SourceResolver implements IComponent {
         }
     }
 
-    public createSourceResolver(sourceIdentifier: IResourceIdentifier): IUnresolvedSource {
+    public createUnresolvedSource(sourceIdentifier: IResourceIdentifier): IUnresolvedSource {
         return new SourceToBeResolvedViaPath(sourceIdentifier, this);
     }
 

--- a/src/chrome/internal/sources/sourceResolver.ts
+++ b/src/chrome/internal/sources/sourceResolver.ts
@@ -1,5 +1,5 @@
 import { ILoadedSource } from './loadedSource';
-import { IUnresolvedSource, SourceToBeResolvedViaPath } from './unresolvedSource';
+import { ISource, SourceToBeResolvedViaPath } from './source';
 import { newResourceIdentifierMap, IResourceIdentifier } from './resourceIdentifier';
 import { IComponent } from '../features/feature';
 import { ScriptParsedEvent } from '../../target/events';
@@ -30,7 +30,7 @@ export class SourceResolver implements IComponent {
         }
     }
 
-    public createUnresolvedSource(sourceIdentifier: IResourceIdentifier): IUnresolvedSource {
+    public createUnresolvedSource(sourceIdentifier: IResourceIdentifier): ISource {
         return new SourceToBeResolvedViaPath(sourceIdentifier, this);
     }
 

--- a/src/chrome/internal/sources/sourceResolver.ts
+++ b/src/chrome/internal/sources/sourceResolver.ts
@@ -1,0 +1,53 @@
+import { ILoadedSource } from './loadedSource';
+import { IUnresolvedSource, SourceToBeResolvedViaPath } from './unresolvedSource';
+import { newResourceIdentifierMap, IResourceIdentifier } from './resourceIdentifier';
+import { IComponent } from '../features/feature';
+import { ScriptParsedEvent } from '../../target/events';
+import { injectable, inject } from 'inversify';
+import { TYPES } from '../../dependencyInjection.ts/types';
+
+export interface EventsConsumedBySourceResolver {
+    onScriptParsed(listener: (scriptEvent: ScriptParsedEvent) => Promise<void>): void;
+}
+
+/**
+ * The SourceResolver listens to onScriptParsed events to build a map of paths to loaded sources. When an SourceToBeResolvedViaPath is created, it'll store a reference to this object,
+ * and use it when it tries to resolve the path to a loaded source
+ */
+
+ @injectable()
+export class SourceResolver implements IComponent {
+    private _pathToSource = newResourceIdentifierMap<ILoadedSource>();
+
+    public tryResolving<R>(sourceIdentifier: IResourceIdentifier,
+        succesfulAction: (resolvedSource: ILoadedSource) => R,
+        failedAction: (sourceIdentifier: IResourceIdentifier) => R = path => { throw new Error(`Couldn't find the source at path ${path}`); }): R {
+        const source = this._pathToSource.tryGetting(sourceIdentifier);
+        if (source !== undefined) {
+            return succesfulAction(source);
+        } else {
+            return failedAction(sourceIdentifier);
+        }
+    }
+
+    public createSourceResolver(sourceIdentifier: IResourceIdentifier): IUnresolvedSource {
+        return new SourceToBeResolvedViaPath(sourceIdentifier, this);
+    }
+
+    public toString(): string {
+        return `Source resolver { path to source: ${this._pathToSource} }`;
+    }
+
+    public install(): this {
+        this._dependencies.onScriptParsed(async params => {
+            params.script.allSources.forEach(source => {
+                this._pathToSource.set(source.identifier, source);
+            });
+        });
+
+        return this;
+    }
+
+    constructor(
+        @inject(TYPES.EventsConsumedByConnectedCDA) private readonly _dependencies: EventsConsumedBySourceResolver) { }
+}

--- a/src/chrome/internal/sources/unresolvedSource.ts
+++ b/src/chrome/internal/sources/unresolvedSource.ts
@@ -1,0 +1,56 @@
+import { IResourceIdentifier } from './resourceIdentifier';
+import { ILoadedSource } from './loadedSource';
+import { SourceResolver } from './sourceResolver';
+
+/**
+ * VS Code debug protocol sends breakpoint requests with a path?: string; or sourceReference?: number; Before we can use the path, we need to wait for the related script to be loaded so we can match it with a script id.
+ * This set of classes will let us represent the information we get from either a path or a sourceReference, and then let us try to resolve it to a script id when possible.
+ */
+export interface IUnresolvedSource {
+    readonly sourceIdentifier: IResourceIdentifier;
+    isEquivalent(right: IUnresolvedSource): boolean;
+    tryResolving<R>(succesfulAction: (resolvedSource: ILoadedSource) => R, failedAction: (sourceIdentifier: IResourceIdentifier) => R): R;
+}
+
+abstract class UnresolvedSourceCommonLogic implements IUnresolvedSource {
+    public abstract tryResolving<R>(succesfulAction: (loadedSource: ILoadedSource) => R, failedAction: (identifier: IResourceIdentifier) => R): R;
+    public abstract get sourceIdentifier(): IResourceIdentifier;
+
+    public isEquivalent(right: IUnresolvedSource): boolean {
+        return this.sourceIdentifier.isEquivalent(right.sourceIdentifier);
+    }
+}
+
+// Find the related source by using the source's path
+export class SourceToBeResolvedViaPath extends UnresolvedSourceCommonLogic implements IUnresolvedSource {
+    public tryResolving<R>(succesfulAction: (resolvedSource: ILoadedSource) => R, failedAction: (sourceIdentifier: IResourceIdentifier) => R) {
+        return this._sourceResolver.tryResolving(this.sourceIdentifier, succesfulAction, failedAction);
+    }
+
+    public toString(): string {
+        return `Resolve source via #${this.sourceIdentifier}`;
+    }
+
+    constructor(public readonly sourceIdentifier: IResourceIdentifier, private readonly _sourceResolver: SourceResolver) {
+        super();
+    }
+}
+
+// This source was already loaded, so we store it in this class
+export class SourceAlreadyResolvedToLoadedSource extends UnresolvedSourceCommonLogic implements IUnresolvedSource {
+    public tryResolving<R>(succesfulAction: (resolvedSource: ILoadedSource) => R, _failedAction: (sourceIdentifier: IResourceIdentifier) => R) {
+        return succesfulAction(this.loadedSource);
+    }
+
+    public get sourceIdentifier(): IResourceIdentifier {
+        return this.loadedSource.identifier;
+    }
+
+    public toString(): string {
+        return `${this.loadedSource}`;
+    }
+
+    constructor(public readonly loadedSource: ILoadedSource) {
+        super();
+    }
+}

--- a/src/chrome/target/events.ts
+++ b/src/chrome/target/events.ts
@@ -1,0 +1,25 @@
+import { IScript } from '../internal/scripts/script';
+
+import { Crdp } from '../..';
+
+export type integer = number;
+
+/**
+ * A new JavaScript Script has been parsed by the debugee and it's about to be executed
+ */
+export interface ScriptParsedEvent {
+    readonly script: IScript;
+    readonly url: string;
+    readonly startLine: integer;
+    readonly startColumn: integer;
+    readonly endLine: integer;
+    readonly endColumn: integer;
+    readonly executionContextId: Crdp.Runtime.ExecutionContextId;
+    readonly hash: string;
+    readonly executionContextAuxData?: any;
+    readonly isLiveEdit?: boolean;
+    readonly sourceMapURL?: string;
+    readonly hasSourceURL?: boolean;
+    readonly isModule?: boolean;
+    readonly length?: integer;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,9 @@
         "noImplicitReturns": true,
         "lib": [
             "es2015"
-        ]
+        ],
+
+        "experimentalDecorators": true
     },
     "include": [
         "src/**/*.ts",


### PR DESCRIPTION
This is part of the V2 refactoring of the debug adapter.

Created the UnresolvedSource to handle the source parameters sent via the vs code protocol that can be a path or a sourceReference.

When we need to use the parameter we'll call unresolvedSource.tryResolving which uses continuation passing style ( https://en.wikipedia.org/wiki/Continuation-passing_style ) to see if the source can be resolved or not, and take the appropriated action.