### PR TITLE
Update script model to support the multiplicities that can happen in production

### DIFF
--- a/src/chrome/collections/bidirectionalMap.ts
+++ b/src/chrome/collections/bidirectionalMap.ts
@@ -5,6 +5,7 @@
 import * as assert from 'assert';
 import { ValidatedMap } from './validatedMap';
 import { printMap } from './printing';
+import { breakWhileDebugging } from '../../validation';
 
 /** A map where we can efficiently get the key from the value or the value from the key */
 export class BidirectionalMap<Left, Right> {
@@ -74,10 +75,12 @@ export class BidirectionalMap<Left, Right> {
         const existingLeftForRight = this._rightToLeft.tryGetting(right);
 
         if (existingRightForLeft !== undefined) {
+            breakWhileDebugging();
             throw new Error(`Can't set the pair left (${left}) and right (${right}) because there is already a right element (${existingRightForLeft}) associated with the left element`);
         }
 
         if (existingLeftForRight !== undefined) {
+            breakWhileDebugging();
             throw new Error(`Can't set the pair left (${left}) and right (${right}) because there is already a left element (${existingLeftForRight}) associated with the right element`);
         }
 

--- a/src/chrome/collections/validatedSet.ts
+++ b/src/chrome/collections/validatedSet.ts
@@ -1,0 +1,81 @@
+import { printSet } from './printing';
+import { breakWhileDebugging } from '../../validation';
+
+export interface IValidatedSet<K> extends Set<K> {
+    addOrReplaceIfExists(key: K): this;
+}
+
+/** A set that throws exceptions instead of returning error codes. */
+export class ValidatedSet<K> implements IValidatedSet<K> {
+    private readonly _wrappedSet: Set<K>;
+
+    public constructor();
+    public constructor(iterable: Iterable<K>);
+    public constructor(values?: ReadonlyArray<K>);
+    public constructor(valuesOrIterable?: ReadonlyArray<K> | undefined | Iterable<K>) {
+        this._wrappedSet = new Set(valuesOrIterable);
+    }
+
+    public get size(): number {
+        return this._wrappedSet.size;
+    }
+
+    public get [Symbol.toStringTag](): 'Set' {
+        return 'ValidatedSet' as 'Set';
+    }
+
+    public clear(): void {
+        this._wrappedSet.clear();
+    }
+
+    public delete(key: K): boolean {
+        if (!this._wrappedSet.delete(key)) {
+            breakWhileDebugging();
+            throw new Error(`Couldn't delete element with key ${key} because it wasn't present in the set`);
+        }
+
+        return true;
+    }
+
+    public forEach(callbackfn: (key: K, sameKeyAgain: K, set: Set<K>) => void, thisArg?: any): void {
+        this._wrappedSet.forEach(callbackfn, thisArg);
+    }
+
+    public has(key: K): boolean {
+        return this._wrappedSet.has(key);
+    }
+
+    public add(key: K): this {
+        if (this.has(key)) {
+            breakWhileDebugging();
+            throw new Error(`Cannot add key ${key} because it already exists`);
+        }
+
+        return this.addOrReplaceIfExists(key);
+    }
+
+    public addOrReplaceIfExists(key: K): this {
+        this._wrappedSet.add(key);
+        return this;
+    }
+
+    [Symbol.iterator](): IterableIterator<K> {
+        return this._wrappedSet[Symbol.iterator]();
+    }
+
+    public entries(): IterableIterator<[K, K]> {
+        return this._wrappedSet.entries();
+    }
+
+    public keys(): IterableIterator<K> {
+        return this._wrappedSet.keys();
+    }
+
+    public values(): IterableIterator<K> {
+        return this._wrappedSet.values();
+    }
+
+    public toString(): string {
+        return printSet('ValidatedSet', this);
+    }
+}

--- a/src/chrome/dependencyInjection.ts/types.ts
+++ b/src/chrome/dependencyInjection.ts/types.ts
@@ -1,9 +1,61 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
 import 'reflect-metadata';
 
 // TODO: Add all necesary types so we can use inversifyjs to create our components
-
 const TYPES = {
+    ISession: Symbol.for('ISession'),
+    communicator: Symbol.for('communicator'),
+    CDTPClient: Symbol.for('chromeConnection.api'),
+    IDOMInstrumentationBreakpoints: Symbol.for('IDOMInstrumentationBreakpoints'),
+    IEventsToClientReporter: Symbol.for('IEventsToClientReporter'),
+    IDebugeeExecutionControl: Symbol.for('IDebugeeExecutionControl'),
+    IPauseOnExceptions: Symbol.for('IPauseOnExceptions'),
+    IBreakpointFeaturesSupport: Symbol.for('IBreakpointFeaturesSupport'),
+    IAsyncDebuggingConfiguration: Symbol.for('IAsyncDebuggingConfiguration'),
+    IStackTracePresentationLogicProvider: Symbol.for('IStackTracePresentationLogicProvider'),
+    IScriptSources: Symbol.for('IScriptSources'),
     EventsConsumedByConnectedCDA: Symbol.for('EventsConsumedByConnectedCDA'),
+    ICDTPDebuggerEventsProvider: Symbol.for('ICDTPDebuggerEventsProvider'),
+    IDebugeeSteppingController: Symbol.for('IDebugeeSteppingController'),
+    IDebuggeeLauncher: Symbol.for('IDebuggeeLauncher'),
+    ChromeDebugLogic: Symbol.for('ChromeDebugLogic'),
+    SourcesLogic: Symbol.for('SourcesLogic'),
+    CDTPScriptsRegistry: Symbol.for('CDTPScriptsRegistry'),
+    ClientToInternal: Symbol.for('ClientToInternal'),
+    InternalToClient: Symbol.for('InternalToClient'),
+    StackTracesLogic: Symbol.for('StackTracesLogic'),
+    BreakpointsLogic: Symbol.for('BreakpointsLogic'),
+    PauseOnExceptionOrRejection: Symbol.for('PauseOnExceptionOrRejection'),
+    Stepping: Symbol.for('Stepping'),
+    DotScriptCommand: Symbol.for('DotScriptCommand'),
+    DeleteMeScriptsRegistry: Symbol.for('DeleteMeScriptsRegistry'),
+    BaseSourceMapTransformer: Symbol.for('BaseSourceMapTransformer'),
+    BasePathTransformer: Symbol.for('BasePathTransformer'),
+    SyncStepping: Symbol.for('SyncStepping'),
+    AsyncStepping: Symbol.for('AsyncStepping'),
+    ConnectedCDAConfiguration: Symbol.for('ConnectedCDAConfiguration'),
+    ExceptionThrownEventProvider: Symbol.for('ExceptionThrownEventProvider'),
+    ExecutionContextEventsProvider: Symbol.for('ExecutionContextEventsProvider'),
+    IInspectDebugeeState: Symbol.for('IInspectDebugeeState'),
+    IUpdateDebugeeState: Symbol.for('IUpdateDebugeeState'),
+    LineColTransformer: Symbol.for('LineColTransformer'),
+    ChromeConnection: Symbol.for('ChromeConnection'),
+    IDebugeeVersionProvider: Symbol.for('IDebugeeVersionProvider'),
+    IBrowserNavigation: Symbol.for('IBrowserNavigation'),
+    IPausedOverlay: Symbol.for('IPausedOverlay'),
+    INetworkCacheConfiguration: Symbol.for('INetworkCacheConfiguration'),
+    ISupportedDomains: Symbol.for('ISupportedDomains'),
+    IDebugeeRunner: Symbol.for('IDebugeeRunner'),
+    ICDTPRuntime: Symbol.for('ICDTPRuntime'),
+    IScriptParsedProvider: Symbol.for('IScriptParsedProvider'),
+    ITargetBreakpoints: Symbol.for('ITargetBreakpoints'),
+    IConsoleEventsProvider: Symbol.for('IConsoleEventsProvider'),
+    ILogEventsProvider: Symbol.for('ILogEventsProvider'),
+    IBlackboxPatternsConfigurer: Symbol.for('IBlackboxPatternsConfigurer'),
+    IDomainsEnabler: Symbol.for('IDomainsEnabler'),
 };
 
 export { TYPES };

--- a/src/chrome/internal/breakpoints/bpRecipeStatusForRuntimeLocation.ts
+++ b/src/chrome/internal/breakpoints/bpRecipeStatusForRuntimeLocation.ts
@@ -1,0 +1,50 @@
+import { BPRecipeInSource } from './bpRecipeInSource';
+import { BreakpointInSource } from './breakpoint';
+import { LocationInLoadedSource } from '../locations/location';
+
+const ImplementsBPRecipeSingleLocationStatus = Symbol();
+export interface IBPRecipeSingleLocationStatus {
+    [ImplementsBPRecipeSingleLocationStatus]: string;
+
+    isVerified(): boolean;
+}
+
+export class BPRecipeIsUnboundInRuntimeLocation implements IBPRecipeSingleLocationStatus {
+    [ImplementsBPRecipeSingleLocationStatus] = 'IBPRecipeSingleLocationStatus';
+
+    public isVerified(): boolean {
+        return false;
+    }
+
+    public toString(): string {
+        // `The JavaScript code associated with this source file hasn't been loaded into the debuggee yet`
+        return `${this.recipe} at ${this.locationInRuntimeSource} is unbound because ${this.error}`;
+    }
+
+    constructor(
+        public readonly recipe: BPRecipeInSource,
+        public readonly locationInRuntimeSource: LocationInLoadedSource,
+        public readonly error: Error) {
+    }
+}
+
+export class BPRecipeIsBoundInRuntimeLocation implements IBPRecipeSingleLocationStatus {
+    [ImplementsBPRecipeSingleLocationStatus] = 'IBPRecipeSingleLocationStatus';
+
+    public isVerified(): boolean {
+        return true;
+    }
+
+    public toString(): string {
+        return `${this.recipe} is bound at ${this.locationInRuntimeSource} with ${this.breakpoints.join(', ')}`;
+    }
+
+    constructor(
+        public readonly recipe: BPRecipeInSource,
+        public readonly locationInRuntimeSource: LocationInLoadedSource,
+        public readonly breakpoints: BreakpointInSource[]) {
+        if (this.breakpoints.length === 0) {
+            throw new Error(`At least a single breakpoint was expected`);
+        }
+    }
+}

--- a/src/chrome/internal/breakpoints/bpRecipes.ts
+++ b/src/chrome/internal/breakpoints/bpRecipes.ts
@@ -22,7 +22,7 @@ export class BaseBPRecipes<TResource extends ILoadedSource | ISource> {
     }
 
     public toString(): string {
-        return printArray(`BPs @ ${this.source}`, this.breakpoints);
+        return printArray(`BPs @ ${this.source}`, this.breakpoints.map(bp => `line ${bp.location.position} do: ${bp.bpActionWhenHit}`));
     }
 }
 

--- a/src/chrome/internal/breakpoints/breakpoint.ts
+++ b/src/chrome/internal/breakpoints/breakpoint.ts
@@ -5,10 +5,10 @@
 import { LocationInScript, LocationInLoadedSource } from '../locations/location';
 import { IScript } from '../scripts/script';
 import { URLRegexp } from '../locations/subtypes';
-import { IResourceIdentifier } from '../sources/resourceIdentifier';
+import { IResourceIdentifier, IURL } from '../sources/resourceIdentifier';
 import { CDTPScriptUrl } from '../sources/resourceIdentifierSubtypes';
 import { ISource } from '../sources/source';
-import { IMappedBPRecipe } from './baseMappedBPRecipe';
+import { IBPRecipeForRuntimeSource } from './baseMappedBPRecipe';
 import { BPRecipeInSource } from './bpRecipeInSource';
 import { IBPRecipe, BPInScriptSupportedHitActions } from './bpRecipe';
 
@@ -41,10 +41,14 @@ export class MappableBreakpoint<TResource extends MappableBPPossibleResources> e
         return new BreakpointInSource(this.recipe.unmappedBPRecipe, this.actualLocation.mappedToSource());
     }
 
