### PR TITLE
CDTP Debuggee model

### DIFF
--- a/src/chrome/cdtpDebuggee/cdtpPrimitives.ts
+++ b/src/chrome/cdtpDebuggee/cdtpPrimitives.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { IScript } from '../internal/scripts/script';
+import { CDTPScriptUrl } from '../internal/sources/resourceIdentifierSubtypes';
+import { URLRegexp } from '../internal/locations/subtypes';
+import { AlwaysPause, ConditionalPause } from '../internal/breakpoints/bpActionWhenHit';
+import { IResourceIdentifier } from '../internal/sources/resourceIdentifier';
+import { IBPRecipeForRuntimeSource } from '../internal/breakpoints/baseMappedBPRecipe';
+import { MappableBreakpoint } from '../internal/breakpoints/breakpoint';
+
+export type integer = number;
+// The IResourceIdentifier<CDTPScriptUrl> is used with the URL that is associated with each Script in CDTP. This should be a URL, but it could also be a string that is not a valid URL
+// For that reason we use IResourceIdentifier<CDTPScriptUrl> for this type, instead of IURL<CDTPScriptUrl>
+export type CDTPSupportedResources = IScript | IResourceIdentifier<CDTPScriptUrl> | URLRegexp;
+export type CDTPSupportedHitActions = AlwaysPause | ConditionalPause;
+export type CDTPBPRecipe = IBPRecipeForRuntimeSource<CDTPSupportedResources, CDTPSupportedHitActions>;
+export type CDTPBreakpoint = MappableBreakpoint<CDTPSupportedResources>;
+const ImplementsFrameId = Symbol();
+export type FrameId = string & { [ImplementsFrameId]: 'FrameId' };

--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpConsoleEventsProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpConsoleEventsProvider.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { CDTPEventsEmitterDiagnosticsModule } from '../infrastructure/cdtpDiagnosticsModule';
+import { Protocol as CDTP } from 'devtools-protocol';
+import { CDTPStackTraceParser } from '../protocolParsers/cdtpStackTraceParser';
+import { inject, injectable } from 'inversify';
+import { CodeFlowStackTrace } from '../../internal/stackTraces/codeFlowStackTrace';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
+import { CDTPDomainsEnabler } from '../infrastructure/cdtpDomainsEnabler';
+
+export type ConsoleAPIEventType = 'log' | 'debug' | 'info' | 'error' | 'warning' | 'dir' | 'dirxml' | 'table' | 'trace' | 'clear' | 'startGroup' | 'startGroupCollapsed' | 'endGroup' | 'assert' | 'profile' | 'profileEnd' | 'count' | 'timeEnd';
+
+export interface IConsoleAPICalledEvent {
+    readonly type: ConsoleAPIEventType;
+    readonly args: CDTP.Runtime.RemoteObject[];
+    readonly executionContextId: CDTP.Runtime.ExecutionContextId;
+    readonly timestamp: CDTP.Runtime.Timestamp;
+    readonly stackTrace?: CodeFlowStackTrace;
+    readonly context?: string;
+}
+
+export type onMessageAddedListener = (message: CDTP.Console.MessageAddedEvent) => void;
+export type onConsoleAPICalled = (message: IConsoleAPICalledEvent) => void;
+
+export interface IConsoleEventsProvider {
+    onMessageAdded(listener: onMessageAddedListener): void;
+    onConsoleAPICalled(listener: onConsoleAPICalled): void;
+}
+
+class CDTPConsoleEventsFromConsoleProvider extends CDTPEventsEmitterDiagnosticsModule<CDTP.ConsoleApi>  {
+    protected readonly api = this._protocolApi.Console;
+
+    public readonly onMessageAdded = this.addApiListener('messageAdded', (params: CDTP.Console.MessageAddedEvent) => params);
+
+    constructor(
+        private readonly _protocolApi: CDTP.ProtocolApi,
+        domainsEnabler: CDTPDomainsEnabler) {
+        super(domainsEnabler);
+    }
+}
+
+class CDTPConsoleEventsFromRuntimeProvider extends CDTPEventsEmitterDiagnosticsModule<CDTP.RuntimeApi> {
+    protected readonly api = this._protocolApi.Runtime;
+    private readonly _stackTraceParser = new CDTPStackTraceParser(this._scriptsRegistry);
+
+    public readonly onConsoleAPICalled = this.addApiListener('consoleAPICalled', async (params: CDTP.Runtime.ConsoleAPICalledEvent) =>
+        ({
+            args: params.args,
+            context: params.context,
+            executionContextId: params.executionContextId,
+            timestamp: params.timestamp,
+            type: params.type,
+            stackTrace: params.stackTrace && await this._stackTraceParser.toStackTraceCodeFlow(params.stackTrace)
+        }));
+
+    constructor(
+        private readonly _protocolApi: CDTP.ProtocolApi,
+        private _scriptsRegistry: CDTPScriptsRegistry,
+        domainsEnabler: CDTPDomainsEnabler,
+    ) {
+        super(domainsEnabler);
+    }
+}
+
+@injectable()
+export class CDTPConsoleEventsProvider implements IConsoleEventsProvider {
+    private readonly _consoleEventsFromConsoleProvider = new CDTPConsoleEventsFromConsoleProvider(this._protocolApi, this._domainsEnabler);
+    private readonly _consoleEventsFromRuntimeProvider = new CDTPConsoleEventsFromRuntimeProvider(this._protocolApi, this._scriptsRegistry, this._domainsEnabler);
+
+    public readonly onMessageAdded = (listener: onMessageAddedListener) => this._consoleEventsFromConsoleProvider.onMessageAdded(listener);
+    public readonly onConsoleAPICalled = (listener: onConsoleAPICalled) => this._consoleEventsFromRuntimeProvider.onConsoleAPICalled(listener);
+
+    constructor(
+        @inject(TYPES.CDTPClient) private readonly _protocolApi: CDTP.ProtocolApi,
+        @inject(TYPES.CDTPScriptsRegistry) private _scriptsRegistry: CDTPScriptsRegistry,
+        @inject(TYPES.IDomainsEnabler) private readonly _domainsEnabler: CDTPDomainsEnabler,
+    ) {
+    }
+}

--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider.ts
@@ -1,0 +1,106 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { CDTPEventsEmitterDiagnosticsModule } from '../infrastructure/cdtpDiagnosticsModule';
+import { asyncMap } from '../../collections/async';
+import { CDTPStackTraceParser } from '../protocolParsers/cdtpStackTraceParser';
+import { CDTPBreakpointIdsRegistry } from '../registries/cdtpBreakpointIdsRegistry';
+import { ScriptCallFrame, CodeFlowFrame } from '../../internal/stackTraces/callFrame';
+import { asyncUndefinedOnFailure } from '../../utils/failures';
+import { CDTPLocationParser } from '../protocolParsers/cdtpLocationParser';
+import { Scope } from '../../internal/stackTraces/scopes';
+import { IScript } from '../../internal/scripts/script';
+import { injectable, inject } from 'inversify';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { Protocol as CDTP } from 'devtools-protocol';
+import { CodeFlowStackTrace } from '../../internal/stackTraces/codeFlowStackTrace';
+import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
+import { CDTPCallFrameRegistry } from '../registries/cdtpCallFrameRegistry';
+import { CDTPDomainsEnabler } from '../infrastructure/cdtpDomainsEnabler';
+import { CDTPBPRecipe } from '../cdtpPrimitives';
+
+export type PauseEventReason = 'XHR' | 'DOM' | 'EventListener' | 'exception' | 'assert' | 'debugCommand' | 'promiseRejection' | 'OOM' | 'other' | 'ambiguous';
+
+export class PausedEvent {
+    constructor(
+        public readonly callFrames: ScriptCallFrame[],
+        public readonly reason: PauseEventReason,
+        public readonly data: any,
+        public readonly hitBreakpoints: CDTPBPRecipe[],
+        public readonly asyncStackTrace: CodeFlowStackTrace | undefined,
+        public readonly asyncStackTraceId: CDTP.Runtime.StackTraceId | undefined,
+        public readonly asyncCallStackTraceId: CDTP.Runtime.StackTraceId | undefined) { }
+
+    public toString(): string {
+        return `Debugger paused due to ${this.reason} on ${this.callFrames.length > 0 ? this.callFrames[0] : 'No call frame'}${this.hitBreakpoints.length > 0 ? 'at ' + this.hitBreakpoints.join(',') : ''}`;
+    }
+}
+
+export interface ICDTDebuggeeExecutionEventsProvider {
+    onPaused(listener: (event: PausedEvent) => void): void;
+    onResumed(listener: () => void): void;
+}
+
+@injectable()
+export class CDTDebuggeeExecutionEventsProvider extends CDTPEventsEmitterDiagnosticsModule<CDTP.DebuggerApi, void, CDTP.Debugger.EnableResponse> implements ICDTDebuggeeExecutionEventsProvider {
+    protected readonly api = this._protocolApi.Debugger;
+
+    private readonly _cdtpLocationParser = new CDTPLocationParser(this._scriptsRegistry);
+    private readonly _stackTraceParser = new CDTPStackTraceParser(this._scriptsRegistry);
+
+    public readonly onPaused = this.addApiListener('paused', async (params: CDTP.Debugger.PausedEvent) => {
+        if (params.callFrames.length === 0) {
+            throw new Error(`Expected a pause event to have at least a single call frame: ${JSON.stringify(params)}`);
+        }
+
+        const callFrames = await asyncMap(params.callFrames, (callFrame, index) => this.toCallFrame(index, callFrame));
+
+        return new PausedEvent(callFrames, params.reason, params.data, await asyncMap(params.hitBreakpoints, hbp => this.getBPFromID(hbp)),
+            params.asyncStackTrace && await this._stackTraceParser.toStackTraceCodeFlow(params.asyncStackTrace),
+            params.asyncStackTraceId, params.asyncCallStackTraceId);
+    });
+
+    public readonly onResumed = this.addApiListener('resumed', (params: void) => params);
+
+    public readonly onScriptFailedToParse = this.addApiListener('resumed', (params: CDTP.Debugger.ScriptFailedToParseEvent) => params);
+
+    constructor(
+        @inject(TYPES.CDTPClient) private readonly _protocolApi: CDTP.ProtocolApi,
+        @inject(TYPES.CDTPScriptsRegistry) private _scriptsRegistry: CDTPScriptsRegistry,
+        @inject(CDTPBreakpointIdsRegistry) private readonly _breakpointIdRegistry: CDTPBreakpointIdsRegistry,
+        @inject(CDTPCallFrameRegistry) private readonly _callFrameRegistry: CDTPCallFrameRegistry,
+        @inject(TYPES.IDomainsEnabler) domainsEnabler: CDTPDomainsEnabler,
+    ) {
+        super(domainsEnabler);
+    }
+
+    private getBPFromID(hitBreakpoint: CDTP.Debugger.BreakpointId): CDTPBPRecipe {
+        return this._breakpointIdRegistry.getRecipeByBreakpointId(hitBreakpoint);
+    }
+
+    private async toCallFrame(index: number, callFrame: CDTP.Debugger.CallFrame): Promise<ScriptCallFrame> {
+        const frame = new ScriptCallFrame(await this.toCodeFlowFrame(index, callFrame),
+            await asyncMap(callFrame.scopeChain, scope => this.toScope(scope)),
+            callFrame.this, callFrame.returnValue);
+
+        this._callFrameRegistry.registerFrameId(callFrame.callFrameId, frame);
+
+        return frame;
+    }
+
+    private toCodeFlowFrame(index: number, callFrame: CDTP.Debugger.CallFrame): Promise<CodeFlowFrame<IScript>> {
+        return this._stackTraceParser.toCodeFlowFrame(index, callFrame, callFrame.location);
+    }
+
+    private async toScope(scope: CDTP.Debugger.Scope): Promise<Scope> {
+        return {
+            type: scope.type,
+            object: scope.object,
+            name: scope.name,
+            // TODO FILE BUG: Chrome sometimes returns line -1 when the doc says it's 0 based
+            startLocation: await asyncUndefinedOnFailure(async () => scope.startLocation && await this._cdtpLocationParser.getLocationInScript(scope.startLocation)),
+            endLocation: await asyncUndefinedOnFailure(async () => scope.endLocation && await this._cdtpLocationParser.getLocationInScript(scope.endLocation))
+        };
+    }
+}

--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider.ts
@@ -63,7 +63,7 @@ export class CDTDebuggeeExecutionEventsProvider extends CDTPEventsEmitterDiagnos
 
     public readonly onResumed = this.addApiListener('resumed', (params: void) => params);
 
-    public readonly onScriptFailedToParse = this.addApiListener('resumed', (params: CDTP.Debugger.ScriptFailedToParseEvent) => params);
+    public readonly onScriptFailedToParse = this.addApiListener('scriptFailedToParse', (params: CDTP.Debugger.ScriptFailedToParseEvent) => params);
 
     constructor(
         @inject(TYPES.CDTPClient) private readonly _protocolApi: CDTP.ProtocolApi,

--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpExceptionThrownEventsProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpExceptionThrownEventsProvider.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Protocol as CDTP } from 'devtools-protocol';
+
+import { CDTPEventsEmitterDiagnosticsModule } from '../infrastructure/cdtpDiagnosticsModule';
+import { CDTPStackTraceParser } from '../protocolParsers/cdtpStackTraceParser';
+import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
+import { injectable, inject } from 'inversify';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { integer } from '../cdtpPrimitives';
+import { IScript } from '../../internal/scripts/script';
+import { CodeFlowStackTrace } from '../../internal/stackTraces/codeFlowStackTrace';
+import { CDTPDomainsEnabler } from '../infrastructure/cdtpDomainsEnabler';
+
+export interface IExceptionThrownEvent {
+    readonly timestamp: CDTP.Runtime.Timestamp;
+    readonly exceptionDetails: IExceptionDetails;
+}
+
+export interface IExceptionDetails {
+    readonly exceptionId: integer;
+    readonly text: string;
+    readonly lineNumber: integer;
+    readonly columnNumber: integer;
+    readonly script?: IScript;
+    readonly url?: string;
+    readonly stackTrace?: CodeFlowStackTrace;
+    readonly exception?: CDTP.Runtime.RemoteObject;
+    readonly executionContextId?: CDTP.Runtime.ExecutionContextId;
+}
+
+export interface IExceptionThrownEventProvider {
+    onExceptionThrown(listener: (event: IExceptionThrownEvent) => void): void;
+}
+
+@injectable()
+export class CDTPExceptionThrownEventsProvider extends CDTPEventsEmitterDiagnosticsModule<CDTP.RuntimeApi> implements IExceptionThrownEventProvider {
+    protected readonly api = this.protocolApi.Runtime;
+
+    private readonly _stackTraceParser = new CDTPStackTraceParser(this._scriptsRegistry);
+
+    public readonly onExceptionThrown = this.addApiListener('exceptionThrown', async (params: CDTP.Runtime.ExceptionThrownEvent) =>
+        ({
+            timestamp: params.timestamp,
+            exceptionDetails: await this.toExceptionDetails(params.exceptionDetails)
+        }));
+
+    constructor(
+        @inject(TYPES.CDTPClient) private readonly protocolApi: CDTP.ProtocolApi,
+        @inject(TYPES.CDTPScriptsRegistry) private _scriptsRegistry: CDTPScriptsRegistry,
+        @inject(TYPES.IDomainsEnabler) domainsEnabler: CDTPDomainsEnabler,
+    ) {
+        super(domainsEnabler);
+    }
+
+    private async toExceptionDetails(exceptionDetails: CDTP.Runtime.ExceptionDetails): Promise<IExceptionDetails> {
+        return {
+            exceptionId: exceptionDetails.exceptionId,
+            text: exceptionDetails.text,
+            lineNumber: exceptionDetails.lineNumber,
+            columnNumber: exceptionDetails.columnNumber,
+            script: exceptionDetails.scriptId ? await this._scriptsRegistry.getScriptByCdtpId(exceptionDetails.scriptId) : undefined,
+            url: exceptionDetails.url,
+            stackTrace: exceptionDetails.stackTrace && await this._stackTraceParser.toStackTraceCodeFlow(exceptionDetails.stackTrace),
+            exception: exceptionDetails.exception,
+            executionContextId: exceptionDetails.executionContextId,
+        };
+    }
+}

