### PR TITLE
Location model

### DIFF
--- a/src/chrome/internal/locations/location.ts
+++ b/src/chrome/internal/locations/location.ts
@@ -1,0 +1,157 @@
+import * as Validation from '../../../validation';
+import { IScript } from '../scripts/script';
+import { ISource } from '../sources/source';
+import { ILoadedSource } from '../sources/loadedSource';
+import { logger } from 'vscode-debugadapter';
+import { ColumnNumber, LineNumber, URLRegexp } from './subtypes';
+import { CDTPScriptUrl } from '../sources/resourceIdentifierSubtypes';
+import { IResourceIdentifier, parseResourceIdentifier, URL } from '../sources/resourceIdentifier';
+
+export type integer = number;
+
+export class Position {
+    constructor(
+        public readonly lineNumber: LineNumber,
+        public readonly columnNumber?: ColumnNumber) {
+        Validation.zeroOrPositive('Line number', lineNumber);
+        if (columnNumber !== undefined) {
+            Validation.zeroOrPositive('Column number', columnNumber);
+        }
+    }
+
+    public isSameAs(location: Position): boolean {
+        return this.lineNumber === location.lineNumber
+            && this.columnNumber === location.columnNumber;
+    }
+
+    public toString(): string {
+        return this.columnNumber !== undefined
+            ? `${this.lineNumber}:${this.columnNumber}`
+            : `${this.lineNumber}`;
+    }
+}
+
+interface ILocation<T extends ScriptOrSourceOrURLOrURLRegexp> {
+    readonly lineNumber: integer;
+    readonly columnNumber?: integer;
+    readonly coordinates: Position;
+    readonly resource: T;
+}
+
+export type ScriptOrSourceOrURLOrURLRegexp = IScript | ILoadedSource | ISource | URLRegexp | URL<CDTPScriptUrl>;
+
+export type Location<T extends ScriptOrSourceOrURLOrURLRegexp> =
+    T extends ISource ? LocationInSource : // Used when receiving locations from the client
+    T extends ILoadedSource ? LocationInLoadedSource : // Used to translate between locations on the client and the debugee
+    T extends IScript ? LocationInScript : // Used when receiving locations from the debugee
+    T extends URLRegexp ? LocationInUrlRegexp : // Used when setting a breakpoint by URL in a local file path in windows, to make it case insensitive
+    T extends URL<CDTPScriptUrl> ? LocationInUrl : // Used when setting a breakpoint by URL for case-insensitive URLs
+    never;
+
+abstract class LocationCommonLogic<T extends ScriptOrSourceOrURLOrURLRegexp> implements ILocation<T> {
+    constructor(
+        public readonly resource: T,
+        public readonly coordinates: Position) { }
+
+    public get lineNumber(): LineNumber {
+        return this.coordinates.lineNumber;
+    }
+
+    public get columnNumber(): ColumnNumber {
+        return this.coordinates.columnNumber;
+    }
+
+    public toString(): string {
+        return `${this.resource}:${this.coordinates}`;
+    }
+}
+
+export class LocationInSource extends LocationCommonLogic<ISource> {
+    public get identifier(): ISource {
+        return this.resource;
+    }
+
+    public tryResolvingSource<R>(
+        whenSuccesfulDo: (locationInLoadedSource: LocationInLoadedSource) => R,
+        whenFailedDo: (locationInSource: LocationInSource) => R): R {
+        return this.identifier.tryResolving(
+            loadedSource => whenSuccesfulDo(new LocationInLoadedSource(loadedSource, this.coordinates)),
+            () => whenFailedDo(this));
+    }
+
+    public resolvedWith(loadedSource: ILoadedSource): LocationInLoadedSource {
+        if (this.resource.sourceIdentifier.isEquivalent(loadedSource.identifier)) {
+            return new LocationInLoadedSource(loadedSource, this.coordinates);
+        } else {
+            throw new Error(`Can't resolve a location with a source (${this}) to a location with a loaded source that doesn't match the unresolved source: ${loadedSource}`);
+        }
+    }
+}
+
+export class LocationInScript extends LocationCommonLogic<IScript> {
+    public get script(): IScript {
+        return this.resource;
+    }
+
+    public mappedToSource(): LocationInLoadedSource {
+        const mapped = this.script.sourcesMapper.getPositionInSource({ line: this.lineNumber, column: this.columnNumber });
+        if (mapped) {
+            const loadedSource = this.script.getSource(parseResourceIdentifier(mapped.source));
+            const result = new LocationInLoadedSource(loadedSource, new Position(mapped.line, mapped.column));
+            logger.verbose(`SourceMap: ${this} to ${result}`);
+            return result;
+        } else {
+            return new LocationInLoadedSource(this.script.developmentSource, this.coordinates);
+        }
+    }
+
+    public mappedToUrl(): LocationInUrl {
+        if (this.script.runtimeSource.doesScriptHasUrl()) {
+            return new LocationInUrl(this.script.runtimeSource.identifier, this.coordinates);
+        } else {
+            throw new Error(`Can't convert a location in a script without an URL (${this}) into a location in an URL`);
+        }
+    }
+
+    public isSameAs(locationInScript: LocationInScript): boolean {
+        return this.script === locationInScript.script &&
+            this.coordinates.isSameAs(locationInScript.coordinates);
+    }
+
+    public toString(): string {
+        return `${this.resource}:${this.coordinates}`;
+    }
+}
+
+export class LocationInLoadedSource extends LocationCommonLogic<ILoadedSource> {
+    public get source(): ILoadedSource {
+        return this.resource;
+    }
+
+    public mappedToScript(): LocationInScript {
+        const mapped = this.source.script.sourcesMapper.getPositionInScript({
+            source: this.source.identifier.textRepresentation,
+            line: this.lineNumber,
+            column: this.columnNumber
+        });
+        if (mapped) {
+            const result = new LocationInScript(this.source.script, new Position(mapped.line, mapped.column));
+            logger.verbose(`SourceMap: ${this} to ${result}`);
+            return result;
+        } else {
+            throw new Error(`Couldn't map the location (${this.coordinates}) in the source $(${this.source}) to a script file`);
+        }
+    }
+}
+
+export class LocationInUrl extends LocationCommonLogic<IResourceIdentifier<CDTPScriptUrl>> {
+    public get url(): URL<CDTPScriptUrl> {
+        return this.resource;
+    }
+}
+
+export class LocationInUrlRegexp extends LocationCommonLogic<URLRegexp> {
+    public get urlRegexp(): URLRegexp {
+        return this.resource;
+    }
+}