-    constructor(public readonly recipe: IMappedBPRecipe<TResource, BPInScriptSupportedHitActions>, public readonly actualLocation: ActualLocation<TResource>) {
+    constructor(public readonly recipe: IBPRecipeForRuntimeSource<TResource, BPInScriptSupportedHitActions>, public readonly actualLocation: ActualLocation<TResource>) {
         super();
     }
 }
+
+export class BreakpointInScript extends MappableBreakpoint<IScript> { }
+
+export class BreakpointInUrl extends MappableBreakpoint<IURL<CDTPScriptUrl>> { }
 
 export class BreakpointInSource extends BaseBreakpoint<ISource> {
     constructor(public readonly recipe: BPRecipeInSource, public readonly actualLocation: ActualLocation<ISource>) {

--- a/src/chrome/internal/features/feature.ts
+++ b/src/chrome/internal/features/feature.ts
@@ -1,3 +1,33 @@
-export interface IComponent {
-    // TODO: Implement this
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+// TODO: Remove the next line and use the import instead
+export interface ConnectedCDAConfiguration {}
+// import { ConnectedCDAConfiguration } from '../../client/chromeDebugAdapter/cdaConfiguration';
+
+import { PromiseOrNot } from '../../utils/promises';
+
+export interface IConfigurableFeature<Configuration> {
+    install(configuration: Configuration): PromiseOrNot<void | this>;
+}
+
+export interface IConfigurationlessFeature {
+    install(): PromiseOrNot<void | this>;
+}
+
+export type ComponentConfiguration = ConnectedCDAConfiguration;
+
+export type IComponent<Configuration = ComponentConfiguration> =
+    Configuration extends void
+    ? IConfigurationlessFeature
+    : IConfigurableFeature<Configuration>;
+
+export interface ICommandHandlerDeclaration {
+    readonly commandName: string;
+    readonly commandHandler: (args: any) => PromiseOrNot<void>;
+}
+
+export interface ICommandHandlerDeclarer {
+    getCommandHandlerDeclarations(): PromiseOrNot<ICommandHandlerDeclaration>;
 }

--- a/src/chrome/internal/locations/rangeInScript.ts
+++ b/src/chrome/internal/locations/rangeInScript.ts
@@ -2,26 +2,28 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { Position, LocationInScript } from './location';
+import { Position, Location, ScriptOrSourceOrURLOrURLRegexp, createLocation } from './location';
 import { IScript } from '../scripts/script';
 
 /** Used by CDTP getPossibleBreakpoints API to inquire the valid set of positions for a breakpoint in a particular range of the script */
-export class RangeInScript {
+export class RangeInResource<TResource extends ScriptOrSourceOrURLOrURLRegexp> {
     constructor(
-        public readonly script: IScript,
-        public readonly start: Position,
-        public readonly end: Position) {
-        if (start.lineNumber > end.lineNumber
-            || (start.lineNumber === end.lineNumber && start.columnNumber > end.columnNumber)) {
-            throw new Error(`Can't create a range in a script ${script.runtimeSource} where the end position (${end}) happens before the start position ${start}`);
+        public readonly resource: TResource,
+        private readonly _start: Position,
+        private readonly _end: Position) {
+        if (_start.lineNumber > _end.lineNumber
+            || (_start.lineNumber === _end.lineNumber && _start.columnNumber > _end.columnNumber)) {
+            throw new Error(`Can't create a range in a resource ${resource} where the end position (${_end}) happens before the start position ${_start}`);
         }
     }
 
-    public get startInScript(): LocationInScript {
-        return new LocationInScript(this.script, this.start);
+    public get start(): Location<TResource> {
+        return createLocation(this.resource, this._start);
     }
 
-    public get endInScript(): LocationInScript {
-        return new LocationInScript(this.script, this.end);
+    public get end(): Location<TResource> {
+        return createLocation(this.resource, this._end);
     }
 }
+
+export type RangeInScript = RangeInResource<IScript>;

--- a/src/chrome/internal/scripts/executionContext.ts
+++ b/src/chrome/internal/scripts/executionContext.ts
@@ -1,3 +1,7 @@
+// TODO: Remove next line and use the import instead
+type FrameId = number;
+// import { FrameId } from '../../cdtpDebuggee/cdtpPrimitives';
+
 /*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
@@ -7,11 +11,14 @@
  * We keep track of this because only scripts of non destroyed execution contexts should be displayed to the user
  */
 export interface IExecutionContext {
+    readonly frameId: FrameId;
     isDestroyed(): boolean;
 }
 
 export class ExecutionContext implements IExecutionContext {
     private _isDestroyed = false;
+
+    public constructor(public readonly frameId: FrameId) {}
 
     public isDestroyed(): boolean {
         return this._isDestroyed;

--- a/src/chrome/internal/scripts/sourcesMapper.ts
+++ b/src/chrome/internal/scripts/sourcesMapper.ts
@@ -2,61 +2,133 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { LineNumber, ColumnNumber, createColumnNumber, createLineNumber } from '../locations/subtypes';
-import { SourceMap } from '../../../sourceMaps/sourceMap';
+import { createColumnNumber, createLineNumber } from '../locations/subtypes';
+import { SourceMap, SourceRange } from '../../../sourceMaps/sourceMap';
+import { LocationInLoadedSource, LocationInScript, Position } from '../locations/location';
+import { ILoadedSource } from '../sources/loadedSource';
+import { IResourceIdentifier, parseResourceIdentifier } from '../sources/resourceIdentifier';
+import { IScript } from './script';
 
-export interface ISourcesMapper {
+export interface ISourceToScriptMapper {
+    getPositionInScript(positionInSource: LocationInLoadedSource): LocationInScript | null;
+}
+
+export interface IScriptToSourceMapper {
+    getPositionInSource(positionInScript: LocationInScript): LocationInLoadedSource | null;
+}
+
+export interface ISourceMapper extends ISourceToScriptMapper, IScriptToSourceMapper { }
+
+export interface IMappedSourcesMapper extends ISourceMapper {
     readonly sources: string[];
-    getPositionInSource(positionInScript: IPositionInScript): IPositionInSource | null;
-    getPositionInScript(positionInSource: IPositionInSource): IPositionInScript | null;
-}
-
-interface IPositionInSource {
-    readonly source: string;
-    readonly line: LineNumber;
-    readonly column?: ColumnNumber;
-}
-
-interface IPositionInScript {
-    readonly line: LineNumber;
-    readonly column?: ColumnNumber;
 }
 
 /** This class maps locations from a script into the sources form which it was compiled, and back. */
-export class SourcesMapper implements ISourcesMapper {
-    public getPositionInSource(positionInScript: IPositionInScript): IPositionInSource | null {
-        const mappedPosition = this._sourceMap.authoredPositionFor(positionInScript.line, positionInScript.column || 0);
-        return mappedPosition && mappedPosition.source && mappedPosition.line
-            ? { source: mappedPosition.source, line: createLineNumber(mappedPosition.line), column: createColumnNumber(mappedPosition.column) }
-            : null;
+export class MappedSourcesMapper implements IMappedSourcesMapper {
+    private readonly _rangeInSources: Map<IResourceIdentifier, SourceRange>;
+
+    public getPositionInSource(positionInScript: LocationInScript): LocationInLoadedSource | null {
+        const scriptPositionInResource = this._script.rangeInSource.start.position;
+
+        // All the lines need to be adjusted by the relative position of the script in the resource (in an .html if the script starts in line 20, the first line is 20 rather than 0)
+        const lineNumberRelativeToScript = positionInScript.position.lineNumber - scriptPositionInResource.lineNumber;
+
+        // The columns on the first line need to be adjusted. Columns on all other lines don't need any adjustment.
+        const columnNumberRelativeToScript = (lineNumberRelativeToScript === 0 ? scriptPositionInResource.columnNumber : 0) + (positionInScript.position.columnNumber || 0);
+
+        const mappedPosition = this._sourceMap.authoredPositionFor(lineNumberRelativeToScript, columnNumberRelativeToScript);
+
+        if (mappedPosition && mappedPosition.source && mappedPosition.line) {
+            const position = new Position(createLineNumber(mappedPosition.line), createColumnNumber(mappedPosition.column));
+            return new LocationInLoadedSource(positionInScript.script.getSource(parseResourceIdentifier(mappedPosition.source)), position);
+        } else {
+            // If we couldn't map it, return the location in the development source
+            return new LocationInLoadedSource(positionInScript.script.developmentSource, positionInScript.position);
+        }
     }
 
-    public getPositionInScript(positionInSource: IPositionInSource): IPositionInScript | null {
-        const mappedPosition = this._sourceMap.generatedPositionFor(positionInSource.source,
-            positionInSource.line, positionInSource.column || 0);
-        return mappedPosition && mappedPosition.line
-            ? { line: createLineNumber(mappedPosition.line), column: createColumnNumber(mappedPosition.column) }
-            : null;
+    public getPositionInScript(positionInSource: LocationInLoadedSource): LocationInScript | null {
+        const range = this._rangeInSources.get(positionInSource.source.identifier);
+        if (!Position.isBetween(range.start, positionInSource.position, range.end)) {
+            // The range of this script in the source doesn't has the position, so there won't be any mapping
+            return null;
+        }
+
+        const mappedPositionRelativeToScript = this._sourceMap.generatedPositionFor(positionInSource.source.identifier.textRepresentation,
+            positionInSource.position.lineNumber, positionInSource.position.columnNumber || 0);
+        const positionInSourceForMapping = this._sourceMap.authoredPositionFor(mappedPositionRelativeToScript.line, mappedPositionRelativeToScript.column);
+        if (positionInSourceForMapping.line !== positionInSource.position.lineNumber) {
+
+        }
+
+        if (mappedPositionRelativeToScript && typeof mappedPositionRelativeToScript.line === 'number') {
+
+            const scriptPositionInResource = this._script.rangeInSource.start.position;
+
+            // All the lines need to be adjusted by the relative position of the script in the resource (in an .html if the script starts in line 20, the first line is 20 rather than 0)
+            const lineNumberRelativeToEntireResource = createLineNumber(mappedPositionRelativeToScript.line + scriptPositionInResource.lineNumber);
+
+            // The columns on the first line need to be adjusted. Columns on all other lines don't need any adjustment.
+            const columnNumberRelativeToEntireResource = createColumnNumber((mappedPositionRelativeToScript.line === 0 ? scriptPositionInResource.columnNumber : 0) + mappedPositionRelativeToScript.column);
+
+            const position = new Position(createLineNumber(lineNumberRelativeToEntireResource), createColumnNumber(columnNumberRelativeToEntireResource));
+            return new LocationInScript(this._script, position);
+        } else {
+            return null;
+        }
     }
 
     public get sources(): string[] {
         return this._sourceMap.authoredSources || [];
     }
 
-    constructor(private readonly _sourceMap: SourceMap) { }
+    constructor(private readonly _script: IScript, private readonly _sourceMap: SourceMap) {
+        this._rangeInSources = this._sourceMap.rangesInSources();
+    }
 
+    public toString(): string {
+        return `Mapped sources mapper of ${this._script} into ${this._script.mappedSources}`;
+    }
 }
 
-export class NoSourceMapping implements ISourcesMapper {
-    public getPositionInSource(_: IPositionInScript): null {
-        return null;
+export class NoMappedSourcesMapper implements IMappedSourcesMapper {
+    constructor(private readonly _script: IScript) {
+
     }
 
-    public getPositionInScript(_: IPositionInSource): null {
-        return null;
+    public getPositionInSource(positionInScript: LocationInScript): LocationInLoadedSource {
+        return new LocationInLoadedSource(this._script.developmentSource, positionInScript.position);
     }
 
-    public get sources(): [] {
+    public getPositionInScript(positionInSource: LocationInLoadedSource): LocationInScript {
+        if (positionInSource.resource === this._script.developmentSource || positionInSource.resource === this._script.runtimeSource) {
+            return new LocationInScript(this._script, positionInSource.position);
+        } else {
+            throw new Error(`This source mapper can only map locations from the runtime or development scripts of ${this._script} yet the location provided was ${positionInSource}`);
+        }
+    }
+
+    public get sources(): string[] {
         return [];
+    }
+
+    public toString(): string {
+        return `No sources mapper of ${this._script}`;
+    }
+}
+
+export class UnmappedSourceMapper implements ISourceMapper {
+    public getPositionInSource(positionInScript: LocationInScript): LocationInLoadedSource {
+        return new LocationInLoadedSource(this._source, positionInScript.position);
+    }
+
+    public getPositionInScript(positionInSource: LocationInLoadedSource): LocationInScript {
+        return new LocationInScript(this._script, positionInSource.position);
+    }
+
+    constructor(private readonly _script: IScript, private readonly _source: ILoadedSource) { }
+
+    public toString(): string {
+        return `Unmapped sources mapper of ${this._script}`;
     }
 }

--- a/src/chrome/internal/sources/identifiedLoadedSource.ts
+++ b/src/chrome/internal/sources/identifiedLoadedSource.ts
@@ -1,0 +1,78 @@
+import * as fs from 'fs';
+import { IScript } from '../scripts/script';
+import { IResourceIdentifier } from './resourceIdentifier';
+import { ILoadedSource, IScriptMapper, ICurrentScriptRelationshipsProvider as IScriptMapperProvider, ContentsLocation, SourceScriptRelationship, ImplementsLoadedSource, ScriptAndSourceMapper } from './loadedSource';
+import { ILoadedSourceToScriptRelationship } from './loadedSourceToScriptRelationship';
+import _ = require('lodash');
+import { printArray } from '../../collections/printing';
+import { LocationInScript, LocationInLoadedSource } from '../locations/location';
+
+/**
+ * Loaded Source classification:
+ * Is the script content available on a single place, or two places? (e.g.: You can find similar scripts in multiple different paths)
+ *  1. Single: Is the single place on storage, or is this a dynamic script?
+ *      Single path on storage: RuntimeScriptRunFromStorage
+ *      Single path not on storage: DynamicRuntimeScript
+ *  2. Two: We assume one path is from the webserver, and the other path is in the workspace: RuntimeScriptWithSourceOnWorkspace
+ */
+export class IdentifiedLoadedSource<TString extends string = string> implements ILoadedSource<TString> {
+    public [ImplementsLoadedSource]: 'ILoadedSource' = 'ILoadedSource';
+
+    private constructor(
+        public readonly identifier: IResourceIdentifier<TString>,
+        public readonly sourceScriptRelationship: SourceScriptRelationship,
+        private readonly _scriptMapperProvider: IScriptMapperProvider,
+        public readonly contentsLocation: ContentsLocation) { }
+
+    public get url(): TString {
+        return this.identifier.textRepresentation;
+    }
+
+    public scriptMapper(): IScriptMapper {
+        return this._scriptMapperProvider.scriptMapper(this);
+    }
+
+    public isMappedSource(): boolean {
+        return false;
+    }
+
+    public doesScriptHasUrl(): boolean {
+        return true;
+    }
+
+    public isEquivalentTo(source: ILoadedSource<TString>): boolean {
+        return this === source;
+    }
+
+    public toString(): string {
+        return `src:${this.identifier}`;
+    }
+
+    public static create<TString extends string>(identifier: IResourceIdentifier<TString>, sourceScriptRelationship: SourceScriptRelationship,
+        currentScriptRelationshipsProvider: IScriptMapperProvider): IdentifiedLoadedSource<TString> {
+
+        const contentsLocation = fs.existsSync(identifier.textRepresentation) ? ContentsLocation.PersistentStorage : ContentsLocation.DynamicMemory;
+        return new IdentifiedLoadedSource<TString>(identifier, sourceScriptRelationship, currentScriptRelationshipsProvider, contentsLocation);
+    }
+}
+
+export class ScriptMapper implements IScriptMapper {
+    public mapToScripts(locationToMap: LocationInLoadedSource): LocationInScript[] {
+        return this.relationships.map(relationship => relationship.scriptAndSourceMapper.sourcesMapper.getPositionInScript(locationToMap))
+            .filter(location => location !== null);
+    }
+
+    constructor(public readonly relationships: ILoadedSourceToScriptRelationship[]) { }
+
+    public get scripts(): IScript[] {
+        return _.uniq(_.flatten(this.relationships.map(relationship => relationship.script)));
+    }
+
+    public get scriptsAndSourceMappers(): ScriptAndSourceMapper[] {
+        return _.flatten(this.relationships.map(relationship => relationship.scriptAndSourceMapper));
+    }
+
+    public toString(): string {
+        return printArray('relationships', this.relationships);
+    }
+}

--- a/src/chrome/internal/sources/loadedSource.ts
+++ b/src/chrome/internal/sources/loadedSource.ts
@@ -3,21 +3,31 @@
  *--------------------------------------------------------*/
 
 import { IScript } from '../scripts/script';
-import { CDTPScriptUrl } from './resourceIdentifierSubtypes';
-import { IResourceIdentifier, parseResourceIdentifier, ResourceName } from './resourceIdentifier';
+import { IResourceIdentifier } from './resourceIdentifier';
 import { determineOrderingOfStrings } from '../../collections/utilities';
 import { IEquivalenceComparable } from '../../utils/equivalence';
+import { IdentifiedLoadedSource } from './identifiedLoadedSource';
+import { ISourceMapper } from '../scripts/sourcesMapper';
+import { LocationInScript, LocationInLoadedSource } from '../locations/location';
 
 /**
  * This interface represents a source or text that is related to a script that the debuggee is executing. The text can be the contents of the script itself,
  *  or a file from which the script was loaded, or a file that was compiled to generate the contents of the script
  */
+export const ImplementsLoadedSource = Symbol();
 export interface ILoadedSource<TString = string> extends IEquivalenceComparable {
-    readonly script: IScript;
+    [ImplementsLoadedSource]: 'ILoadedSource';
+
     readonly identifier: IResourceIdentifier<TString>;
-    readonly origin: string;
+    readonly url: TString;
+    readonly sourceScriptRelationship: SourceScriptRelationship;
+    readonly contentsLocation: ContentsLocation;
+
+    // readonly origin: string;
     doesScriptHasUrl(): boolean; // TODO DIEGO: Figure out if we can delete this property
     isMappedSource(): boolean;
+
+    scriptMapper(): IScriptMapper;
 }
 
 /**
@@ -28,72 +38,34 @@ export interface ILoadedSource<TString = string> extends IEquivalenceComparable 
  *      Single path not on storage: DynamicRuntimeScript
  *  2. Two: We assume one path is from the webserver, and the other path is in the workspace: RuntimeScriptWithSourceOnWorkspace
  */
-
-abstract class LoadedSourceWithURLCommonLogic<TSource = string> implements ILoadedSource<TSource> {
-    public isMappedSource(): boolean {
-        return false;
-    }
-
-    public doesScriptHasUrl(): boolean {
-        return true;
-    }
-
-    public isEquivalentTo(source: ILoadedSource<TSource>): boolean {
-        return this === source;
-    }
-
-    public toString(): string {
-        return `src:${this.identifier}`;
-    }
-
-    constructor(
-        public readonly script: IScript,
-        public readonly identifier: IResourceIdentifier<TSource>,
-        public readonly origin: string) { }
+export interface ICurrentScriptRelationshipsProvider {
+    scriptMapper(loadedSource: IdentifiedLoadedSource): IScriptMapper;
 }
 
-export class ScriptRunFromLocalStorage extends LoadedSourceWithURLCommonLogic<CDTPScriptUrl> implements ILoadedSource<CDTPScriptUrl> { }
-export class DynamicScript extends LoadedSourceWithURLCommonLogic<CDTPScriptUrl> implements ILoadedSource<CDTPScriptUrl> { }
-export class ScriptRuntimeSource extends LoadedSourceWithURLCommonLogic<CDTPScriptUrl> implements ILoadedSource<CDTPScriptUrl> { }
-export class ScriptDevelopmentSource extends LoadedSourceWithURLCommonLogic implements ILoadedSource { }
-
-export class NoURLScriptSource implements ILoadedSource<CDTPScriptUrl> {
-    public get identifier(): IResourceIdentifier<CDTPScriptUrl> {
-        return parseResourceIdentifier<CDTPScriptUrl>(`${NoURLScriptSource.EVAL_PSEUDO_PREFIX}${this.name.textRepresentation}` as any);
-    }
-
-    // TODO DIEGO: Move these two properties to the client layer
-    public static EVAL_FILENAME_PREFIX = 'VM';
-    public static EVAL_PSEUDO_FOLDER = '<eval>';
-    public static EVAL_PSEUDO_PREFIX = `${NoURLScriptSource.EVAL_PSEUDO_FOLDER}\\${NoURLScriptSource.EVAL_FILENAME_PREFIX}`;
-
-    public isMappedSource(): boolean {
-        return false;
-    }
-
-    public doesScriptHasUrl(): boolean {
-        return false;
-    }
-
-    public isEquivalentTo(source: NoURLScriptSource): boolean {
-        return this === source;
-    }
-
-    public toString(): string {
-        return `No URL script source with id: ${this.name}`;
-    }
-
+export class ScriptAndSourceMapper {
     constructor(
         public readonly script: IScript,
-        public readonly name: ResourceName<CDTPScriptUrl>,
-        public readonly origin: string) { }
+        public readonly sourcesMapper: ISourceMapper) { }
 }
 
-// This represents a path to a development source that was compiled to generate the runtime code of the script
-export class MappedSource extends LoadedSourceWithURLCommonLogic implements ILoadedSource {
-    public isMappedSource(): boolean {
-        return true;
-    }
+export interface IScriptMapper {
+    readonly scripts: IScript[];
+    mapToScripts(position: LocationInLoadedSource): LocationInScript[];
+}
+
+export enum SourceScriptRelationship {
+    SourceIsSingleScript,
+    SourceIsMoreThanAScript,
+    Unknown
+}
+
+export function isLoadedSource(object: unknown): object is ILoadedSource {
+    return !!(<any>object)[ImplementsLoadedSource];
+}
+
+export enum ContentsLocation {
+    DynamicMemory,
+    PersistentStorage
 }
 
 export interface ILoadedSourceTreeNode {

--- a/src/chrome/internal/sources/loadedSourceToScriptRelationship.ts
+++ b/src/chrome/internal/sources/loadedSourceToScriptRelationship.ts
@@ -1,0 +1,58 @@
+import { IScript } from '../scripts/script';
+import { UnmappedSourceMapper } from '../scripts/sourcesMapper';
+import { ILoadedSource, ScriptAndSourceMapper } from './loadedSource';
+
+export interface ILoadedSourceToScriptRelationship {
+    readonly scriptAndSourceMapper: ScriptAndSourceMapper;
+    readonly script: IScript;
+}
+
+abstract class BaseLoadedSourceToScriptRelationship implements ILoadedSourceToScriptRelationship {
+    abstract get scriptAndSourceMapper(): ScriptAndSourceMapper;
+    abstract get script(): IScript;
+}
+
+/// Script was created from this source
+export class RuntimeSourceOf extends BaseLoadedSourceToScriptRelationship {
+    constructor(public readonly runtimeSource: ILoadedSource, public readonly script: IScript) {
+        super();
+    }
+
+    public get scriptAndSourceMapper(): ScriptAndSourceMapper {
+        return new ScriptAndSourceMapper(this.script, new UnmappedSourceMapper(this.script, this.runtimeSource));
+    }
+
+    public toString(): string {
+        return `${this.runtimeSource} is runtime source of ${this.script}`;
+    }
+}
+
+/// The runtime source was generated from this source in the user's workspace
+export class DevelopmentSourceOf extends BaseLoadedSourceToScriptRelationship {
+    constructor(public readonly developmentSource: ILoadedSource, public readonly runtimeSource: ILoadedSource, public readonly script: IScript) {
+        super();
+    }
+
+    public get scriptAndSourceMapper(): ScriptAndSourceMapper {
+        return new ScriptAndSourceMapper(this.script, new UnmappedSourceMapper(this.script, this.developmentSource));
+    }
+
+    public toString(): string {
+        return `${this.developmentSource} is development source of ${this.runtimeSource}`;
+    }
+}
+
+/// A sourcemap indicated that this mapped source was used to generate the DevelopmentSource
+export class MappedSourceOf extends BaseLoadedSourceToScriptRelationship {
+    constructor(public readonly mappedSource: ILoadedSource, public readonly script: IScript) {
+        super();
+    }
+
+    public get scriptAndSourceMapper(): ScriptAndSourceMapper {
+        return new ScriptAndSourceMapper(this.script, this.script.sourceMapper);
+    }
+
+    public toString(): string {
+        return `${this.mappedSource} is a mapped source of ${this.script.developmentSource}/${this.script}`;
+    }
+}

--- a/src/chrome/internal/sources/resourceIdentifier.ts
+++ b/src/chrome/internal/sources/resourceIdentifier.ts
@@ -3,10 +3,10 @@
  *--------------------------------------------------------*/
 
 import * as path from 'path';
-import { utils } from '../../..';
 import { IValidatedMap } from '../../collections/validatedMap';
 import { MapUsingProjection } from '../../collections/mapUsingProjection';
 import { IEquivalenceComparable } from '../../utils/equivalence';
+import * as utils from '../../../utils';
 
 /**
  * Hierarchy:
@@ -23,14 +23,23 @@ import { IEquivalenceComparable } from '../../utils/equivalence';
  */
 
 /** This interface represents a text to identify a particular resource. This class will properly compare urls and file paths, while preserving the original case that was used for the identifier */
+const ImplementsResourceIdentifier = Symbol();
 export interface IResourceIdentifier<TString = string> extends IEquivalenceComparable {
+    [ImplementsResourceIdentifier]: void;
+
     readonly textRepresentation: TString;
     readonly canonicalized: string;
     isEquivalentTo(right: IResourceIdentifier<TString>): boolean;
     isLocalFilePath(): boolean;
 }
 
+export function isResourceIdentifier(object: object): object is IResourceIdentifier<string> {
+    return object.hasOwnProperty(ImplementsResourceIdentifier);
+}
+
 abstract class IsEquivalentCommonLogic {
+    [ImplementsResourceIdentifier]: void;
+
     public abstract get canonicalized(): string;
 
     public isEquivalentTo(right: IResourceIdentifier): boolean {
@@ -95,13 +104,15 @@ export class LocalFileURL<TString extends string = string> extends IsEquivalentC
 
     constructor(fileUrl: TString) {
         super();
-        let filePath = decodeURIComponent(fileUrl.replace(`^file://`, ''));
+        let filePath = decodeURIComponent(fileUrl.replace(/^file:\/\/\//, ''));
         this._localResourcePath = parseLocalResourcePath(filePath);
     }
 }
 
 // Any URL that is not a 'file:///' url
 export class NonLocalFileURL<TString extends string = string> extends IsEquivalentAndConstructorCommonLogic<TString> implements IURL<TString> {
+    [ImplementsResourceIdentifier]: void;
+
     public toString(): string {
         return path.basename(this.textRepresentation);
     }
@@ -158,10 +169,6 @@ export class WindowLocalFilePath<TString extends string = string> extends LocalF
 
     public static isValid(path: string) {
         return path.match(/^[A-Za-z]:/);
-    }
-
-    public get canonicalized(): string {
-        return this.textRepresentation.toLowerCase().replace(/[\\\/]+/, '\\');
     }
 }
 

--- a/src/chrome/internal/sources/source.ts
+++ b/src/chrome/internal/sources/source.ts
@@ -11,12 +11,23 @@ import { IEquivalenceComparable } from '../../utils/equivalence';
  * VS Code debug protocol sends breakpoint requests with a path?: string; or sourceReference?: number; Before we can use the path, we need to wait for the related script to be loaded so we can match it with a script id.
  * This set of classes will let us represent the information we get from either a path or a sourceReference, and then let us try to resolve it to a script id when possible.
  */
+const ImplementsSource = Symbol();
 export interface ISource extends IEquivalenceComparable {
+    [ImplementsSource]: string;
+
     readonly sourceIdentifier: IResourceIdentifier;
     tryResolving<R>(succesfulAction: (resolvedSource: ILoadedSource) => R, failedAction: (sourceIdentifier: IResourceIdentifier) => R): R;
+
+    isEquivalentTo(right: ISource): boolean;
 }
 
-abstract class SourceCommonLogic implements ISource {
+export function isSource(object: unknown): object is ISource {
+    return !!(<any>object)[ImplementsSource];
+}
+
+abstract class BaseSource implements ISource {
+    [ImplementsSource]: 'ISource';
+
     public abstract tryResolving<R>(succesfulAction: (loadedSource: ILoadedSource) => R, failedAction: (identifier: IResourceIdentifier) => R): R;
     public abstract get sourceIdentifier(): IResourceIdentifier;
 
@@ -26,13 +37,13 @@ abstract class SourceCommonLogic implements ISource {
 }
 
 // Find the related source by using the source's path
-export class SourceToBeResolvedViaPath extends SourceCommonLogic implements ISource {
+export class SourceToBeResolvedViaPath extends BaseSource implements ISource {
     public tryResolving<R>(succesfulAction: (resolvedSource: ILoadedSource) => R, failedAction: (sourceIdentifier: IResourceIdentifier) => R) {
         return this._sourceResolver.tryResolving(this.sourceIdentifier, succesfulAction, failedAction);
     }
 
     public toString(): string {
-        return `Resolve source via #${this.sourceIdentifier}`;
+        return `${this.sourceIdentifier}`;
     }
 
     constructor(public readonly sourceIdentifier: IResourceIdentifier, private readonly _sourceResolver: SourceResolver) {
@@ -41,7 +52,7 @@ export class SourceToBeResolvedViaPath extends SourceCommonLogic implements ISou
 }
 
 // This source was already loaded, so we store it in this class
-export class SourceAlreadyResolvedToLoadedSource extends SourceCommonLogic implements ISource {
+export class SourceAlreadyResolvedToLoadedSource extends BaseSource implements ISource {
     public tryResolving<R>(succesfulAction: (resolvedSource: ILoadedSource) => R, _failedAction: (sourceIdentifier: IResourceIdentifier) => R) {
         return succesfulAction(this.loadedSource);
     }

--- a/src/chrome/internal/sources/sourceResolver.ts
+++ b/src/chrome/internal/sources/sourceResolver.ts
@@ -10,10 +10,11 @@ import { injectable, inject } from 'inversify';
 import { TYPES } from '../../dependencyInjection.ts/types';
 import { IScript } from '../scripts/script';
 
-// TODO: Delete this and use the proper interface
+// TODO: Remove next line and use the import instead
 interface IScriptParsedEvent {
-    script: IScript;
+    readonly script: IScript;
 }
+// import { IScriptParsedEvent } from '../../cdtpDebuggee/eventsProviders/cdtpOnScriptParsedEventProvider';
 
 export interface IEventsConsumedBySourceResolver {
     onScriptParsed(listener: (scriptEvent: IScriptParsedEvent) => Promise<void>): void;
@@ -50,7 +51,8 @@ export class SourceResolver implements IComponent {
     public install(): this {
         this._dependencies.onScriptParsed(async params => {
             params.script.allSources.forEach(source => {
-                this._pathToSource.set(source.identifier, source);
+                // The same file can be loaded as a script twice, and different scripts can share the same mapped source, so we ignore exact duplicates
+                this._pathToSource.setAndIgnoreDuplicates(source.identifier, source, (left, right) => left.isEquivalentTo(right));
             });
         });
 

--- a/src/chrome/internal/sources/unidentifiedLoadedSource.ts
+++ b/src/chrome/internal/sources/unidentifiedLoadedSource.ts
@@ -1,0 +1,74 @@
+import { IScript } from '../scripts/script';
+import { CDTPScriptUrl } from './resourceIdentifierSubtypes';
+import { IResourceIdentifier, parseResourceIdentifier, ResourceName } from './resourceIdentifier';
+import { ILoadedSource, IScriptMapper, SourceScriptRelationship, ImplementsLoadedSource, ScriptAndSourceMapper, ContentsLocation } from './loadedSource';
+import { ILoadedSourceToScriptRelationship, DevelopmentSourceOf, RuntimeSourceOf } from './loadedSourceToScriptRelationship';
+import { UnmappedSourceMapper } from '../scripts/sourcesMapper';
+import { LocationInLoadedSource, LocationInScript } from '../locations/location';
+
+export class UnidentifiedLoadedSource implements ILoadedSource<CDTPScriptUrl> {
+    public [ImplementsLoadedSource]: 'ILoadedSource' = 'ILoadedSource';
+
+    public contentsLocation = ContentsLocation.PersistentStorage;
+
+    public readonly sourceScriptRelationship = SourceScriptRelationship.SourceIsSingleScript;
+
+    // TODO DIEGO: Move these two properties to the client layer
+    public static EVAL_FILENAME_PREFIX = 'VM';
+    public static EVAL_PSEUDO_FOLDER = '<eval>';
+    public static EVAL_PSEUDO_PREFIX = `${UnidentifiedLoadedSource.EVAL_PSEUDO_FOLDER}\\${UnidentifiedLoadedSource.EVAL_FILENAME_PREFIX}`;
+
+    constructor(public readonly script: IScript, public readonly name: ResourceName<CDTPScriptUrl>, public readonly origin: string) { }
+
+    public get url(): never {
+        throw Error(`Can't get the url for ${this} because it doesn't have one`);
+    }
+
+    public get identifier(): IResourceIdentifier<CDTPScriptUrl> {
+        return parseResourceIdentifier<CDTPScriptUrl>(`${UnidentifiedLoadedSource.EVAL_PSEUDO_PREFIX}${this.name.textRepresentation}` as any);
+    }
+
+    public isMappedSource(): boolean {
+        return false;
+    }
+
+    public doesScriptHasUrl(): boolean {
+        return false;
+    }
+
+    public scriptMapper(): IScriptMapper {
+        return new CurrentUnidentifiedSourceScriptRelationships(this, this.script);
+    }
+
+    public isEquivalentTo(source: UnidentifiedLoadedSource): boolean {
+        return this === source;
+    }
+
+    public toString(): string {
+        return `No URL script source with id: ${this.name}`;
+    }
+}
+
+export class CurrentUnidentifiedSourceScriptRelationships implements IScriptMapper {
+    public mapToScripts(position: LocationInLoadedSource): LocationInScript[] {
+        return [new LocationInScript(this._script, position.position)];
+    }
+
+    public get relationships(): ILoadedSourceToScriptRelationship[] {
+        return [new DevelopmentSourceOf(this._source, this._source, this._source.script), new RuntimeSourceOf(this._source, this._source.script)];
+    }
+
+    public get scriptsAndSourceMappers(): ScriptAndSourceMapper[] {
+        return [new ScriptAndSourceMapper(this._source.script, new UnmappedSourceMapper(this._source.script, this._source))];
+    }
+
+    public get scripts(): IScript[] {
+        return [this._source.script];
+    }
+
+    public toString(): string {
+        return `This unidentified source is it's own runtime and development script`;
+    }
+
+    constructor(private readonly _source: UnidentifiedLoadedSource, private readonly _script: IScript) { }
+}

--- a/src/chrome/internal/stackTraces/callFrame.ts
+++ b/src/chrome/internal/stackTraces/callFrame.ts
@@ -44,6 +44,10 @@ export class CodeFlowFrame<TResource extends ScriptOrLoadedSource> {
     public get columnNumber(): number {
         return this.location.position.columnNumber;
     }
+
+    public toString(): string {
+        return `${this.functionName} at ${this.location}`;
+    }
 }
 
 /**
@@ -107,6 +111,10 @@ export class ScriptCallFrame extends BaseCallFrame<IScript> {
     public mappedToSource(): LoadedSourceCallFrame {
         const codeFlow = new CodeFlowFrame<ILoadedSource>(this.index, this.codeFlow.functionName, this.location.mappedToSource());
         return new LoadedSourceCallFrame(this, codeFlow);
+    }
+
+    public toString(): string {
+        return `${this.codeFlow}`;
     }
 }
 

--- a/src/chrome/internal/stackTraces/callFramePresentation.ts
+++ b/src/chrome/internal/stackTraces/callFramePresentation.ts
@@ -8,7 +8,6 @@ import { ILoadedSource } from '../sources/loadedSource';
 import { CodeFlowFrame, ICallFrame, CallFrame } from './callFrame';
 import { CallFramePresentationHint, IStackTracePresentationRow } from './stackTracePresentationRow';
 import { DebugProtocol } from 'vscode-debugprotocol';
-import { IScript } from '../scripts/script';
 
 export type SourcePresentationHint = 'normal' | 'emphasize' | 'deemphasize';
 
@@ -48,7 +47,7 @@ export class CallFramePresentation implements IStackTracePresentationRow {
     public get description(): string {
         const location = this.callFrame.location;
 
-        let formattedDescription = functionDescription(this.callFrame.codeFlow.functionName, location.source.script);
+        let formattedDescription = functionDescription(this.callFrame.codeFlow.functionName, location.source);
 
         if (this._descriptionFormatArgs) {
             if (this._descriptionFormatArgs.module) {
@@ -71,10 +70,10 @@ export class CallFramePresentation implements IStackTracePresentationRow {
     }
 }
 
-export function functionDescription(functionName: string | undefined, functionModule: IScript): string {
+export function functionDescription(functionName: string | undefined, functionModule: ILoadedSource): string {
     if (functionName) {
         return functionName;
-    } else if (functionModule.runtimeSource.doesScriptHasUrl()) {
+    } else if (functionModule.doesScriptHasUrl()) {
         return '(anonymous function)';
     } else {
         return '(eval code)';


### PR DESCRIPTION
Update script model to support the multiplicities that can happen in production

The previous script model assumed that a lot of multiplicities was 1 to 1 (.e.g: a Loaded source used to be related to a single script).

We can find more complex cases in production, so we updated the models to support the cases that could actually happen in production:

```
/**
 * Multiplicity:
 *   Scripts N [HTMLFile or MultipleTimesLoaded] ... 1 RuntimeSource(LoadedSource)(URLs)
 *   RuntimeSource(LoadedSource)(URLs) N ... 1 DevelopmentSource(LoadedSource)
 *   DevelopmentSource(LoadedSource) N ... M MappedSource(LoadedSource)
 *
 * --- Details ---
 * Scripts N [HTMLFile or MultipleTimesLoaded] ... 1 RuntimeSource(LoadedSource)(URLs)
 *   RuntimeSource(LoadedSource)(URLs) can have N Scripts if it's an .html file with multiple scripts or multiple event handlers
 *   RuntimeSource(LoadedSource)(URLs) can have N Scripts if the same script was loaded multiple times (We've seen this happen in Node when the require cache is deleted)
 *
 * RuntimeSource(LoadedSource)(URLs) N ... 1 DevelopmentSource(LoadedSource)
 * DevelopmentSource(LoadedSource) can be associated with multiple RuntimeSource(LoadedSource)(URLs) if the web-server severs the same file from multiple URLs
 *
 * DevelopmentSource(LoadedSource) N ... M MappedSource(LoadedSource)
 * DevelopmentSource(LoadedSource) can be associated with multiple MappedSource(LoadedSource) if files were bundled or compiled with TypeScript bundling option
 * MappedSource(LoadedSource) can be associated with multiple DevelopmentSource(LoadedSource) if the same typescript file gets bundled into different javascript files
 *
 * Additional notes:
 * It's extremelly unlikely, but it's possible for a .js file to be the MappedSource of a Script A, the RuntimeSource of a different script B, and the DevelopmentSource for a different script C at the same time
 */
```