--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpExecutionContextEventsProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpExecutionContextEventsProvider.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { CDTPEventsEmitterDiagnosticsModule } from '../infrastructure/cdtpDiagnosticsModule';
+import { Protocol as CDTP } from 'devtools-protocol';
+
+import { inject, injectable } from 'inversify';
+import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { CDTPDomainsEnabler } from '../infrastructure/cdtpDomainsEnabler';
+import { FrameId } from '../cdtpPrimitives';
+
+@injectable()
+export class CDTPExecutionContextEventsProvider extends CDTPEventsEmitterDiagnosticsModule<CDTP.RuntimeApi> {
+    protected readonly api = this._protocolApi.Runtime;
+
+    public readonly onExecutionContextsCleared = this.addApiListener('executionContextsCleared', (params: void) => params);
+
+    public readonly onExecutionContextDestroyed = this.addApiListener('executionContextDestroyed', async (params: CDTP.Runtime.ExecutionContextDestroyedEvent) =>
+        this._scriptsRegistry.markExecutionContextAsDestroyed(params.executionContextId));
+
+    public readonly onExecutionContextCreated = this.addApiListener('executionContextCreated', async (params: CDTP.Runtime.ExecutionContextCreatedEvent) =>
+        this._scriptsRegistry.registerExecutionContext(params.context.id, <FrameId>params.context.auxData.frameId));
+
+    constructor(
+        @inject(TYPES.CDTPClient) private readonly _protocolApi: CDTP.ProtocolApi,
+        @inject(TYPES.CDTPScriptsRegistry) private readonly _scriptsRegistry: CDTPScriptsRegistry,
+        @inject(TYPES.IDomainsEnabler) domainsEnabler: CDTPDomainsEnabler,
+    ) {
+        super(domainsEnabler);
+    }
+}

--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpLogEventsProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpLogEventsProvider.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { CDTPEventsEmitterDiagnosticsModule } from '../infrastructure/cdtpDiagnosticsModule';
+import { Protocol as CDTP } from 'devtools-protocol';
+
+import { CDTPStackTraceParser } from '../protocolParsers/cdtpStackTraceParser';
+import { integer } from '../cdtpPrimitives';
+import { CodeFlowStackTrace } from '../../internal/stackTraces/codeFlowStackTrace';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { inject } from 'inversify';
+import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
+import { CDTPDomainsEnabler } from '../infrastructure/cdtpDomainsEnabler';
+
+export type LogEntrySource = 'xml' | 'javascript' | 'network' | 'storage' | 'appcache' | 'rendering' | 'security' | 'deprecation' | 'worker' | 'violation' | 'intervention' | 'recommendation' | 'other';
+export type LogLevel = 'verbose' | 'info' | 'warning' | 'error';
+
+export interface ILogEntry {
+    readonly source: LogEntrySource;
+    readonly level: LogLevel;
+    readonly text: string;
+    readonly timestamp: CDTP.Runtime.Timestamp;
+    readonly url?: string;
+    readonly lineNumber?: integer;
+    readonly stackTrace?: CodeFlowStackTrace;
+    readonly networkRequestId?: CDTP.Network.RequestId;
+    readonly workerId?: string;
+    readonly args?: CDTP.Runtime.RemoteObject[];
+}
+
+export interface ILogEventsProvider {
+    onEntryAdded(listener: (entry: ILogEntry) => void): void;
+}
+
+export class CDTPLogEventsProvider extends CDTPEventsEmitterDiagnosticsModule<CDTP.LogApi> implements ILogEventsProvider {
+    protected readonly api = this._protocolApi.Log;
+
+    private readonly _stackTraceParser = new CDTPStackTraceParser(this._scriptsRegistry);
+
+    public readonly onEntryAdded = this.addApiListener('entryAdded', async (params: CDTP.Log.EntryAddedEvent) => await this.toLogEntry(params.entry));
+
+    constructor(
+        @inject(TYPES.CDTPClient) private readonly _protocolApi: CDTP.ProtocolApi,
+        @inject(TYPES.CDTPScriptsRegistry) private _scriptsRegistry: CDTPScriptsRegistry,
+        @inject(TYPES.IDomainsEnabler) domainsEnabler: CDTPDomainsEnabler,
+    ) {
+        super(domainsEnabler);
+    }
+
+    private async toLogEntry(entry: CDTP.Log.LogEntry): Promise<ILogEntry> {
+        return {
+            source: entry.source,
+            level: entry.level,
+            text: entry.text,
+            timestamp: entry.timestamp,
+            url: entry.url,
+            lineNumber: entry.lineNumber,
+            networkRequestId: entry.networkRequestId,
+            workerId: entry.workerId,
+            args: entry.args,
+            stackTrace: entry.stackTrace && await this._stackTraceParser.toStackTraceCodeFlow(entry.stackTrace),
+        };
+    }
+}

--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpOnScriptParsedEventProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpOnScriptParsedEventProvider.ts
@@ -1,0 +1,257 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Protocol as CDTP } from 'devtools-protocol';
+import { CDTPEventsEmitterDiagnosticsModule } from '../infrastructure/cdtpDiagnosticsModule';
+import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
+import { IScript, Script } from '../../internal/scripts/script';
+import { createCDTPScriptUrl, CDTPScriptUrl } from '../../internal/sources/resourceIdentifierSubtypes';
+import { MappedSourcesMapper, IMappedSourcesMapper, NoMappedSourcesMapper } from '../../internal/scripts/sourcesMapper';
+import { IResourceIdentifier, ResourceName, parseResourceIdentifier } from '../../internal/sources/resourceIdentifier';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { CDTPStackTraceParser } from '../protocolParsers/cdtpStackTraceParser';
+import { inject } from 'inversify';
+import { integer } from '../cdtpPrimitives';
+import { CodeFlowStackTrace } from '../../internal/stackTraces/codeFlowStackTrace';
+import { IExecutionContext } from '../../internal/scripts/executionContext';
+import { CDTPDomainsEnabler } from '../infrastructure/cdtpDomainsEnabler';
+import { LoadedSourcesRegistry } from '../registries/loadedSourcesRegistry';
+import { ILoadedSource, SourceScriptRelationship } from '../../internal/sources/loadedSource';
+import { IdentifiedLoadedSource } from '../../internal/sources/identifiedLoadedSource';
+import { DevelopmentSourceOf, RuntimeSourceOf, MappedSourceOf } from '../../internal/sources/loadedSourceToScriptRelationship';
+import { Position } from '../../internal/locations/location';
+import { createLineNumber, createColumnNumber } from '../../internal/locations/subtypes';
+import { RangeInResource } from '../../internal/locations/rangeInScript';
+import * as _ from 'lodash';
+import { SourceMap } from '../../../sourceMaps/sourceMap';
+import { BasePathTransformer } from '../../../transformers/basePathTransformer';
+import { BaseSourceMapTransformer } from '../../../transformers/baseSourceMapTransformer';
+
+/**
+ * A new JavaScript Script has been parsed by the debugee and it's about to be executed
+ */
+export interface IScriptParsedEvent {
+    readonly script: IScript;
+    readonly url: string;
+    readonly startLine: integer;
+    readonly startColumn: integer;
+    readonly endLine: integer;
+    readonly endColumn: integer;
+    readonly executionContext: IExecutionContext;
+    readonly hash: string;
+    readonly executionContextAuxData?: any;
+    readonly isLiveEdit?: boolean;
+    readonly sourceMapURL?: string;
+    readonly hasSourceURL?: boolean;
+    readonly isModule?: boolean;
+    readonly length?: integer;
+    readonly stackTrace?: CodeFlowStackTrace;
+}
+
+export class ScriptParsedEvent implements IScriptParsedEvent {
+    public readonly script: IScript;
+    public readonly url: string;
+    public readonly startLine: integer;
+    public readonly startColumn: integer;
+    public readonly endLine: integer;
+    public readonly endColumn: integer;
+    public readonly executionContext: IExecutionContext;
+    public readonly hash: string;
+    public readonly executionContextAuxData?: any;
+    public readonly isLiveEdit?: boolean;
+    public readonly sourceMapURL?: string;
+    public readonly hasSourceURL?: boolean;
+    public readonly isModule?: boolean;
+    public readonly length?: integer;
+    public readonly stackTrace?: CodeFlowStackTrace;
+
+    public constructor(parsedEvent: IScriptParsedEvent) {
+        this.script = parsedEvent.script;
+        this.url = parsedEvent.url;
+        this.startLine = parsedEvent.startLine;
+        this.startColumn = parsedEvent.startColumn;
+        this.endLine = parsedEvent.endLine;
+        this.endColumn = parsedEvent.endColumn;
+        this.executionContext = parsedEvent.executionContext;
+        this.hash = parsedEvent.hash;
+        this.executionContextAuxData = parsedEvent.executionContextAuxData;
+        this.isLiveEdit = parsedEvent.isLiveEdit;
+        this.sourceMapURL = parsedEvent.sourceMapURL;
+        this.hasSourceURL = parsedEvent.hasSourceURL;
+        this.isModule = parsedEvent.isModule;
+        this.length = parsedEvent.length;
+        this.stackTrace = parsedEvent.stackTrace;
+    }
+
+    public toString() {
+        return `Script was parsed: ${this.script} with development source: ${this.script.developmentSource} and mapped sources: ${this.script.mappedSources.join(', ')}`;
+    }
+}
+
+export type ScriptParsedListener = (params: IScriptParsedEvent) => void;
+
+export interface IScriptParsedProvider {
+    onScriptParsed(listener: (event: IScriptParsedEvent) => void): void;
+}
+
+export class CDTPOnScriptParsedEventProvider extends CDTPEventsEmitterDiagnosticsModule<CDTP.DebuggerApi, void, CDTP.Debugger.EnableResponse> implements IScriptParsedProvider {
+    protected readonly api = this._protocolApi.Debugger;
+
+    private readonly _stackTraceParser = new CDTPStackTraceParser(this._scriptsRegistry);
+
+    public onScriptParsed = this.addApiListener('scriptParsed', async (params: CDTP.Debugger.ScriptParsedEvent) => {
+        // The stack trace and hash can be large and the DA doesn't need it.
+        delete params.stackTrace;
+        delete params.hash;
+
+        const creator = !!params.url ? IdentifiedScriptCreator : UnidentifiedScriptCreator;
+        await new creator(this._scriptsRegistry, this._loadedSourcesRegistry, this._pathTransformer, this._sourceMapTransformer, params).createAndRegisterScript();
+
+        return await this.toScriptParsedEvent(params);
+    });
+
+    constructor(
+        @inject(TYPES.CDTPClient) private readonly _protocolApi: CDTP.ProtocolApi,
+        @inject(TYPES.BasePathTransformer) private readonly _pathTransformer: BasePathTransformer,
+        @inject(TYPES.BaseSourceMapTransformer) private readonly _sourceMapTransformer: BaseSourceMapTransformer,
+        @inject(TYPES.CDTPScriptsRegistry) private readonly _scriptsRegistry: CDTPScriptsRegistry,
+        @inject(TYPES.IDomainsEnabler) domainsEnabler: CDTPDomainsEnabler,
+        @inject(LoadedSourcesRegistry) private readonly _loadedSourcesRegistry: LoadedSourcesRegistry,
+    ) {
+        super(domainsEnabler);
+    }
+
+    private async toScriptParsedEvent(params: CDTP.Debugger.ScriptParsedEvent): Promise<IScriptParsedEvent> {
+        const executionContext = this._scriptsRegistry.getExecutionContextById(params.executionContextId);
+
+        return new ScriptParsedEvent(
+            {
+                url: params.url,
+                startLine: params.startLine,
+                startColumn: params.startColumn,
+                endLine: params.endLine,
+                endColumn: params.endColumn,
+                executionContext: executionContext,
+                hash: params.hash,
+                executionContextAuxData: params.executionContextAuxData,
+                isLiveEdit: params.isLiveEdit,
+                sourceMapURL: params.sourceMapURL,
+                hasSourceURL: params.hasSourceURL,
+                isModule: params.isModule,
+                length: params.length,
+                script: await this._scriptsRegistry.getScriptByCdtpId(params.scriptId),
+                stackTrace: params.stackTrace && await this._stackTraceParser.toStackTraceCodeFlow(params.stackTrace)
+            });
+    }
+}
+
+abstract class ScriptCreator {
+    protected readonly runtimeSourcePath = parseResourceIdentifier(createCDTPScriptUrl(this._scriptParsedEvent.url || ''));
+
+    constructor(
+        private readonly _scriptsRegistry: CDTPScriptsRegistry,
+        protected readonly _loadedSourcesRegistry: LoadedSourcesRegistry,
+        protected readonly _pathTransformer: BasePathTransformer,
+        private readonly _sourceMapTransformer: BaseSourceMapTransformer,
+        protected readonly _scriptParsedEvent: CDTP.Debugger.ScriptParsedEvent,
+    ) { }
+
+    public async createAndRegisterScript(): Promise<IScript> {
+        const executionContext = this._scriptsRegistry.getExecutionContextById(this._scriptParsedEvent.executionContextId);
+
+        const script = await this._scriptsRegistry.registerScript(this._scriptParsedEvent.scriptId, async () => {
+            const sourceMap = await this.sourceMap();
+            const sourceMapperProvider = _.memoize(script => this.sourceMapper(script, sourceMap));
+            const mappedSourcesProvider = _.memoize(script => this.mappedSources(sourceMapperProvider(script)));
+
+            return this.createScript(executionContext, sourceMapperProvider, mappedSourcesProvider);
+        });
+
+        script.mappedSources.forEach(source =>
+            this._loadedSourcesRegistry.registerRelationship(source, new MappedSourceOf(source, script)));
+
+        await this.registerRuntimeAndDevelopmentSourcesRelationships(script);
+
+        return script;
+    }
+
+    private sourceMap(): Promise<SourceMap> {
+        return this._sourceMapTransformer.scriptParsed(this.runtimeSourcePath.canonicalized, this._scriptParsedEvent.sourceMapURL);
+    }
+
+    protected abstract createScript(executionContext: IExecutionContext, sourceMapperProvider: (script: IScript) => IMappedSourcesMapper,
+        mappedSourcesProvider: (script: IScript) => IdentifiedLoadedSource<string>[]): Promise<IScript>;
+
+    protected abstract registerRuntimeAndDevelopmentSourcesRelationships(script: IScript): Promise<void>;
+
+    private mappedSources(sourceMapper: IMappedSourcesMapper): IdentifiedLoadedSource[] {
+        return sourceMapper.sources.map((path: string) => this.obtainLoadedSource(parseResourceIdentifier(path), SourceScriptRelationship.Unknown));
+    }
+
+    private sourceMapper(script: IScript, sourceMap: SourceMap): IMappedSourcesMapper {
+        const sourceMapper = sourceMap
+            ? new MappedSourcesMapper(script, sourceMap)
+            : new NoMappedSourcesMapper(script);
+        return sourceMapper;
+    }
+
+    protected scriptRange(runtimeSource: ILoadedSource<CDTPScriptUrl>) {
+        const startPosition = new Position(createLineNumber(this._scriptParsedEvent.startLine), createColumnNumber(this._scriptParsedEvent.startColumn));
+        const endPosition = new Position(createLineNumber(this._scriptParsedEvent.endLine), createColumnNumber(this._scriptParsedEvent.endColumn));
+        const scriptRange = new RangeInResource(runtimeSource, startPosition, endPosition);
+        return scriptRange;
+    }
+
+    protected obtainLoadedSource(sourceUrl: IResourceIdentifier, sourceScriptRelationship: SourceScriptRelationship): IdentifiedLoadedSource {
+        return this._loadedSourcesRegistry.getOrAdd(sourceUrl, provider => {
+            return IdentifiedLoadedSource.create(sourceUrl, sourceScriptRelationship, provider);
+        });
+    }
+}
+
+class IdentifiedScriptCreator extends ScriptCreator {
+    private readonly runtimeSource = _.memoize(() => this.obtainRuntimeSource());
+    private readonly developmentSource = _.memoize(() => this.obtainDevelopmentSource());
+
+    protected async createScript(executionContext: IExecutionContext, sourceMapperProvider: (script: IScript) => IMappedSourcesMapper,
+        mappedSourcesProvider: (script: IScript) => IdentifiedLoadedSource<string>[]): Promise<IScript> {
+        return Script.create(executionContext, this.runtimeSource(), await this.developmentSource(), sourceMapperProvider, mappedSourcesProvider, this.scriptRange(this.runtimeSource()));
+    }
+
+    private obtainRuntimeSource(): IdentifiedLoadedSource<CDTPScriptUrl> {
+        // This is an heuristic. I think that if the script starts on (0, 0) then that means the file is a script file, and not an .html file or something which is a script and something else
+        // I cannot think of any case where this would be false, but we've been surprised before...
+        const isSingleScript = this._scriptParsedEvent.startLine === 0 && this._scriptParsedEvent.startColumn === 0;
+        const sourceScriptRelationship = isSingleScript ? SourceScriptRelationship.SourceIsSingleScript : SourceScriptRelationship.SourceIsMoreThanAScript;
+
+        // TODO: Figure out a way to remove the cast in next line
+        return <IdentifiedLoadedSource<CDTPScriptUrl>><unknown>this.obtainLoadedSource(this.runtimeSourcePath, sourceScriptRelationship);
+    }
+
+    private async obtainDevelopmentSource(): Promise<IdentifiedLoadedSource> {
+        // TODO: Remove .textRepresentation and use resource identifier instead
+        const developmentSourceLocation = await this._pathTransformer.scriptParsed(this.runtimeSourcePath.textRepresentation);
+
+        // The development file should have the same contents, so it should have the same source script relationship as the runtime file
+        return this.obtainLoadedSource(parseResourceIdentifier(developmentSourceLocation), this.runtimeSource().sourceScriptRelationship);
+    }
+
+    protected async registerRuntimeAndDevelopmentSourcesRelationships(script: IScript): Promise<void> {
+        const developmentSource = await this.developmentSource();
+        this._loadedSourcesRegistry.registerRelationship(developmentSource, new DevelopmentSourceOf(developmentSource, this.runtimeSource(), script));
+
+        const runtimeSource = await this.runtimeSource();
+        this._loadedSourcesRegistry.registerRelationship(runtimeSource, new RuntimeSourceOf(runtimeSource, script));
+    }
+}
+
+class UnidentifiedScriptCreator extends ScriptCreator {
+    protected async createScript(executionContext: IExecutionContext, sourceMapperProvider: (script: IScript) => IMappedSourcesMapper,
+        mappedSourcesProvider: (script: IScript) => IdentifiedLoadedSource<string>[]): Promise<IScript> {
+        return Script.createWithUnidentifiedSource(new ResourceName(createCDTPScriptUrl(`${this._scriptParsedEvent.scriptId}`)),
+            executionContext, sourceMapperProvider, mappedSourcesProvider, (runtimeSource: ILoadedSource<CDTPScriptUrl>) => this.scriptRange(runtimeSource));
+    }
+
+    protected async registerRuntimeAndDevelopmentSourcesRelationships(_script: IScript): Promise<void> { }
+}