--- a/src/chrome/internal/locations/location.ts
+++ b/src/chrome/internal/locations/location.ts
@@ -51,14 +51,6 @@ abstract class LocationCommonLogic<T extends ScriptOrSourceOrURLOrURLRegexp> imp
         public readonly resource: T,
         public readonly position: Position) { }
 
-    public get lineNumber(): LineNumber {
-        return this.position.lineNumber;
-    }
-
-    public get columnNumber(): ColumnNumber {
-        return this.position.columnNumber;
-    }
-
     public toString(): string {
         return `${this.resource}:${this.position}`;
     }
@@ -92,7 +84,7 @@ export class LocationInScript extends LocationCommonLogic<IScript> {
     }
 
     public mappedToSource(): LocationInLoadedSource {
-        const mapped = this.script.sourcesMapper.getPositionInSource({ line: this.lineNumber, column: this.columnNumber });
+        const mapped = this.script.sourcesMapper.getPositionInSource({ line: this.position.lineNumber, column: this.position.columnNumber });
         if (mapped) {
             const loadedSource = this.script.getSource(parseResourceIdentifier(mapped.source));
             const result = new LocationInLoadedSource(loadedSource, new Position(mapped.line, mapped.column));
@@ -129,8 +121,8 @@ export class LocationInLoadedSource extends LocationCommonLogic<ILoadedSource> {
     public mappedToScript(): LocationInScript {
         const mapped = this.source.script.sourcesMapper.getPositionInScript({
             source: this.source.identifier.textRepresentation,
-            line: this.lineNumber,
-            column: this.columnNumber
+            line: this.position.lineNumber,
+            column: this.position.columnNumber
         });
         if (mapped) {
             const result = new LocationInScript(this.source.script, new Position(mapped.line, mapped.column));

--- a/src/chrome/internal/locations/location.ts
+++ b/src/chrome/internal/locations/location.ts
@@ -34,7 +34,7 @@ export class Position {
 interface ILocation<T extends ScriptOrSourceOrURLOrURLRegexp> {
     readonly lineNumber: integer;
     readonly columnNumber?: integer;
-    readonly coordinates: Position;
+    readonly position: Position;
     readonly resource: T;
 }
 
@@ -51,18 +51,18 @@ export type Location<T extends ScriptOrSourceOrURLOrURLRegexp> =
 abstract class LocationCommonLogic<T extends ScriptOrSourceOrURLOrURLRegexp> implements ILocation<T> {
     constructor(
         public readonly resource: T,
-        public readonly coordinates: Position) { }
+        public readonly position: Position) { }
 
     public get lineNumber(): LineNumber {
-        return this.coordinates.lineNumber;
+        return this.position.lineNumber;
     }
 
     public get columnNumber(): ColumnNumber {
-        return this.coordinates.columnNumber;
+        return this.position.columnNumber;
     }
 
     public toString(): string {
-        return `${this.resource}:${this.coordinates}`;
+        return `${this.resource}:${this.position}`;
     }
 }
 
@@ -75,13 +75,13 @@ export class LocationInSource extends LocationCommonLogic<ISource> {
         whenSuccesfulDo: (locationInLoadedSource: LocationInLoadedSource) => R,
         whenFailedDo: (locationInSource: LocationInSource) => R): R {
         return this.identifier.tryResolving(
-            loadedSource => whenSuccesfulDo(new LocationInLoadedSource(loadedSource, this.coordinates)),
+            loadedSource => whenSuccesfulDo(new LocationInLoadedSource(loadedSource, this.position)),
             () => whenFailedDo(this));
     }
 
     public resolvedWith(loadedSource: ILoadedSource): LocationInLoadedSource {
         if (this.resource.sourceIdentifier.isEquivalent(loadedSource.identifier)) {
-            return new LocationInLoadedSource(loadedSource, this.coordinates);
+            return new LocationInLoadedSource(loadedSource, this.position);
         } else {
             throw new Error(`Can't resolve a location with a source (${this}) to a location with a loaded source that doesn't match the unresolved source: ${loadedSource}`);
         }
@@ -101,13 +101,13 @@ export class LocationInScript extends LocationCommonLogic<IScript> {
             logger.verbose(`SourceMap: ${this} to ${result}`);
             return result;
         } else {
-            return new LocationInLoadedSource(this.script.developmentSource, this.coordinates);
+            return new LocationInLoadedSource(this.script.developmentSource, this.position);
         }
     }
 
     public mappedToUrl(): LocationInUrl {
         if (this.script.runtimeSource.doesScriptHasUrl()) {
-            return new LocationInUrl(this.script.runtimeSource.identifier, this.coordinates);
+            return new LocationInUrl(this.script.runtimeSource.identifier, this.position);
         } else {
             throw new Error(`Can't convert a location in a script without an URL (${this}) into a location in an URL`);
         }
@@ -115,11 +115,11 @@ export class LocationInScript extends LocationCommonLogic<IScript> {
 
     public isSameAs(locationInScript: LocationInScript): boolean {
         return this.script === locationInScript.script &&
-            this.coordinates.isSameAs(locationInScript.coordinates);
+            this.position.isSameAs(locationInScript.position);
     }
 
     public toString(): string {
-        return `${this.resource}:${this.coordinates}`;
+        return `${this.resource}:${this.position}`;
     }
 }
 
@@ -139,7 +139,7 @@ export class LocationInLoadedSource extends LocationCommonLogic<ILoadedSource> {
             logger.verbose(`SourceMap: ${this} to ${result}`);
             return result;
         } else {
-            throw new Error(`Couldn't map the location (${this.coordinates}) in the source $(${this.source}) to a script file`);
+            throw new Error(`Couldn't map the location (${this.position}) in the source $(${this.source}) to a script file`);
         }
     }
 }

--- a/src/chrome/internal/locations/location.ts
+++ b/src/chrome/internal/locations/location.ts
@@ -32,8 +32,6 @@ export class Position {
 }
 
 interface ILocation<T extends ScriptOrSourceOrURLOrURLRegexp> {
-    readonly lineNumber: integer;
-    readonly columnNumber?: integer;
     readonly position: Position;
     readonly resource: T;
 }

--- a/src/chrome/internal/locations/rangeInScript.ts
+++ b/src/chrome/internal/locations/rangeInScript.ts
@@ -1,0 +1,23 @@
+import { Position, LocationInScript } from './location';
+import { IScript } from '../scripts/script';
+
+/** Used by CDTP getPossibleBreakpoints API to inquire the valid set of positions for a breakpoint in a particular range of the script */
+export class RangeInScript {
+    constructor(
+        public readonly script: IScript,
+        public readonly start: Position,
+        public readonly end: Position) {
+        if (start.lineNumber > end.lineNumber
+            || (start.lineNumber === end.lineNumber && start.columnNumber > end.columnNumber)) {
+            throw new Error(`Can't create a range in a script ${script.runtimeSource} where the end position (${end}) happens before the start position ${start}`);
+        }
+    }
+
+    public get startInScript(): LocationInScript {
+        return new LocationInScript(this.script, this.start);
+    }
+
+    public get endInScript(): LocationInScript {
+        return new LocationInScript(this.script, this.end);
+    }
+}

--- a/src/chrome/internal/locations/subtypes.ts
+++ b/src/chrome/internal/locations/subtypes.ts
@@ -3,5 +3,20 @@
 const lineIndexSymbol = Symbol();
 export type LineNumber = number & { [lineIndexSymbol]: true };
 
+export function createLineNumber(numberRepresentation: number): LineNumber {
+    return <LineNumber>numberRepresentation;
+}
+
 const columnIndexSymbol = Symbol();
 export type ColumnNumber = number & { [columnIndexSymbol]: true };
+
+export function createColumnNumber(numberRepresentation: number): ColumnNumber {
+    return <ColumnNumber>numberRepresentation;
+}
+
+const URLRegexpSymbol = Symbol();
+export type URLRegexp = string & { [URLRegexpSymbol]: true };
+
+export function createURLRegexp(textRepresentation: string): URLRegexp {
+    return <URLRegexp>textRepresentation;
+}

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,0 +1,14 @@
+export function zeroOrPositive(name: string, value: number) {
+    if (value < 0) {
+        breakWhileDebugging();
+        throw new Error(`Expected ${name} to be either zero or a positive number and instead it was ${value}`);
+    }
+}
+
+/** Used for debugging while developing to automatically break when something unexpected happened */
+export function breakWhileDebugging() {
+    if (process.env.BREAK_WHILE_DEBUGGING === 'true') {
+        // tslint:disable-next-line:no-debugger
+        debugger;
+    }
+}


### PR DESCRIPTION
New location model for V2.
We use the location model to represent the location in a file/resources, e.g.: a breakpoint in myFile.js:34. We also use it to map those locations to other files using source maps eg.: myFile.js:34 --> myWidget.ts:26
We primarily use this location model to store and map information about breakpoints and stack traces between JavaScript and TypeScript.