--- a/src/chrome/cdtpDebuggee/features/cdtpAsyncDebuggingConfigurer.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpAsyncDebuggingConfigurer.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Protocol as CDTP } from 'devtools-protocol';
+import { inject, injectable } from 'inversify';
+import { TYPES } from '../../dependencyInjection.ts/types';
+
+export interface IAsyncDebuggingConfigurer {
+    setAsyncCallStackDepth(maxDepth: CDTP.integer): Promise<void>;
+}
+
+@injectable()
+export class CDTPAsyncDebuggingConfigurer implements IAsyncDebuggingConfigurer {
+    protected readonly api = this._protocolApi.Debugger;
+
+    constructor(
+        @inject(TYPES.CDTPClient)
+        private readonly _protocolApi: CDTP.ProtocolApi) {
+    }
+
+    public setAsyncCallStackDepth(maxDepth: CDTP.integer): Promise<void> {
+        return this.api.setAsyncCallStackDepth({ maxDepth });
+    }
+}

--- a/src/chrome/cdtpDebuggee/features/cdtpBlackboxPatternsConfigurer.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpBlackboxPatternsConfigurer.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Protocol as CDTP } from 'devtools-protocol';
+import { IScript } from '../../internal/scripts/script';
+import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
+import { inject, injectable } from 'inversify';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { LocationInScript } from '../../internal/locations/location';
+
+export interface IBlackboxPatternsConfigurer {
+    setBlackboxPatterns(params: CDTP.Debugger.SetBlackboxPatternsRequest): Promise<void>;
+    setBlackboxedRanges(script: IScript, positions: LocationInScript[]): Promise<void>;
+}
+
+@injectable()
+export class CDTPBlackboxPatternsConfigurer implements IBlackboxPatternsConfigurer {
+    protected readonly api = this._protocolApi.Debugger;
+
+    constructor(
+        @inject(TYPES.CDTPClient)
+        private readonly _protocolApi: CDTP.ProtocolApi,
+        @inject(TYPES.CDTPScriptsRegistry)
+        private readonly _scriptsRegistry: CDTPScriptsRegistry) {
+    }
+
+    public setBlackboxedRanges(script: IScript, positions: LocationInScript[]): Promise<void> {
+        if (!positions.every(location => location.script === script)) {
+            throw new Error(`Expected all the position: ${positions} to be in the script ${script}`);
+        }
+
+        const cdtpPositions: CDTP.Debugger.ScriptPosition[] = positions.map(p => ({
+            lineNumber: p.position.lineNumber,
+            columnNumber: p.position.columnNumber
+        }));
+
+        return this.api.setBlackboxedRanges({ scriptId: this._scriptsRegistry.getCdtpId(script), positions: cdtpPositions });
+    }
+
+    public setBlackboxPatterns(params: CDTP.Debugger.SetBlackboxPatternsRequest): Promise<void> {
+        return this.api.setBlackboxPatterns(params);
+    }
+}

--- a/src/chrome/cdtpDebuggee/features/cdtpBreakpointFeaturesSupport.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpBreakpointFeaturesSupport.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { injectable, inject } from 'inversify';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { Protocol as CDTP } from 'devtools-protocol';
+import * as utils from '../../../utils';
+
+export interface IBreakpointFeaturesSupport {
+    supportsColumnBreakpoints: Promise<boolean>;
+}
+
+@injectable()
+export class CDTPBreakpointFeaturesSupport implements IBreakpointFeaturesSupport {
+    private result = utils.promiseDefer<boolean>();
+
+    public supportsColumnBreakpoints = this.result.promise;
+
+    constructor(
+        @inject(TYPES.CDTPClient) private readonly api: CDTP.ProtocolApi) {
+        api.Debugger.on('scriptParsed', params => this.onScriptParsed(params));
+    }
+
+    private async onScriptParsed(params: CDTP.Debugger.ScriptParsedEvent): Promise<void> {
+        const scriptId = params.scriptId;
+
+        try {
+            await this.api.Debugger.getPossibleBreakpoints({
+                start: { scriptId, lineNumber: 0, columnNumber: 0 },
+                end: { scriptId, lineNumber: 1, columnNumber: 0 },
+                restrictToFunction: false
+            });
+
+            this.result.resolve(true);
+        } catch (e) {
+            this.result.resolve(false);
+        }
+    }
+}

--- a/src/chrome/cdtpDebuggee/features/cdtpBrowserNavigator.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpBrowserNavigator.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Protocol as CDTP } from 'devtools-protocol';
+
+import { injectable, inject } from 'inversify';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { CDTPEventsEmitterDiagnosticsModule } from '../infrastructure/cdtpDiagnosticsModule';
+import { CDTPDomainsEnabler } from '../infrastructure/cdtpDomainsEnabler';
+
+export interface IBrowserNavigator {
+    navigate(params: CDTP.Page.NavigateRequest): Promise<CDTP.Page.NavigateResponse>;
+    reload(params: CDTP.Page.ReloadRequest): Promise<void>;
+    onFrameNavigated(listener: (params: CDTP.Page.FrameNavigatedEvent) => void): void;
+}
+
+@injectable()
+export class CDTPBrowserNavigator extends CDTPEventsEmitterDiagnosticsModule<CDTP.PageApi> implements IBrowserNavigator {
+    protected api = this._protocolApi.Page;
+
+    public readonly onFrameNavigated = this.addApiListener('frameNavigated', (params: CDTP.Page.FrameNavigatedEvent) => params);
+
+    constructor(
+        @inject(TYPES.CDTPClient)
+        protected _protocolApi: CDTP.ProtocolApi,
+        @inject(TYPES.IDomainsEnabler) domainsEnabler: CDTPDomainsEnabler,
+    ) {
+        super(domainsEnabler);
+    }
+
+    public navigate(params: CDTP.Page.NavigateRequest): Promise<CDTP.Page.NavigateResponse> {
+        return this.api.navigate(params);
+    }
+
+    public reload(params: CDTP.Page.ReloadRequest): Promise<void> {
+        return this.api.reload(params);
+    }
+}

--- a/src/chrome/cdtpDebuggee/features/cdtpDOMInstrumentationBreakpointsSetter.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpDOMInstrumentationBreakpointsSetter.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Protocol as CDTP } from 'devtools-protocol';
+
+import { injectable, inject } from 'inversify';
+import { TYPES } from '../../dependencyInjection.ts/types';
+
+export interface IDOMInstrumentationBreakpointsSetter {
+    setInstrumentationBreakpoint(params: CDTP.DOMDebugger.SetInstrumentationBreakpointRequest): Promise<void>;
+    removeInstrumentationBreakpoint(params: CDTP.DOMDebugger.SetInstrumentationBreakpointRequest): Promise<void>;
+}
+
+@injectable()
+export class CDTPDOMInstrumentationBreakpointsSetter implements IDOMInstrumentationBreakpointsSetter {
+    protected api = this._protocolApi.DOMDebugger;
+
+    constructor(
+        @inject(TYPES.CDTPClient)
+        protected _protocolApi: CDTP.ProtocolApi) { }
+
+    public setInstrumentationBreakpoint(params: CDTP.DOMDebugger.SetInstrumentationBreakpointRequest): Promise<void> {
+        return this.api.setInstrumentationBreakpoint(params);
+    }
+
+    public removeInstrumentationBreakpoint(params: CDTP.DOMDebugger.SetInstrumentationBreakpointRequest): Promise<void> {
+        return this.api.removeInstrumentationBreakpoint(params);
+    }
+}

--- a/src/chrome/cdtpDebuggee/features/cdtpDebugeeExecutionController.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpDebugeeExecutionController.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Protocol as CDTP } from 'devtools-protocol';
+import { injectable, inject } from 'inversify';
+import { TYPES } from '../../dependencyInjection.ts/types';
+
+export interface IDebugeeExecutionController {
+    resume(): Promise<void>;
+    pause(): Promise<void>;
+}
+
+@injectable()
+export class CDTPDebugeeExecutionController implements IDebugeeExecutionController {
+    constructor(
+        @inject(TYPES.CDTPClient) protected readonly api: CDTP.ProtocolApi) {
+    }
+
+    public resume(): Promise<void> {
+        return this.api.Debugger.resume();
+    }
+
+    public pause(): Promise<void> {
+        return this.api.Debugger.pause();
+    }
+}

--- a/src/chrome/cdtpDebuggee/features/cdtpDebugeeRuntimeVersionProvider.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpDebugeeRuntimeVersionProvider.ts
@@ -22,8 +22,10 @@ export interface IDebugeeRuntimeVersionProvider {
     componentVersions(): Promise<CDTPComponentsVersions>;
 }
 
-/// TODO: Move this to a browser-shared package
-/// TODO: Update this so we automatically try to use ChromeConnection.version first, and then fallback to this if neccesary
+/**
+ * TODO: Move this to a browser-shared package
+ * TODO: Update this so we automatically try to use ChromeConnection.version first, and then fallback to this if neccesary
+ */
 @injectable()
 export class CDTPDebugeeRuntimeVersionProvider implements IDebugeeRuntimeVersionProvider {
     protected api = this._protocolApi.Browser;

--- a/src/chrome/cdtpDebuggee/features/cdtpDebugeeRuntimeVersionProvider.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpDebugeeRuntimeVersionProvider.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Protocol as CDTP } from 'devtools-protocol';
+
+import { injectable, inject } from 'inversify';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { Version } from '../../utils/Version';
+import * as _ from 'lodash';
+
+export interface CDTPComponentsVersions {
+    product: string;
+    crdp: string;
+    revision: string;
+    userAgent: string;
+    v8: string;
+}
+
+export interface IDebugeeRuntimeVersionProvider {
+    version(): Promise<Version>;
+    componentVersions(): Promise<CDTPComponentsVersions>;
+}
+
+/// TODO: Move this to a browser-shared package
+/// TODO: Update this so we automatically try to use ChromeConnection.version first, and then fallback to this if neccesary
+@injectable()
+export class CDTPDebugeeRuntimeVersionProvider implements IDebugeeRuntimeVersionProvider {
+    protected api = this._protocolApi.Browser;
+    private readonly _componentsVersions = _.memoize(() => this.api.getVersion());
+
+    constructor(
+        @inject(TYPES.CDTPClient)
+        protected _protocolApi: CDTP.ProtocolApi) {
+    }
+
+    public async version(): Promise<Version> {
+        return Version.coerce((await this._componentsVersions()).product);
+    }
+
+    public async componentVersions(): Promise<CDTPComponentsVersions> {
+        const rawComponentVersions = await this._componentsVersions();
+        return {
+            product: rawComponentVersions.product,
+            revision: rawComponentVersions.revision,
+            crdp: rawComponentVersions.protocolVersion,
+            v8: rawComponentVersions.jsVersion,
+            userAgent: rawComponentVersions.userAgent
+        };
+    }
+}

--- a/src/chrome/cdtpDebuggee/features/cdtpDebugeeStateInspector.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpDebugeeStateInspector.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Protocol as CDTP } from 'devtools-protocol';
+
+import { CDTPCallFrameRegistry } from '../registries/cdtpCallFrameRegistry';
+import { injectable, inject } from 'inversify';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { ScriptCallFrame } from '../../internal/stackTraces/callFrame';
+
+export interface IEvaluateOnCallFrameRequest {
+    readonly frame: ScriptCallFrame;
+    readonly expression: string;
+    readonly objectGroup?: string;
+    readonly includeCommandLineAPI?: boolean;
+    readonly silent?: boolean;
+    readonly returnByValue?: boolean;
+    readonly generatePreview?: boolean;
+    readonly throwOnSideEffect?: boolean;
+    readonly timeout?: CDTP.Runtime.TimeDelta;
+}
+
+export interface IDebugeeStateInspector {
+    callFunctionOn(params: CDTP.Runtime.CallFunctionOnRequest): Promise<CDTP.Runtime.CallFunctionOnResponse>;
+    getProperties(params: CDTP.Runtime.GetPropertiesRequest): Promise<CDTP.Runtime.GetPropertiesResponse>;
+    evaluate(params: CDTP.Runtime.EvaluateRequest): Promise<CDTP.Runtime.EvaluateResponse>;
+    evaluateOnCallFrame(params: IEvaluateOnCallFrameRequest): Promise<CDTP.Debugger.EvaluateOnCallFrameResponse>;
+}
+
+export class AddSourceUriToExpession {
+    private nextEvaluateScriptId = 0;
+
+    constructor(private readonly _prefix: string) { }
+
+    public addURLIfMissing(expression: string): string {
+        const sourceUrlPrefix = '\n//# sourceURL=';
+
+        if (expression.indexOf(sourceUrlPrefix) < 0) {
+            expression += `${sourceUrlPrefix}<debugger-internal>/${this._prefix}/id=${this.nextEvaluateScriptId++}`;
+        }
+
+        return expression;
+    }
+}
+
+@injectable()
+export class CDTPDebugeeStateInspector implements IDebugeeStateInspector {
+    private addSourceUriToEvaluates = new AddSourceUriToExpession('evaluateOnFrame');
+
+    constructor(
+        @inject(TYPES.CDTPClient) protected readonly api: CDTP.ProtocolApi,
+        private readonly _callFrameRegistry: CDTPCallFrameRegistry) {
+    }
+
+    public callFunctionOn(params: CDTP.Runtime.CallFunctionOnRequest): Promise<CDTP.Runtime.CallFunctionOnResponse> {
+        return this.api.Runtime.callFunctionOn(params);
+    }
+
+    public getProperties(params: CDTP.Runtime.GetPropertiesRequest): Promise<CDTP.Runtime.GetPropertiesResponse> {
+        return this.api.Runtime.getProperties(params);
+    }
+
+    public evaluate(params: CDTP.Runtime.EvaluateRequest): Promise<CDTP.Runtime.EvaluateResponse> {
+        params.expression = this.addSourceUriToEvaluates.addURLIfMissing(params.expression);
+        return this.api.Runtime.evaluate(params);
+    }
+
+    public evaluateOnCallFrame(params: IEvaluateOnCallFrameRequest): Promise<CDTP.Debugger.EvaluateOnCallFrameResponse> {
+        return this.api.Debugger.evaluateOnCallFrame({
+            callFrameId: this._callFrameRegistry.getFrameId(params.frame),
+            expression: this.addSourceUriToEvaluates.addURLIfMissing(params.expression),
+            objectGroup: params.objectGroup,
+            includeCommandLineAPI: params.includeCommandLineAPI,
+            silent: params.silent,
+            returnByValue: params.returnByValue,
+            generatePreview: params.generatePreview,
+            throwOnSideEffect: params.throwOnSideEffect,
+            timeout: params.timeout,
+        });
+    }
+}

--- a/src/chrome/cdtpDebuggee/features/cdtpDebugeeStateSetter.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpDebugeeStateSetter.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+ import { Protocol as CDTP } from 'devtools-protocol';
+import { CDTPCallFrameRegistry } from '../registries/cdtpCallFrameRegistry';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { injectable, inject } from 'inversify';
+import { ScriptCallFrame } from '../../internal/stackTraces/callFrame';
+import { integer } from '../cdtpPrimitives';
+
+export interface ISetVariableValueRequest {
+    readonly scopeNumber: integer;
+    readonly variableName: string;
+    readonly newValue: CDTP.Runtime.CallArgument;
+    readonly frame: ScriptCallFrame;
+}
+
+export interface IDebugeeStateSetter {
+    setVariableValue(params: ISetVariableValueRequest): Promise<void>;
+}
+
+@injectable()
+export class CDTPDebugeeStateSetter implements IDebugeeStateSetter {
+    constructor(
+        @inject(TYPES.CDTPClient) private readonly api: CDTP.ProtocolApi,
+        private readonly _callFrameRegistry: CDTPCallFrameRegistry) {
+    }
+
+    public setVariableValue(params: ISetVariableValueRequest): Promise<void> {
+        return this.api.Debugger.setVariableValue({
+            callFrameId: this._callFrameRegistry.getFrameId(params.frame),
+            scopeNumber: params.scopeNumber,
+            variableName: params.variableName,
+            newValue: params.newValue
+        });
+    }
+}

--- a/src/chrome/cdtpDebuggee/features/cdtpDebugeeSteppingController.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpDebugeeSteppingController.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Protocol as CDTP } from 'devtools-protocol';
+import { ScriptCallFrame } from '../../internal/stackTraces/callFrame';
+import { CDTPCallFrameRegistry } from '../registries/cdtpCallFrameRegistry';
+import { injectable, inject } from 'inversify';
+import { TYPES } from '../../dependencyInjection.ts/types';
+
+export interface IDebugeeSteppingController {
+    stepOver(): Promise<void>;
+    stepInto(params: { breakOnAsyncCall: boolean }): Promise<void>;
+    stepOut(): Promise<void>;
+    restartFrame(callFrame: ScriptCallFrame): Promise<CDTP.Debugger.RestartFrameResponse>;
+    pauseOnAsyncCall(params: CDTP.Debugger.PauseOnAsyncCallRequest): Promise<void>;
+}
+
+@injectable()
+export class CDTPDebugeeSteppingController implements IDebugeeSteppingController {
+    constructor(
+        @inject(TYPES.CDTPClient)
+        protected readonly api: CDTP.ProtocolApi,
+        private readonly _callFrameRegistry: CDTPCallFrameRegistry) {
+    }
+
+    public pauseOnAsyncCall(params: CDTP.Debugger.PauseOnAsyncCallRequest): Promise<void> {
+        return this.api.Debugger.pauseOnAsyncCall(params);
+    }
+
+    public stepOver(): Promise<void> {
+        return this.api.Debugger.stepOver();
+    }
+
+    public stepInto(params: CDTP.Debugger.StepIntoRequest): Promise<void> {
+        return this.api.Debugger.stepInto(params);
+    }
+
+    public stepOut(): Promise<void> {
+        return this.api.Debugger.stepOut();
+    }
+
+    public restartFrame(frame: ScriptCallFrame): Promise<CDTP.Debugger.RestartFrameResponse> {
+        return this.api.Debugger.restartFrame({ callFrameId: this._callFrameRegistry.getFrameId(frame) });
+    }
+}

--- a/src/chrome/cdtpDebuggee/features/cdtpDebuggeeBreakpointsSetter.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpDebuggeeBreakpointsSetter.ts
@@ -1,0 +1,151 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { BPRecipe, IBPRecipe } from '../../internal/breakpoints/bpRecipe';
+import { RangeInScript } from '../../internal/locations/rangeInScript';
+import { Position, LocationInScript } from '../../internal/locations/location';
+import { Protocol as CDTP } from 'devtools-protocol';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { inject, injectable } from 'inversify';
+import { CDTPBreakpointIdsRegistry } from '../registries/cdtpBreakpointIdsRegistry';
+import { asyncMap } from '../../collections/async';
+import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
+import { CDTPLocationParser } from '../protocolParsers/cdtpLocationParser';
+import { CDTPEventsEmitterDiagnosticsModule } from '../infrastructure/cdtpDiagnosticsModule';
+import { CDTPDomainsEnabler } from '../infrastructure/cdtpDomainsEnabler';
+import { CDTPSupportedResources, CDTPSupportedHitActions, CDTPBreakpoint } from '../cdtpPrimitives';
+import { Listeners } from '../../communication/listeners';
+import { IScript } from '../../internal/scripts/script';
+import { IURL, IResourceIdentifier } from '../../internal/sources/resourceIdentifier';
+import { CDTPScriptUrl } from '../../internal/sources/resourceIdentifierSubtypes';
+import { URLRegexp } from '../../internal/locations/subtypes';
+import { MappableBreakpoint, ActualLocation } from '../../internal/breakpoints/breakpoint';
+import { BPRecipeInScript, BPRecipeInUrl, BPRecipeInUrlRegexp, IBPRecipeForRuntimeSource } from '../../internal/breakpoints/BaseMappedBPRecipe';
+import { ConditionalPause } from '../../internal/breakpoints/bpActionWhenHit';
+import { singleElementOfArray } from '../../collections/utilities';
+
+type SetBPInCDTPCall<TResource extends CDTPSupportedResources> = (resource: TResource, position: Position, cdtpConditionField: string) => Promise<CDTP.Debugger.SetBreakpointByUrlResponse>;
+export type OnBreakpointResolvedListener = (breakpoint: CDTPBreakpoint) => void;
+
+export interface IDebuggeeBreakpointsSetter {
+    setBreakpoint(bpRecipe: BPRecipeInScript): Promise<MappableBreakpoint<IScript>>;
+    setBreakpointByUrl(bpRecipe: BPRecipeInUrl): Promise<MappableBreakpoint<IURL<CDTPScriptUrl>>[]>;
+    setBreakpointByUrlRegexp(bpRecipe: BPRecipeInUrlRegexp): Promise<MappableBreakpoint<URLRegexp>[]>;
+    getPossibleBreakpoints(rangeInScript: RangeInScript): Promise<LocationInScript[]>;
+    removeBreakpoint(bpRecipe: IBPRecipe<CDTPSupportedResources>): Promise<void>;
+    onBreakpointResolvedAsync(listener: OnBreakpointResolvedListener): void;
+    onBreakpointResolvedSyncOrAsync(listener: OnBreakpointResolvedListener): void;
+}
+
+@injectable()
+export class CDTPDebuggeeBreakpointsSetter extends CDTPEventsEmitterDiagnosticsModule<CDTP.DebuggerApi, void, CDTP.Debugger.EnableResponse> implements IDebuggeeBreakpointsSetter {
+    protected readonly api = this.protocolApi.Debugger;
+
+    private readonly _cdtpLocationParser = new CDTPLocationParser(this._scriptsRegistry);
+
+    private readonly onBreakpointResolvedSyncOrAsyncListeners = new Listeners<CDTPBreakpoint, void>();
+
+    public readonly onBreakpointResolvedAsync = this.addApiListener('breakpointResolved', async (params: CDTP.Debugger.BreakpointResolvedEvent) => {
+        const bpRecipe = this._breakpointIdRegistry.getRecipeByBreakpointId(params.breakpointId);
+        const breakpoint = new MappableBreakpoint(bpRecipe,
+            await this.toLocationInScript(params.location));
+        return breakpoint;
+    });
+
+    constructor(
+        @inject(TYPES.CDTPClient) protected readonly protocolApi: CDTP.ProtocolApi,
+        @inject(CDTPBreakpointIdsRegistry) private readonly _breakpointIdRegistry: CDTPBreakpointIdsRegistry,
+        @inject(TYPES.CDTPScriptsRegistry) private readonly _scriptsRegistry: CDTPScriptsRegistry,
+        @inject(TYPES.IDomainsEnabler) domainsEnabler: CDTPDomainsEnabler,
+    ) {
+        super(domainsEnabler);
+        this.onBreakpointResolvedAsync(bp => this.onBreakpointResolvedSyncOrAsyncListeners.call(bp));
+    }
+
+    public onBreakpointResolvedSyncOrAsync(listener: (breakpoint: MappableBreakpoint<CDTPSupportedResources>) => void): void {
+        this.onBreakpointResolvedSyncOrAsyncListeners.add(listener);
+    }
+
+    public async setBreakpoint(bpRecipe: BPRecipeInScript): Promise<MappableBreakpoint<IScript>> {
+        const breakpoints = await this.setBreakpointHelper(bpRecipe, async (_resource, _position, cdtpConditionField) => {
+            const response = await this.api.setBreakpoint({ location: this.toCrdpLocation(bpRecipe.location), condition: cdtpConditionField });
+            return { breakpointId: response.breakpointId, locations: [response.actualLocation] };
+        });
+
+        return singleElementOfArray(breakpoints);
+    }
+
+    public async setBreakpointByUrl(bpRecipe: BPRecipeInUrl): Promise<MappableBreakpoint<IURL<CDTPScriptUrl>>[]> {
+        return this.setBreakpointHelper(bpRecipe, (resource, position, cdtpConditionField) =>
+            this.api.setBreakpointByUrl({
+                url: resource.textRepresentation, lineNumber: position.lineNumber,
+                columnNumber: position.columnNumber, condition: cdtpConditionField
+            }));
+    }
+
+    public async setBreakpointByUrlRegexp(bpRecipe: BPRecipeInUrlRegexp): Promise<MappableBreakpoint<URLRegexp>[]> {
+        return this.setBreakpointHelper(bpRecipe, (resource, position, cdtpConditionField) =>
+            this.api.setBreakpointByUrl({
+                urlRegex: resource, lineNumber: position.lineNumber,
+                columnNumber: position.columnNumber, condition: cdtpConditionField
+            }));
+    }
+
+    private async setBreakpointHelper<TResource extends IScript | IResourceIdentifier<CDTPScriptUrl> | URLRegexp, TBPActionWhenHit extends CDTPSupportedHitActions>
+        (bpRecipe: IBPRecipeForRuntimeSource<TResource, TBPActionWhenHit>,
+            setBPInCDTPCall: SetBPInCDTPCall<TResource>): Promise<MappableBreakpoint<TResource>[]> {
+        const cdtpConditionField = this.getCDTPConditionField(bpRecipe);
+        const resource: TResource = bpRecipe.location.resource; // TODO: Figure out why the <TResource> is needed and remove it
+        const position = bpRecipe.location.position;
+
+        const response = await setBPInCDTPCall(resource, position, cdtpConditionField);
+
+        /*
+         * We need to call registerRecipe sync with the response, before any awaits so if we get an event with
+         * a breakpointId we'll be able to resolve it properly
+         */
+        this._breakpointIdRegistry.registerRecipe(response.breakpointId, bpRecipe);
+
+        const breakpoints = await Promise.all(response.locations.map(cdtpLocation => this.toBreakpoinInResource(bpRecipe, cdtpLocation)));
+        breakpoints.forEach(bp => this.onBreakpointResolvedSyncOrAsyncListeners.call(bp));
+        return breakpoints;
+    }
+
+    public async getPossibleBreakpoints(rangeInScript: RangeInScript): Promise<LocationInScript[]> {
+        const response = await this.api.getPossibleBreakpoints({
+            start: this.toCrdpLocation(rangeInScript.start),
+            end: this.toCrdpLocation(rangeInScript.end)
+        });
+
+        return asyncMap(response.locations, async location => await this.toLocationInScript(location));
+    }
+
+    public async removeBreakpoint(bpRecipe: BPRecipe<CDTPSupportedResources>): Promise<void> {
+        await this.api.removeBreakpoint({ breakpointId: this._breakpointIdRegistry.getBreakpointId(bpRecipe) });
+        this._breakpointIdRegistry.unregisterRecipe(bpRecipe);
+    }
+
+    private getCDTPConditionField(bpRecipe: IBPRecipe<CDTPSupportedResources, CDTPSupportedHitActions>): string | undefined {
+        return bpRecipe.bpActionWhenHit instanceof ConditionalPause
+            ? bpRecipe.bpActionWhenHit.expressionOfWhenToPause
+            : undefined;
+    }
+
+    private async toBreakpoinInResource<TResource extends CDTPSupportedResources>(bpRecipe: IBPRecipeForRuntimeSource<TResource, CDTPSupportedHitActions>, actualLocation: CDTP.Debugger.Location): Promise<MappableBreakpoint<TResource>> {
+        const breakpoint = new MappableBreakpoint<TResource>(bpRecipe, <ActualLocation<TResource>>await this.toLocationInScript(actualLocation));
+        return breakpoint;
+    }
+
+    private toCrdpLocation(location: LocationInScript): CDTP.Debugger.Location {
+        return {
+            scriptId: this._scriptsRegistry.getCdtpId(location.script),
+            lineNumber: location.position.lineNumber,
+            columnNumber: location.position.columnNumber
+        };
+    }
+
+    public toLocationInScript(location: CDTP.Debugger.Location): Promise<LocationInScript> {
+        return this._cdtpLocationParser.getLocationInScript(location);
+    }
+}

--- a/src/chrome/cdtpDebuggee/features/cdtpNetworkCacheConfigurer.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpNetworkCacheConfigurer.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Protocol as CDTP } from 'devtools-protocol';
+
+export interface INetworkCacheConfigurer {
+    setCacheDisabled(params: CDTP.Network.SetCacheDisabledRequest): Promise<void>;
+}
+
+export class CDTPNetworkCacheConfigurer implements INetworkCacheConfigurer {
+    constructor(protected api: CDTP.NetworkApi) {
+    }
+
+    public enable(parameters: CDTP.Network.EnableRequest): Promise<void> {
+        return this.api.enable(parameters);
+    }
+
+    public disable(): Promise<void> {
+        return this.api.disable();
+    }
+
+    public setCacheDisabled(params: CDTP.Network.SetCacheDisabledRequest): Promise<void> {
+        return this.api.setCacheDisabled(params);
+    }
+}

--- a/src/chrome/cdtpDebuggee/features/cdtpPauseOnExceptionsConfigurer.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpPauseOnExceptionsConfigurer.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+ import { Protocol as CDTP } from 'devtools-protocol';
+import { IPauseOnExceptionsStrategy, PauseOnAllExceptions, PauseOnUnhandledExceptions, DoNotPauseOnAnyExceptions } from '../../internal/exceptions/strategies';
+import { inject, injectable } from 'inversify';
+import { TYPES } from '../../dependencyInjection.ts/types';
+
+export interface IPauseOnExceptionsConfigurer {
+    setPauseOnExceptions(strategy: IPauseOnExceptionsStrategy): Promise<void>;
+}
+
+export type ExceptionCategories = 'none' | 'uncaught' | 'all';
+
+@injectable()
+export class CDTPPauseOnExceptionsConfigurer implements IPauseOnExceptionsConfigurer {
+    protected readonly api = this._protocolApi.Debugger;
+
+    constructor(
+        @inject(TYPES.CDTPClient)
+        private readonly _protocolApi: CDTP.ProtocolApi) {
+    }
+
+    public setPauseOnExceptions(strategy: IPauseOnExceptionsStrategy): Promise<void> {
+        let state: ExceptionCategories;
+
+        if (strategy instanceof PauseOnAllExceptions) {
+            state = 'all';
+        } else if (strategy instanceof PauseOnUnhandledExceptions) {
+            state = 'uncaught';
+        } else if (strategy instanceof DoNotPauseOnAnyExceptions) {
+            state = 'none';
+        } else {
+            throw new Error(`Can't pause on exception using an unknown strategy ${strategy}`);
+        }
+
+        return this.api.setPauseOnExceptions({ state });
+    }
+}

--- a/src/chrome/cdtpDebuggee/features/cdtpPausedOverlayConfigurer.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpPausedOverlayConfigurer.ts
@@ -12,7 +12,9 @@ export interface IPausedOverlayConfigurer {
     setPausedInDebuggerMessage(params: CDTP.Overlay.SetPausedInDebuggerMessageRequest): Promise<void>;
 }
 
-// TODO: Move this to a browser shared package
+/**
+ * TODO: Move this to a browser shared package
+ */
 export class CDTPPausedOverlayConfigurer extends CDTPEnableableDiagnosticsModule<CDTP.OverlayApi> implements IPausedOverlayConfigurer {
     protected readonly api = this._protocolApi.Overlay;
 

--- a/src/chrome/cdtpDebuggee/features/cdtpPausedOverlayConfigurer.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpPausedOverlayConfigurer.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { CDTPEnableableDiagnosticsModule } from '../infrastructure/cdtpDiagnosticsModule';
+import { Protocol as CDTP } from 'devtools-protocol';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { inject } from 'inversify';
+import { CDTPDomainsEnabler } from '../infrastructure/cdtpDomainsEnabler';
+
+export interface IPausedOverlayConfigurer {
+    setPausedInDebuggerMessage(params: CDTP.Overlay.SetPausedInDebuggerMessageRequest): Promise<void>;
+}
+
+// TODO: Move this to a browser shared package
+export class CDTPPausedOverlayConfigurer extends CDTPEnableableDiagnosticsModule<CDTP.OverlayApi> implements IPausedOverlayConfigurer {
+    protected readonly api = this._protocolApi.Overlay;
+
+    constructor(
+        @inject(TYPES.CDTPClient) private readonly _protocolApi: CDTP.ProtocolApi,
+        @inject(TYPES.IDomainsEnabler) domainsEnabler: CDTPDomainsEnabler, ) {
+        super(domainsEnabler);
+    }
+
+    public setPausedInDebuggerMessage(params: CDTP.Overlay.SetPausedInDebuggerMessageRequest): Promise<void> {
+        return this.api.setPausedInDebuggerMessage(params);
+    }
+}

--- a/src/chrome/cdtpDebuggee/features/cdtpRuntimeStarter.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpRuntimeStarter.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+ import { Protocol as CDTP } from 'devtools-protocol';
+
+export interface IRuntimeStarter {
+    runIfWaitingForDebugger(): Promise<void>;
+}
+
+export class CDTPRuntimeStarter implements IRuntimeStarter {
+    constructor(
+        protected readonly api: CDTP.RuntimeApi) {
+    }
+
+    public async runIfWaitingForDebugger(): Promise<void> {
+        // This is a CDTP version difference which will have to be handled more elegantly with others later...
+        // For now, we need to send both messages and ignore a failing one.
+        try {
+            await Promise.all([
+                this.api.runIfWaitingForDebugger(),
+                (this.api as any).run()
+            ]);
+        } catch (exception) {
+            // TODO: Make sure that at least one of the two calls succeeded
+            // Ignore the failed call
+        }
+    }
+}

--- a/src/chrome/cdtpDebuggee/features/cdtpSchemaProvider.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpSchemaProvider.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+ import { Protocol as CDTP } from 'devtools-protocol';
+
+export class CDTPSchemaProvider {
+    constructor(protected api: CDTP.SchemaApi) { }
+
+    public async getDomains(): Promise<CDTP.Schema.Domain[]> {
+        return (await this.api.getDomains()).domains;
+    }
+}

--- a/src/chrome/cdtpDebuggee/features/cdtpScriptSourcesRetriever.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpScriptSourcesRetriever.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+ import { Protocol as CDTP } from 'devtools-protocol';
+import { IScript } from '../../internal/scripts/script';
+import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
+import { inject, injectable } from 'inversify';
+import { TYPES } from '../../dependencyInjection.ts/types';
+
+export interface IScriptSourcesRetriever {
+    getScriptSource(script: IScript): Promise<string>;
+}
+
+@injectable()
+export class CDTPScriptSourcesRetriever implements IScriptSourcesRetriever {
+    protected readonly api = this._protocolApi.Debugger;
+
+    constructor(
+        @inject(TYPES.CDTPClient)
+        private readonly _protocolApi: CDTP.ProtocolApi,
+        @inject(TYPES.CDTPScriptsRegistry)
+        private readonly _scriptsRegistry: CDTPScriptsRegistry) {
+    }
+
+    public async getScriptSource(script: IScript): Promise<string> {
+        return (await this.api.getScriptSource({ scriptId: this._scriptsRegistry.getCdtpId(script) })).scriptSource;
+    }
+}

--- a/src/chrome/cdtpDebuggee/infrastructure/cdtpDiagnosticsModule.ts
+++ b/src/chrome/cdtpDebuggee/infrastructure/cdtpDiagnosticsModule.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { TransformedListenerRegistry } from '../../communication/transformedListenerRegistry';
+import { PromiseOrNot } from '../../utils/promises';
+import { injectable } from 'inversify';
+import { CDTPDomainsEnabler } from './cdtpDomainsEnabler';
+
+export interface IEnableableApi<EnableParameters = void, EnableResponse = void> {
+    enable(parameters: EnableParameters): Promise<EnableResponse>;
+    on(eventName: string, listener: Function): void;
+}
+
+@injectable()
+export abstract class CDTPEnableableDiagnosticsModule<T extends IEnableableApi<EnableParameters, EnableResponse>, EnableParameters = void, EnableResponse = void> {
+    protected abstract get api(): T;
+
+    public enable(): EnableParameters extends void ? Promise<EnableResponse> : never;
+    public enable(parameters: EnableParameters): Promise<EnableResponse>;
+    public async enable(parameters?: EnableParameters): Promise<EnableResponse> {
+        return await this._domainsEnabler.registerToEnable<T, EnableParameters, EnableResponse>(this.api, parameters);
+    }
+
+    constructor(private readonly _domainsEnabler: CDTPDomainsEnabler) { }
+}
+
+@injectable()
+export abstract class CDTPEventsEmitterDiagnosticsModule<T extends {} & IEnableableApi<EnableParameters, EnableResponse>, EnableParameters = void, EnableResponse = void>
+    extends CDTPEnableableDiagnosticsModule<T, EnableParameters, EnableResponse> {
+    public addApiListener<O, T>(eventName: string, transformation: (params: O) => PromiseOrNot<T>): (transformedListener: ((params: T) => void)) => void {
+
+        const transformedListenerRegistryPromise = new TransformedListenerRegistry<O, T>(this.constructor.name, async originalListener => {
+            this.api.on(eventName, originalListener);
+        }, transformation).install();
+
+        this.enable(); // The domain will be enabled eventually (Assuming this happens during the startup/initial configuration phase). We don't block on it.
+
+        return async transformedListener => (await transformedListenerRegistryPromise).registerListener(transformedListener);
+    }
+}

--- a/src/chrome/cdtpDebuggee/infrastructure/cdtpDiagnosticsModule.ts
+++ b/src/chrome/cdtpDebuggee/infrastructure/cdtpDiagnosticsModule.ts
@@ -16,13 +16,13 @@ export interface IEnableableApi<EnableParameters = void, EnableResponse = void> 
 export abstract class CDTPEnableableDiagnosticsModule<T extends IEnableableApi<EnableParameters, EnableResponse>, EnableParameters = void, EnableResponse = void> {
     protected abstract get api(): T;
 
+    constructor(private readonly _domainsEnabler: CDTPDomainsEnabler) { }
+
     public enable(): EnableParameters extends void ? Promise<EnableResponse> : never;
     public enable(parameters: EnableParameters): Promise<EnableResponse>;
     public async enable(parameters?: EnableParameters): Promise<EnableResponse> {
         return await this._domainsEnabler.registerToEnable<T, EnableParameters, EnableResponse>(this.api, parameters);
     }
-
-    constructor(private readonly _domainsEnabler: CDTPDomainsEnabler) { }
 }
 
 @injectable()

--- a/src/chrome/cdtpDebuggee/infrastructure/cdtpDomainsEnabler.ts
+++ b/src/chrome/cdtpDebuggee/infrastructure/cdtpDomainsEnabler.ts
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+ import { IEnableableApi } from './cdtpDiagnosticsModule';
+import { Protocol as CDTP } from 'devtools-protocol';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { inject, injectable } from 'inversify';
+import * as utils from '../../../utils';
+import { asyncMap } from '../../collections/async';
+import { ValidatedMap } from '../../collections/validatedMap';
+import * as _ from 'lodash';
+
+export interface IDomainsEnabler {
+    registerToEnable<T extends IEnableableApi<EnableParameters, EnableResponse>, EnableParameters, EnableResponse>
+        (api: T, parameters: EnableParameters): Promise<EnableResponse>;
+
+    enableDomains(): Promise<void>;
+}
+
+interface IState {
+    registerToEnable<T extends IEnableableApi<EnableParameters, EnableResponse>, EnableParameters, EnableResponse>
+        (api: T, parameters: EnableParameters): Promise<EnableResponse>;
+    enableDomains(): Promise<IState>;
+}
+
+class EnableDomainFunctionAndResultPromise<EnableResponse> {
+    constructor(
+        public readonly enableDomain: () => Promise<EnableResponse>,
+        public readonly parameters: unknown,
+        public readonly defer: utils.IPromiseDefer<EnableResponse>,
+    ) { }
+}
+
+class GatheringDomainsToEnableDuringStartup implements IState {
+    private readonly _registeredDomains = new ValidatedMap<IEnableableApi<unknown, unknown>, EnableDomainFunctionAndResultPromise<any>>();
+
+    public async enableDomains(): Promise<IState> {
+        const entries = Array.from(this._registeredDomains.entries());
+        await asyncMap(entries, async pair => this.executeEnable(pair[0], pair[1]));
+        return new DomainsAlreadyEnabledAfterStartup();
+    }
+
+    public async executeEnable(domain: IEnableableApi<unknown, unknown>, extras: EnableDomainFunctionAndResultPromise<any>): Promise<void> {
+        await this.verifyPrerequisitesAreMet(domain);
+
+        try {
+            extras.defer.resolve(extras.enableDomain());
+        } catch (exception) {
+            extras.defer.reject(exception);
+        }
+    }
+
+    public async verifyPrerequisitesAreMet(domain: IEnableableApi<unknown, unknown>): Promise<void> {
+        if (domain !== this.protocolApi.Runtime) {
+            // TODO: For the time being we assume that all domains require the Runtime domain to be enabled. Figure out if this can be improved
+            await this._registeredDomains.get(this.protocolApi.Runtime).defer.promise;
+        }
+    }
+
+    public async registerToEnable<T extends IEnableableApi<EnableParameters, EnableResponse>, EnableParameters, EnableResponse>
+        (api: T, parameters: EnableParameters): Promise<EnableResponse> {
+        const enableDomain = () => api.enable(parameters);
+
+        const entry = this._registeredDomains.getOrAdd(api, () =>
+            new EnableDomainFunctionAndResultPromise(enableDomain, parameters, utils.promiseDefer<EnableResponse>()));
+
+        if (entry.parameters !== parameters) {
+            throw new Error(`Cannot register enable(${parameters}) for domain ${this.getDomainName(api)} because it was registered previously with enable(${entry.parameters})`);
+        }
+
+        return await entry.defer.promise;
+    }
+
+    private getDomainName(api: IEnableableApi<unknown, unknown>): string {
+        return _.findKey(this.protocolApi, api);
+    }
+
+    constructor(@inject(TYPES.CDTPClient) protected readonly protocolApi: CDTP.ProtocolApi) { }
+}
+
+class DomainsAlreadyEnabledAfterStartup implements IState {
+    public registerToEnable<T extends IEnableableApi<EnableParameters, EnableResponse>, EnableParameters, EnableResponse>
+        (api: T, parameters: EnableParameters): Promise<EnableResponse> {
+        return api.enable(parameters);
+    }
+
+    public enableDomains(): Promise<IState> {
+        throw new Error('Startup was already finished');
+    }
+}
+
+@injectable()
+export class CDTPDomainsEnabler implements IDomainsEnabler {
+    private _state: IState = new GatheringDomainsToEnableDuringStartup(this._protocolApi);
+
+    public registerToEnable<T extends IEnableableApi<EnableParameters, EnableResponse>, EnableParameters, EnableResponse>
+        (api: T, parameters: EnableParameters): Promise<EnableResponse> {
+        return this._state.registerToEnable(api, parameters);
+    }
+
+    public async enableDomains(): Promise<void> {
+        this._state = await this._state.enableDomains();
+    }
+
+    constructor(@inject(TYPES.CDTPClient) private readonly _protocolApi: CDTP.ProtocolApi) { }
+}

--- a/src/chrome/cdtpDebuggee/protocolParsers/cdtpLocationParser.ts
+++ b/src/chrome/cdtpDebuggee/protocolParsers/cdtpLocationParser.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Position, LocationInScript } from '../../internal/locations/location';
+import { createColumnNumber, createLineNumber } from '../../internal/locations/subtypes';
+import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
+import { Protocol as CDTP } from 'devtools-protocol';
+
+interface IHasCoordinates {
+    lineNumber: number;
+    columnNumber?: number;
+}
+
+interface IHasScript {
+    scriptId: CDTP.Runtime.ScriptId;
+}
+
+export interface IHasScriptLocation extends IHasCoordinates, IHasScript { }
+
+export class CDTPLocationParser {
+    public async getLocationInScript(crdpObjectWithScriptLocation: IHasScriptLocation): Promise<LocationInScript> {
+        return new LocationInScript(await this._scriptsRegistry.getScriptByCdtpId(crdpObjectWithScriptLocation.scriptId),
+            this.getCoordinates(crdpObjectWithScriptLocation));
+    }
+
+    private getCoordinates(crdpObjectWithCoordinates: IHasCoordinates): Position {
+        return new Position(createLineNumber(crdpObjectWithCoordinates.lineNumber), createColumnNumber(crdpObjectWithCoordinates.columnNumber));
+    }
+
+    constructor(private _scriptsRegistry: CDTPScriptsRegistry) { }
+}

--- a/src/chrome/cdtpDebuggee/protocolParsers/cdtpLocationParser.ts
+++ b/src/chrome/cdtpDebuggee/protocolParsers/cdtpLocationParser.ts
@@ -19,6 +19,8 @@ interface IHasScript {
 export interface IHasScriptLocation extends IHasCoordinates, IHasScript { }
 
 export class CDTPLocationParser {
+    constructor(private _scriptsRegistry: CDTPScriptsRegistry) { }
+
     public async getLocationInScript(crdpObjectWithScriptLocation: IHasScriptLocation): Promise<LocationInScript> {
         return new LocationInScript(await this._scriptsRegistry.getScriptByCdtpId(crdpObjectWithScriptLocation.scriptId),
             this.getCoordinates(crdpObjectWithScriptLocation));
@@ -27,6 +29,4 @@ export class CDTPLocationParser {
     private getCoordinates(crdpObjectWithCoordinates: IHasCoordinates): Position {
         return new Position(createLineNumber(crdpObjectWithCoordinates.lineNumber), createColumnNumber(crdpObjectWithCoordinates.columnNumber));
     }
-
-    constructor(private _scriptsRegistry: CDTPScriptsRegistry) { }
 }

--- a/src/chrome/cdtpDebuggee/protocolParsers/cdtpStackTraceParser.ts
+++ b/src/chrome/cdtpDebuggee/protocolParsers/cdtpStackTraceParser.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+ import { Protocol as CDTP } from 'devtools-protocol';
+
+import { IScript, } from '../../internal/scripts/script';
+import { CodeFlowStackTrace } from '../../internal/stackTraces/codeFlowStackTrace';
+import { CodeFlowFrame } from '../../internal/stackTraces/callFrame';
+import { CDTPLocationParser, IHasScriptLocation } from './cdtpLocationParser';
+import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
+import { asyncMap } from '../../collections/async';
+
+export class CDTPStackTraceParser {
+    private readonly _cdtpLocationParser = new CDTPLocationParser(this._scriptsRegistry);
+
+    public async toStackTraceCodeFlow(stackTrace: CDTP.Runtime.StackTrace): Promise<CodeFlowStackTrace> {
+        return {
+            codeFlowFrames: await asyncMap(stackTrace.callFrames, (callFrame, index) => this.runtimeCallFrameToCodeFlowFrame(index, callFrame)),
+            description: stackTrace.description,
+            parent: stackTrace.parent && await this.toStackTraceCodeFlow(stackTrace.parent)
+        };
+    }
+
+    private runtimeCallFrameToCodeFlowFrame(index: number, callFrame: CDTP.Runtime.CallFrame): Promise<CodeFlowFrame<IScript>> {
+        return this.toCodeFlowFrame(index, callFrame, callFrame);
+    }
+
+    public async toCodeFlowFrame(index: number, callFrame: CDTP.Runtime.CallFrame | CDTP.Debugger.CallFrame, location: IHasScriptLocation): Promise<CodeFlowFrame<IScript>> {
+        const scriptLocation = await this._cdtpLocationParser.getLocationInScript(location);
+        return new CodeFlowFrame(index, callFrame.functionName, scriptLocation);
+    }
+
+    constructor(private _scriptsRegistry: CDTPScriptsRegistry) { }
+}

--- a/src/chrome/cdtpDebuggee/protocolParsers/cdtpStackTraceParser.ts
+++ b/src/chrome/cdtpDebuggee/protocolParsers/cdtpStackTraceParser.ts
@@ -14,6 +14,8 @@ import { asyncMap } from '../../collections/async';
 export class CDTPStackTraceParser {
     private readonly _cdtpLocationParser = new CDTPLocationParser(this._scriptsRegistry);
 
+    constructor(private _scriptsRegistry: CDTPScriptsRegistry) { }
+
     public async toStackTraceCodeFlow(stackTrace: CDTP.Runtime.StackTrace): Promise<CodeFlowStackTrace> {
         return {
             codeFlowFrames: await asyncMap(stackTrace.callFrames, (callFrame, index) => this.runtimeCallFrameToCodeFlowFrame(index, callFrame)),
@@ -30,6 +32,4 @@ export class CDTPStackTraceParser {
         const scriptLocation = await this._cdtpLocationParser.getLocationInScript(location);
         return new CodeFlowFrame(index, callFrame.functionName, scriptLocation);
     }
-
-    constructor(private _scriptsRegistry: CDTPScriptsRegistry) { }
 }

--- a/src/chrome/cdtpDebuggee/registries/cdtpBreakpointIdsRegistry.ts
+++ b/src/chrome/cdtpDebuggee/registries/cdtpBreakpointIdsRegistry.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+ import { BidirectionalMap } from '../../collections/bidirectionalMap';
+import { Protocol as CDTP } from 'devtools-protocol';
+import { injectable } from 'inversify';
+import { CDTPBPRecipe } from '../cdtpPrimitives';
+
+@injectable()
+export class CDTPBreakpointIdsRegistry {
+    // TODO DIEGO: Figure out how to handle if two breakpoint rules set a breakpoint in the same location so it ends up being the same breakpoint id
+    private readonly _recipeToBreakpointId = new BidirectionalMap<CDTPBPRecipe, CDTP.Debugger.BreakpointId>();
+
+    public registerRecipe(cdtpBreakpointId: CDTP.Debugger.BreakpointId, bpRecipe: CDTPBPRecipe): void {
+        this._recipeToBreakpointId.set(bpRecipe, cdtpBreakpointId);
+    }
+
+    public unregisterRecipe(bpRecipe: CDTPBPRecipe): void {
+        this._recipeToBreakpointId.deleteByLeft(bpRecipe);
+    }
+
+    public getBreakpointId(bpRecipe: CDTPBPRecipe): CDTP.Debugger.BreakpointId {
+        return this._recipeToBreakpointId.getByLeft(bpRecipe);
+    }
+
+    public getRecipeByBreakpointId(cdtpBreakpointId: CDTP.Debugger.BreakpointId): CDTPBPRecipe {
+        return this._recipeToBreakpointId.getByRight(cdtpBreakpointId);
+    }
+
+    public toString(): string {
+        return `Breakpoint IDs: ${this._recipeToBreakpointId}`;
+    }
+}

--- a/src/chrome/cdtpDebuggee/registries/cdtpCallFrameRegistry.ts
+++ b/src/chrome/cdtpDebuggee/registries/cdtpCallFrameRegistry.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+ import { Protocol as CDTP } from 'devtools-protocol';
+import { ValidatedMap } from '../../collections/validatedMap';
+import { ScriptCallFrame } from '../../internal/stackTraces/callFrame';
+import { injectable } from 'inversify';
+
+@injectable()
+export class CDTPCallFrameRegistry {
+    private readonly _callFrameToId = new ValidatedMap<ScriptCallFrame, CDTP.Debugger.CallFrameId>();
+
+    public registerFrameId(callFrameId: CDTP.Debugger.CallFrameId, frame: ScriptCallFrame): void {
+        this._callFrameToId.set(frame, callFrameId);
+    }
+
+    public getFrameId(frame: ScriptCallFrame): CDTP.Debugger.CallFrameId {
+        return this._callFrameToId.get(frame);
+    }
+}

--- a/src/chrome/cdtpDebuggee/registries/cdtpScriptsRegistry.ts
+++ b/src/chrome/cdtpDebuggee/registries/cdtpScriptsRegistry.ts
@@ -1,0 +1,105 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+ import { Protocol as CDTP } from 'devtools-protocol';
+import { IScript } from '../../internal/scripts/script';
+import { ValidatedMap } from '../../collections/validatedMap';
+import { ExecutionContext, IExecutionContext } from '../../internal/scripts/executionContext';
+import { injectable } from 'inversify';
+import { IResourceIdentifier, newResourceIdentifierMap } from '../../internal/sources/resourceIdentifier';
+import { FrameId } from '../cdtpPrimitives';
+
+/**
+ * TODO: The CDTPScriptsRegistry is still a work in progress. We need to understand exactly how the ExecutionContexts, the Scripts, and the script "generations" work to figure out the best way to implement this
+ * Is ExecutionContext == Generation? Or is a Generation a set of ExecutionContexts?
+ */
+
+@injectable()
+export class CDTPScriptsRegistry {
+    private readonly _idToExecutionContext = new ValidatedMap<CDTP.Runtime.ExecutionContextId, ExecutionContext>();
+    private readonly _scripts = new CDTPCurrentGeneration();
+
+    public registerExecutionContext(executionContextId: CDTP.Runtime.ExecutionContextId, frameId: FrameId): IExecutionContext {
+        const executionContext = new ExecutionContext(frameId);
+        this._idToExecutionContext.set(executionContextId, executionContext);
+        return executionContext;
+    }
+
+    public markExecutionContextAsDestroyed(executionContextId: CDTP.Runtime.ExecutionContextId): IExecutionContext {
+        const executionContext = this._idToExecutionContext.get(executionContextId);
+        executionContext.markAsDestroyed();
+        return executionContext;
+    }
+
+    public getExecutionContextById(executionContextId: CDTP.Runtime.ExecutionContextId): IExecutionContext {
+        return this._idToExecutionContext.get(executionContextId);
+    }
+
+    public registerScript(scriptId: CDTP.Runtime.ScriptId, obtainScript: () => Promise<IScript>): Promise<IScript> {
+        return this._scripts.registerNewScript(scriptId, obtainScript);
+    }
+
+    public getCdtpId(script: IScript): any {
+        return this._scripts.getCdtpId(script);
+    }
+
+    public getScriptByCdtpId(runtimeScriptCrdpId: CDTP.Runtime.ScriptId): Promise<IScript> {
+        return this._scripts.getScriptByCdtpId(runtimeScriptCrdpId);
+    }
+
+    public getAllScripts(): IterableIterator<Promise<IScript>> {
+        return this._scripts.getAllScripts();
+    }
+
+    public getScriptsByPath(nameOrLocation: IResourceIdentifier): IScript[] {
+        return this._scripts.getScriptByPath(nameOrLocation);
+    }
+}
+
+class CDTPCurrentGeneration {
+    // We use these two maps instead of a bidirectional map because we need to map an ID to a Promise instead of a script, to avoid having race conditions...
+    private readonly _cdtpIdByScript = new ValidatedMap<CDTP.Runtime.ScriptId, Promise<IScript>>();
+    private readonly _scriptByCdtpId = new ValidatedMap<IScript, CDTP.Runtime.ScriptId>();
+    private readonly _scriptByPath = newResourceIdentifierMap<IScript[]>();
+
+    public async registerNewScript(scriptId: CDTP.Runtime.ScriptId, obtainScript: () => Promise<IScript>): Promise<IScript> {
+        const scriptWithConfigurationPromise = obtainScript().then(script => {
+            /**
+             * We need to configure the script here, so we can guarantee that clients who try to use a script will get
+             * blocked until the script is created, and all the initial configuration is done, so they can use APIs to get
+             * the script id, search by URL, etc...
+             */
+            this.createScriptInitialConfiguration(scriptId, script);
+            return script;
+        });
+
+        this._cdtpIdByScript.set(scriptId, scriptWithConfigurationPromise);
+
+        return await scriptWithConfigurationPromise;
+    }
+
+    private createScriptInitialConfiguration(scriptId: CDTP.Runtime.ScriptId, script: IScript): void {
+        this._scriptByCdtpId.set(script, scriptId);
+
+        let scriptsWithSamePath = this._scriptByPath.getOrAdd(script.runtimeSource.identifier, () => []);
+        scriptsWithSamePath.push(script);
+    }
+
+    public getCdtpId(script: IScript): CDTP.Runtime.ScriptId {
+        return this._scriptByCdtpId.get(script);
+    }
+
+    public getScriptByCdtpId(runtimeScriptCrdpId: string): Promise<IScript> {
+        return this._cdtpIdByScript.get(runtimeScriptCrdpId);
+    }
+
+    public getAllScripts(): IterableIterator<Promise<IScript>> {
+        return this._cdtpIdByScript.values();
+    }
+
+    public getScriptByPath(path: IResourceIdentifier): IScript[] {
+        const runtimeScript = this._scriptByPath.tryGetting(path);
+        return runtimeScript || [];
+    }
+}

--- a/src/chrome/cdtpDebuggee/registries/loadedSourcesRegistry.ts
+++ b/src/chrome/cdtpDebuggee/registries/loadedSourcesRegistry.ts
@@ -1,0 +1,38 @@
+import { newResourceIdentifierMap, IResourceIdentifier } from '../../internal/sources/resourceIdentifier';
+import { ICurrentScriptRelationshipsProvider, IScriptMapper } from '../../internal/sources/loadedSource';
+import { IdentifiedLoadedSource, ScriptMapper } from '../../internal/sources/identifiedLoadedSource';
+import { CDTPScriptUrl } from '../../internal/sources/resourceIdentifierSubtypes';
+import { ValidatedMultiMap } from '../../collections/validatedMultiMap';
+import { ILoadedSourceToScriptRelationship } from '../../internal/sources/loadedSourceToScriptRelationship';
+import { injectable } from 'inversify';
+
+@injectable()
+export class LoadedSourcesRegistry implements ICurrentScriptRelationshipsProvider {
+    // TODO: Figure out a way to store IdentifiedLoadedSource<CDTPScriptUrl> and IdentifiedLoadedSource<string> in a single map while preserving type safety
+    private readonly _loadedSourceByPath = newResourceIdentifierMap<IdentifiedLoadedSource>();
+
+    private readonly _loadedSourceToCurrentScriptRelationships = new ValidatedMultiMap<IdentifiedLoadedSource, ILoadedSourceToScriptRelationship>();
+
+    public getOrAdd(pathOrUrl: IResourceIdentifier,
+        obtainValueToAdd: (provider: ICurrentScriptRelationshipsProvider) => IdentifiedLoadedSource): IdentifiedLoadedSource {
+        // TODO: The casts in this method are actually false sometimes (Although they won't cause any issues at runtime). Figure out a way of doing this with type safety
+        const url = <IResourceIdentifier<CDTPScriptUrl>><unknown>pathOrUrl;
+        return <IdentifiedLoadedSource>this._loadedSourceByPath.getOrAdd(url, () => {
+            const newLoadedSource = obtainValueToAdd(this);
+            this._loadedSourceToCurrentScriptRelationships.addKeyIfNotExistant(newLoadedSource);
+            return newLoadedSource;
+        });
+    }
+
+    public registerRelationship(loadedSource: IdentifiedLoadedSource, relationship: ILoadedSourceToScriptRelationship) {
+        this._loadedSourceToCurrentScriptRelationships.add(loadedSource, relationship);
+    }
+
+    public scriptMapper(loadedSource: IdentifiedLoadedSource<string>): IScriptMapper {
+        return new ScriptMapper(Array.from(this._loadedSourceToCurrentScriptRelationships.get(loadedSource)));
+    }
+
+    public toString(): string {
+        return `Loaded sources: ${this._loadedSourceByPath}\nRelationships:\n${this._loadedSourceToCurrentScriptRelationships}`;
+    }
+}

--- a/src/chrome/communication/transformedListenerRegistry.ts
+++ b/src/chrome/communication/transformedListenerRegistry.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Listeners } from './listeners';
+import { PromiseOrNot } from '../utils/promises';
+
+export class TransformedListenerRegistry<O, T> {
+    private readonly _transformedListeners = new Listeners<T, void>();
+
+    public registerListener(transformedListener: (params: T) => void) {
+        this._transformedListeners.add(transformedListener);
+    }
+
+    public async install(): Promise<this> {
+        await this._registerOriginalListener(async originalParameters => {
+            const transformedParameters = await this._transformation(originalParameters);
+            return this._transformedListeners.call(transformedParameters);
+        });
+        return this;
+    }
+
+    constructor(
+        public readonly _description: string, // This description is only used for debugging purposes
+        private readonly _registerOriginalListener: (originalListener: (originalParameters: O) => void) => PromiseOrNot<void>,
+        private readonly _transformation: (originalParameters: O) => PromiseOrNot<T>) {
+    }
+}

--- a/src/chrome/communication/transformedListenerRegistry.ts
+++ b/src/chrome/communication/transformedListenerRegistry.ts
@@ -8,6 +8,12 @@ import { PromiseOrNot } from '../utils/promises';
 export class TransformedListenerRegistry<O, T> {
     private readonly _transformedListeners = new Listeners<T, void>();
 
+    constructor(
+        public readonly _description: string, // This description is only used for debugging purposes
+        private readonly _registerOriginalListener: (originalListener: (originalParameters: O) => void) => PromiseOrNot<void>,
+        private readonly _transformation: (originalParameters: O) => PromiseOrNot<T>) {
+    }
+
     public registerListener(transformedListener: (params: T) => void) {
         this._transformedListeners.add(transformedListener);
     }
@@ -18,11 +24,5 @@ export class TransformedListenerRegistry<O, T> {
             return this._transformedListeners.call(transformedParameters);
         });
         return this;
-    }
-
-    constructor(
-        public readonly _description: string, // This description is only used for debugging purposes
-        private readonly _registerOriginalListener: (originalListener: (originalParameters: O) => void) => PromiseOrNot<void>,
-        private readonly _transformation: (originalParameters: O) => PromiseOrNot<T>) {
     }
 }

--- a/src/chrome/internal/exceptions/strategies.ts
+++ b/src/chrome/internal/exceptions/strategies.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+export interface IPauseOnExceptionsStrategy {
+
+}
+
+export class PauseOnUnhandledExceptions implements IPauseOnExceptionsStrategy { }
+export class PauseOnAllExceptions implements IPauseOnExceptionsStrategy { }
+export class DoNotPauseOnAnyExceptions implements IPauseOnExceptionsStrategy { }
+
+export interface IPauseOnPromiseRejectionsStrategy {
+    shouldPauseOnRejections(): boolean;
+}
+
+export class PauseOnAllRejections implements IPauseOnPromiseRejectionsStrategy {
+    public shouldPauseOnRejections(): boolean {
+        return true;
+    }
+}
+
+export class DoNotPauseOnAnyRejections implements IPauseOnPromiseRejectionsStrategy {
+    public shouldPauseOnRejections(): boolean {
+        return false;
+    }
+}

--- a/src/chrome/internal/locations/location.ts
+++ b/src/chrome/internal/locations/location.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------*/
 
 import * as Validation from '../../../validation';
-import * as utils from '../../../utils';
 import { IScript, Script } from '../scripts/script';
 import { ISource, isSource } from '../sources/source';
 import { ILoadedSource, isLoadedSource } from '../sources/loadedSource';

--- a/src/chrome/internal/scripts/executionContext.ts
+++ b/src/chrome/internal/scripts/executionContext.ts
@@ -1,6 +1,4 @@
-// TODO: Remove next line and use the import instead
-type FrameId = number;
-// import { FrameId } from '../../cdtpDebuggee/cdtpPrimitives';
+import { FrameId } from '../../cdtpDebuggee/cdtpPrimitives';
 
 /*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.

--- a/src/chrome/internal/sources/source.ts
+++ b/src/chrome/internal/sources/source.ts
@@ -36,7 +36,9 @@ abstract class BaseSource implements ISource {
     }
 }
 
-// Find the related source by using the source's path
+/**
+ * Find the related source by using the source's path
+ */
 export class SourceToBeResolvedViaPath extends BaseSource implements ISource {
     public tryResolving<R>(succesfulAction: (resolvedSource: ILoadedSource) => R, failedAction: (sourceIdentifier: IResourceIdentifier) => R) {
         return this._sourceResolver.tryResolving(this.sourceIdentifier, succesfulAction, failedAction);
@@ -51,7 +53,9 @@ export class SourceToBeResolvedViaPath extends BaseSource implements ISource {
     }
 }
 
-// This source was already loaded, so we store it in this class
+/**
+ * This source was already loaded, so we store it in this class
+ */
 export class SourceAlreadyResolvedToLoadedSource extends BaseSource implements ISource {
     public tryResolving<R>(succesfulAction: (resolvedSource: ILoadedSource) => R, _failedAction: (sourceIdentifier: IResourceIdentifier) => R) {
         return succesfulAction(this.loadedSource);

--- a/src/chrome/internal/stackTraces/stackTracePresentationRow.ts
+++ b/src/chrome/internal/stackTraces/stackTracePresentationRow.ts
@@ -4,12 +4,16 @@
 
 export type CallFramePresentationHint = 'normal' | 'label' | 'subtle';
 
-// Row of a stack trace that we send to the client
+/**
+ * Row of a stack trace that we send to the client
+ */
 export interface IStackTracePresentationRow {
     readonly presentationHint?: CallFramePresentationHint;
 }
 
-// Row of a stack trace that is a label e.g.: [Show more frames] or [Frames skipped by smartStep], etc...
+/**
+ * Row of a stack trace that is a label e.g.: [Show more frames] or [Frames skipped by smartStep], etc...
+ */
 export class StackTraceLabel implements IStackTracePresentationRow {
     public readonly presentationHint = 'label';
 

--- a/src/sourceMaps/sourceMaps.ts
+++ b/src/sourceMaps/sourceMaps.ts
@@ -69,11 +69,14 @@ export class SourceMaps {
     /**
      * Given a new path to a new script file, finds and loads the sourcemap for that file
      */
-    public async processNewSourceMap(pathToGenerated: string, sourceMapURL: string, isVSClient = false): Promise<void> {
+    public async processNewSourceMap(pathToGenerated: string, sourceMapURL: string, isVSClient = false): Promise<SourceMap> {
         const sourceMap = await this._sourceMapFactory.getMapForGeneratedPath(pathToGenerated, sourceMapURL, isVSClient);
         if (sourceMap) {
             this._generatedPathToSourceMap.set(pathToGenerated.toLowerCase(), sourceMap);
             sourceMap.authoredSources.forEach(authoredSource => this._authoredPathToSourceMap.set(authoredSource.toLowerCase(), sourceMap));
+            return sourceMap;
+        } else {
+            return null;
         }
     }
 }

--- a/src/transformers/baseSourceMapTransformer.ts
+++ b/src/transformers/baseSourceMapTransformer.ts
@@ -2,19 +2,19 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import * as path from 'path';
 import { DebugProtocol } from 'vscode-debugprotocol';
 
-import { ISetBreakpointsArgs, ILaunchRequestArgs, IAttachRequestArgs,
-    ISetBreakpointsResponseBody, IInternalStackTraceResponseBody, IScopesResponseBody, IInternalStackFrame } from '../debugAdapterInterfaces';
-import { MappedPosition, ISourcePathDetails } from '../sourceMaps/sourceMap';
+import { ILaunchRequestArgs, IAttachRequestArgs,
+    ISetBreakpointsResponseBody, IScopesResponseBody } from '../debugAdapterInterfaces';
+import { MappedPosition, ISourcePathDetails, SourceMap } from '../sourceMaps/sourceMap';
 import { SourceMaps } from '../sourceMaps/sourceMaps';
-import * as utils from '../utils';
 import { logger } from 'vscode-debugadapter';
-import { ISourceContainer } from '../chrome/chromeDebugAdapter';
 
-import * as nls from 'vscode-nls';
-const localize = nls.loadMessageBundle();
+import { ILoadedSource } from '../chrome/internal/sources/loadedSource';
+import { IComponent } from '../chrome/internal/features/feature';
+import { TYPES } from '../chrome/dependencyInjection.ts/types';
+// import { injectable, inject } from 'inversify';
+import { inject } from 'inversify';
 
 interface ISavedSetBreakpointsArgs {
     generatedPath: string;
@@ -23,24 +23,27 @@ interface ISavedSetBreakpointsArgs {
 }
 
 export interface ISourceLocation {
-    source: DebugProtocol.Source;
+    source: ILoadedSource;
     line: number;
     column: number;
     isSourceMapped?: boolean; // compat with stack frame
 }
 
+// TODO: Remove Configuration and use IConnectedCDAConfiguration instead
+interface Configuration {
+     args: ILaunchRequestArgs | IAttachRequestArgs;
+     _clientCapabilities: {clientID: string};
+}
+
 /**
  * If sourcemaps are enabled, converts from source files on the client side to runtime files on the target side
  */
-export class BaseSourceMapTransformer {
+export class BaseSourceMapTransformer implements IComponent {
     protected _sourceMaps: SourceMaps;
-    protected _sourceHandles: utils.ReverseHandles<ISourceContainer>;
     private _enableSourceMapCaching: boolean;
 
     private _requestSeqToSetBreakpointsArgs: Map<number, ISavedSetBreakpointsArgs>;
     private _allRuntimeScriptPaths: Set<string>;
-    private _authoredPathsToMappedBPs: Map<string, DebugProtocol.SourceBreakpoint[]>;
-    private _authoredPathsToClientBreakpointIds: Map<string, number[]>;
 
     protected _preLoad = Promise.resolve();
     private _processingNewSourceMap: Promise<any> = Promise.resolve();
@@ -49,8 +52,14 @@ export class BaseSourceMapTransformer {
 
     protected _isVSClient = false;
 
-    constructor(sourceHandles: utils.ReverseHandles<ISourceContainer>) {
-        this._sourceHandles = sourceHandles;
+    constructor(@inject(TYPES.ConnectedCDAConfiguration) configuration: Configuration) {
+        this._enableSourceMapCaching = configuration.args.enableSourceMapCaching;
+        this.init(configuration.args);
+        this.isVSClient = configuration._clientCapabilities.clientID === 'visualstudio';
+    }
+
+    public install(_configuration: Configuration): this {
+        return this;
     }
 
     public get sourceMaps(): SourceMaps {
@@ -61,115 +70,19 @@ export class BaseSourceMapTransformer {
         this._isVSClient = newValue;
     }
 
-    public launch(args: ILaunchRequestArgs): void {
-        this.init(args);
-    }
-
-    public attach(args: IAttachRequestArgs): void {
-        this.init(args);
-    }
-
     protected init(args: ILaunchRequestArgs | IAttachRequestArgs): void {
-        if (args.sourceMaps) {
+        // Enable sourcemaps and async callstacks by default
+        const areSourceMapsEnabled = typeof args.sourceMaps === 'undefined' || args.sourceMaps;
+        if (areSourceMapsEnabled) {
             this._enableSourceMapCaching = args.enableSourceMapCaching;
             this._sourceMaps = new SourceMaps(args.pathMapping, args.sourceMapPathOverrides, this._enableSourceMapCaching);
             this._requestSeqToSetBreakpointsArgs = new Map<number, ISavedSetBreakpointsArgs>();
             this._allRuntimeScriptPaths = new Set<string>();
-            this._authoredPathsToMappedBPs = new Map<string, DebugProtocol.SourceBreakpoint[]>();
-            this._authoredPathsToClientBreakpointIds = new Map<string, number[]>();
         }
     }
 
     public clearTargetContext(): void {
         this._allRuntimeScriptPaths = new Set<string>();
-    }
-
-    /**
-     * Apply sourcemapping to the setBreakpoints request path/lines.
-     * Returns true if completed successfully, and setBreakpoint should continue.
-     */
-    public setBreakpoints(args: ISetBreakpointsArgs, requestSeq: number, ids?: number[]): { args: ISetBreakpointsArgs, ids: number[] } {
-        if (!this._sourceMaps) {
-            return { args, ids };
-        }
-
-        const originalBPs = JSON.parse(JSON.stringify(args.breakpoints));
-
-        if (args.source.sourceReference) {
-            // If the source contents were inlined, then args.source has no path, but we
-            // stored it in the handle
-            const handle = this._sourceHandles.get(args.source.sourceReference);
-            if (handle && handle.mappedPath) {
-                args.source.path = handle.mappedPath;
-            }
-        }
-
-        if (args.source.path) {
-            const argsPath = args.source.path;
-            const mappedPath = this._sourceMaps.getGeneratedPathFromAuthoredPath(argsPath);
-            if (mappedPath) {
-                logger.log(`SourceMaps.setBP: Mapped ${argsPath} to ${mappedPath}`);
-                args.authoredPath = argsPath;
-                args.source.path = mappedPath;
-
-                // DebugProtocol doesn't send cols yet, but they need to be added from sourcemaps
-                args.breakpoints.forEach(bp => {
-                    const { line, column = 0 } = bp;
-                    const mapped = this._sourceMaps.mapToGenerated(argsPath, line, column);
-                    if (mapped) {
-                        logger.log(`SourceMaps.setBP: Mapped ${argsPath}:${line + 1}:${column + 1} to ${mappedPath}:${mapped.line + 1}:${mapped.column + 1}`);
-                        bp.line = mapped.line;
-                        bp.column = mapped.column;
-                    } else {
-                        logger.log(`SourceMaps.setBP: Mapped ${argsPath} but not line ${line + 1}, column 1`);
-                        bp.column = column; // take 0 default if needed
-                    }
-                });
-
-                this._authoredPathsToMappedBPs.set(argsPath, args.breakpoints);
-
-                // Store the client breakpoint Ids for the mapped BPs as well
-                if (ids) {
-                    this._authoredPathsToClientBreakpointIds.set(argsPath, ids);
-                }
-
-                // Include BPs from other files that map to the same file. Ensure the current file's breakpoints go first
-                this._sourceMaps.allMappedSources(mappedPath).forEach(sourcePath => {
-                    if (sourcePath === argsPath) {
-                        return;
-                    }
-
-                    const sourceBPs = this._authoredPathsToMappedBPs.get(sourcePath);
-                    if (sourceBPs) {
-                        // Don't modify the cached array
-                        args.breakpoints = args.breakpoints.concat(sourceBPs);
-
-                        // We need to assign the client IDs we generated for the mapped breakpoints becuase the runtime IDs may change
-                        // So make sure we concat the client ids to the ids array so that they get mapped to the respective breakpoints later
-                        const clientBreakpointIds = this._authoredPathsToClientBreakpointIds.get(sourcePath);
-                        if (ids) {
-                            ids = ids.concat(clientBreakpointIds);
-                        }
-                    }
-                });
-            } else if (this.isRuntimeScript(argsPath)) {
-                // It's a generated file which is loaded
-                logger.log(`SourceMaps.setBP: SourceMaps are enabled but ${argsPath} is a runtime script`);
-            } else {
-                // Source (or generated) file which is not loaded.
-                logger.log(`SourceMaps.setBP: ${argsPath} can't be resolved to a loaded script. It may just not be loaded yet.`);
-            }
-        } else {
-            // No source.path
-        }
-
-        this._requestSeqToSetBreakpointsArgs.set(requestSeq, {
-            originalBPs,
-            authoredPath: args.authoredPath,
-            generatedPath: args.source.path
-        });
-
-        return { args, ids };
     }
 
     /**
@@ -200,67 +113,7 @@ export class BaseSourceMapTransformer {
         }
     }
 
-    /**
-     * Apply sourcemapping to the stacktrace response
-     */
-    public async stackTraceResponse(response: IInternalStackTraceResponseBody): Promise<void> {
-        if (this._sourceMaps) {
-            await this._processingNewSourceMap;
-            for (let stackFrame of response.stackFrames) {
-                await this.fixSourceLocation(stackFrame);
-            }
-        }
-    }
-
-    public async fixSourceLocation(sourceLocation: ISourceLocation|IInternalStackFrame): Promise<void> {
-        if (!this._sourceMaps) {
-            return;
-        }
-
-        if (!sourceLocation.source) {
-            return;
-        }
-
-        await this._processingNewSourceMap;
-
-        const mapped = this._sourceMaps.mapToAuthored(sourceLocation.source.path, sourceLocation.line, sourceLocation.column);
-        if (mapped && utils.existsSync(mapped.source)) {
-            // Script was mapped to a valid path
-            sourceLocation.source.path = mapped.source;
-            sourceLocation.source.sourceReference = undefined;
-            sourceLocation.source.name = path.basename(mapped.source);
-            sourceLocation.line = mapped.line;
-            sourceLocation.column = mapped.column;
-            sourceLocation.isSourceMapped = true;
-        } else {
-            const inlinedSource = mapped && this._sourceMaps.sourceContentFor(mapped.source);
-            if (mapped && inlinedSource) {
-                // Clear the path and set the sourceReference - the client will ask for
-                // the source later and it will be returned from the sourcemap
-                sourceLocation.source.name = path.basename(mapped.source);
-                sourceLocation.source.path = mapped.source;
-                sourceLocation.source.sourceReference = this.getSourceReferenceForScriptPath(mapped.source, inlinedSource);
-                sourceLocation.source.origin = localize('origin.inlined.source.map', 'read-only inlined content from source map');
-                sourceLocation.line = mapped.line;
-                sourceLocation.column = mapped.column;
-                sourceLocation.isSourceMapped = true;
-            } else if (utils.existsSync(sourceLocation.source.path)) {
-                // Script could not be mapped, but does exist on disk. Keep it and clear the sourceReference.
-                sourceLocation.source.sourceReference = undefined;
-                sourceLocation.source.origin = undefined;
-            }
-        }
-    }
-
-    /**
-     * Get the existing handle for this script, identified by runtime scriptId, or create a new one
-     */
-    private getSourceReferenceForScriptPath(mappedPath: string, contents: string): number {
-        return this._sourceHandles.lookupF(container => container.mappedPath === mappedPath) ||
-            this._sourceHandles.create({ contents, mappedPath });
-    }
-
-    public async scriptParsed(pathToGenerated: string, sourceMapURL: string): Promise<string[]> {
+    public async scriptParsed(pathToGenerated: string, sourceMapURL: string | undefined): Promise<SourceMap> {
         if (this._sourceMaps) {
             this._allRuntimeScriptPaths.add(this.fixPathCasing(pathToGenerated));
 
@@ -274,9 +127,11 @@ export class BaseSourceMapTransformer {
             const sources = this._sourceMaps.allMappedSources(pathToGenerated);
             if (sources) {
                 logger.log(`SourceMaps.scriptParsed: ${pathToGenerated} was just loaded and has mapped sources: ${JSON.stringify(sources) }`);
+            } else {
+                logger.log(`No SourceMaps.scriptParsed: ${pathToGenerated} was just loaded and doesn't have any mapped sources at url: ${sourceMapURL}`);
             }
 
-            return sources;
+            return processNewSourceMapP;
         } else {
             return null;
         }

--- a/src/transformers/eagerSourceMapTransformer.ts
+++ b/src/transformers/eagerSourceMapTransformer.ts
@@ -9,6 +9,7 @@ import { BaseSourceMapTransformer } from './baseSourceMapTransformer';
 import { ILaunchRequestArgs, IAttachRequestArgs } from '../debugAdapterInterfaces';
 import * as utils from '../utils';
 import { logger } from 'vscode-debugadapter';
+import { SourceMap } from '../sourceMaps/sourceMap';
 
 /**
  * Load SourceMaps on launch. Requires reading the file and parsing out the sourceMappingURL, because
@@ -41,7 +42,7 @@ export class EagerSourceMapTransformer extends BaseSourceMapTransformer {
         }
     }
 
-    private discoverSourceMapForGeneratedScript(generatedScriptPath: string): Promise<void> {
+    private discoverSourceMapForGeneratedScript(generatedScriptPath: string): Promise<void | SourceMap> {
         return this.findSourceMapUrlInFile(generatedScriptPath)
             .then(uri => {
                 if (uri) {


### PR DESCRIPTION
CDTP Debuggee model: This model converts the objects and information we get from CDTP back and forth to the internal model that we use in the rest of the debugger. It's also responsible for keeping track of the internal CDTP Ids (breakpoint id, execution context id, etc...).

src/chrome/cdtpDebuggee/eventsProviders/*: Classes to subscribe to CDTP events
src/chrome/cdtpDebuggee/features/*: Classes that expose the capabilities that CDTP provides
src/chrome/cdtpDebuggee/infrastructure/*: Infrastructure used to implement the classes in eventProviders or features
src/chrome/cdtpDebuggee/protocolParsers/*: Parses information in CDTP json format and transforms it into the internal model.
src/chrome/cdtpDebuggee/registries/*: Stores of information. Most of them associate an internal model with a CDTP id.

Note:
src\chrome\chromeDebugAdapter.ts doesn't compile after this changes. After we merge all the changes from the private branch, chromeDebugAdapter.ts will compile again.