### PR TITLE
Client Model

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -95,7 +95,11 @@ function doBuild(buildNls, failOnError) {
         });
 }
 
-gulp.task('build', ['clean'], () => {
+gulp.task('clean', () => {
+    return del(['out', 'lib']);
+});
+
+gulp.task('build', gulp.series('clean'), () => {
     return doBuild(true, true);
 });
 
@@ -103,16 +107,12 @@ gulp.task('_dev-build', () => {
     return doBuild(false, false);
 });
 
-gulp.task('clean', () => {
-    return del(['out', 'lib']);
-});
-
-gulp.task('watch', ['clean'], () => {
+gulp.task('watch', gulp.series('clean'), () => {
     log('Watching build sources...');
     return runSequence('_dev-build', () => gulp.watch(sources, ['_dev-build']));
 });
 
-gulp.task('default', ['build']);
+gulp.task('default', gulp.series('build'));
 
 gulp.task('tslint', () => {
       return gulp.src(lintSources, { base: '.' })
@@ -120,13 +120,13 @@ gulp.task('tslint', () => {
         .pipe(tslint.report());
 });
 
-gulp.task('transifex-push', ['build'], function () {
+gulp.task('transifex-push', gulp.series('build'), function () {
     return gulp.src(['out/nls.metadata.header.json', 'out/nls.metadata.json'])
         .pipe(nls.createXlfFiles(transifexProjectName, transifexExtensionName))
         .pipe(nls.pushXlfFiles(transifexApiHostname, transifexApiName, transifexApiToken));
 });
 
-gulp.task('transifex-push-test', ['build'], function () {
+gulp.task('transifex-push-test', gulp.series('build'), function () {
     return gulp.src(['out/nls.metadata.header.json', 'out/nls.metadata.json'])
         .pipe(nls.createXlfFiles(transifexProjectName, transifexExtensionName))
         .pipe(gulp.dest(path.join('..', `${transifexExtensionName}-push-test`)));

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -2976,3 +2976,10 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
         this._committedBreakpointsByUrl.set(canonicalizedUrl, value);
     }
 }
+
+// TODO: Placeholder until we can merge the real class
+export class ChromeDebugLogic {
+    public disconnect(): void {}
+    public shutdown(): void {}
+    public install(): void {}
+}

--- a/src/chrome/client/chromeDebugAdapter/cdaConfiguration.ts
+++ b/src/chrome/client/chromeDebugAdapter/cdaConfiguration.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { IExtensibilityPoints } from '../../extensibility/extensibilityPoints';
+import { IClientCapabilities, ILaunchRequestArgs, IAttachRequestArgs } from '../../../debugAdapterInterfaces';
+import { ChromeConnection } from '../../chromeConnection';
+import { ILoggingConfiguration } from '../../internal/services/logging';
+import { ScenarioType } from './unconnectedCDA';
+import { injectable } from 'inversify';
+import { ISession } from '../session';
+import * as utils from '../../../utils';
+
+export interface IConnectedCDAConfiguration {
+    args: ILaunchRequestArgs | IAttachRequestArgs;
+    isVSClient: boolean;
+    extensibilityPoints: IExtensibilityPoints;
+    loggingConfiguration: ILoggingConfiguration;
+    session: ISession;
+    clientCapabilities: IClientCapabilities;
+    chromeConnectionClass: typeof ChromeConnection;
+    scenarioType: ScenarioType;
+}
+
+@injectable()
+export class ConnectedCDAConfiguration implements IConnectedCDAConfiguration {
+    public readonly args: ILaunchRequestArgs | IAttachRequestArgs;
+
+    public readonly isVSClient = this.clientCapabilities.clientID === 'visualstudio';
+
+    constructor(
+        public readonly extensibilityPoints: IExtensibilityPoints,
+        public readonly loggingConfiguration: ILoggingConfiguration,
+        public readonly session: ISession,
+        public readonly clientCapabilities: IClientCapabilities,
+        public readonly chromeConnectionClass: typeof ChromeConnection,
+        public readonly scenarioType: ScenarioType,
+        private readonly originalArgs: ILaunchRequestArgs | IAttachRequestArgs) {
+        this.args = this.extensibilityPoints.updateArguments(this.originalArgs);
+
+        if (this.args.pathMapping) {
+            for (const urlToMap in this.args.pathMapping) {
+                this.args.pathMapping[urlToMap] = utils.canonicalizeUrl(this.args.pathMapping[urlToMap]);
+            }
+        }
+    }
+}

--- a/src/chrome/client/chromeDebugAdapter/chromeDebugAdapterV2.ts
+++ b/src/chrome/client/chromeDebugAdapter/chromeDebugAdapterV2.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+import { DebugProtocol } from 'vscode-debugprotocol';
+import { ChromeDebugSession, IChromeDebugSessionOpts } from '../../chromeDebugSession';
+import { ChromeConnection } from '../../chromeConnection';
+import { StepProgressEventsEmitter, IObservableEvents, IStepStartedEventsEmitter, IFinishedStartingUpEventsEmitter } from '../../../executionTimingsReporter';
+import { UninitializedCDA } from './uninitializedCDA';
+import { IDebugAdapter, IDebugAdapterState, ITelemetryPropertyCollector } from '../../../debugAdapterInterfaces';
+import { CommandText } from '../requests';
+
+export class ChromeDebugAdapter implements IDebugAdapter, IObservableEvents<IStepStartedEventsEmitter & IFinishedStartingUpEventsEmitter>{
+    public readonly events = new StepProgressEventsEmitter();
+    private _state: IDebugAdapterState;
+
+    constructor(args: IChromeDebugSessionOpts, originalSession: ChromeDebugSession) {
+        this._state = new UninitializedCDA(args.extensibilityPoints, originalSession, args.extensibilityPoints.chromeConnection || ChromeConnection);
+    }
+
+    public async processRequest(requestName: CommandText, args: unknown, telemetryPropertyCollector: ITelemetryPropertyCollector): Promise<unknown> {
+        const response = await this._state.processRequest(requestName, args, telemetryPropertyCollector);
+        switch (requestName) {
+            case 'initialize':
+                const { capabilities, newState } = <{ capabilities: DebugProtocol.Capabilities, newState: IDebugAdapterState }>response;
+                this._state = newState;
+                return capabilities;
+            case 'launch':
+            case 'attach':
+                this._state = <IDebugAdapterState>response;
+                return {};
+            default:
+                // For all other messages where the state doesn't change, we don't need to do anything
+                return response;
+        }
+    }
+}

--- a/src/chrome/client/chromeDebugAdapter/connectedCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/connectedCDA.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { inject, injectable, multiInject } from 'inversify';
+import { ChromeDebugLogic } from '../../chromeDebugAdapter';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { ValidatedMap } from '../../collections/validatedMap';
+import { CommandText } from '../requests';
+import { RequestHandler, ICommandHandlerDeclarer } from '../../internal/features/components';
+
+@injectable()
+export class ConnectedCDA {
+    public static SCRIPTS_COMMAND = '.scripts';
+
+    private readonly _requestNameToHandler = new ValidatedMap<CommandText, RequestHandler>();
+
+    constructor(
+        @inject(TYPES.ChromeDebugLogic) private readonly _chromeDebugAdapter: ChromeDebugLogic,
+        @multiInject(TYPES.ICommandHandlerDeclarer) private readonly _requestHandlerDeclarers: ICommandHandlerDeclarer[]
+    ) { }
+
+    public async processRequest(requestName: CommandText, args: unknown): Promise<unknown> {
+        switch (requestName) {
+            case 'initialize':
+                throw new Error('The debug adapter is already initialized. Calling initialize again is not supported.');
+            case 'launch':
+            case 'attach':
+                throw new Error("Can't launch or attach to a new target while connected to a previous target");
+            default:
+                return this._requestNameToHandler.get(requestName).call('Process request has no this', args);
+        }
+    }
+
+    public async install(): Promise<this> {
+        for (const requestHandlerDeclarer of this._requestHandlerDeclarers) {
+            for (const requestHandlerDeclaration of await requestHandlerDeclarer.getCommandHandlerDeclarations()) {
+                this._requestNameToHandler.set(requestHandlerDeclaration.commandName, requestHandlerDeclaration.commandHandler);
+            }
+        }
+
+        await this._chromeDebugAdapter.install();
+
+        return this;
+    }
+}

--- a/src/chrome/client/chromeDebugAdapter/unconnectedCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/unconnectedCDA.ts
@@ -1,0 +1,140 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import Uri from 'vscode-uri';
+import * as path from 'path';
+import * as errors from '../../../errors';
+import * as utils from '../../../utils';
+import { InitializedEvent, Logger } from 'vscode-debugadapter';
+import { IClientCapabilities, IDebugAdapterState, ILaunchRequestArgs, ITelemetryPropertyCollector, IAttachRequestArgs } from '../../../debugAdapterInterfaces';
+import { ChromeConnection } from '../../chromeConnection';
+import { DependencyInjection } from '../../dependencyInjection.ts/di';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { IExtensibilityPoints } from '../../extensibility/extensibilityPoints';
+import { Logging, ILoggingConfiguration } from '../../internal/services/logging';
+import { DelayMessagesUntilInitializedSession } from '../delayMessagesUntilInitializedSession';
+import { DoNotPauseWhileSteppingSession } from '../doNotPauseWhileSteppingSession';
+import { ConnectedCDAConfiguration } from './cdaConfiguration';
+import { ConnectedCDA } from './connectedCDA';
+import { IDebuggeeLauncher } from '../../debugeeStartup/debugeeLauncher';
+import { IDomainsEnabler } from '../../cdtpDebuggee/infrastructure/cdtpDomainsEnabler';
+import { MethodsCalledLoggerConfiguration, ReplacementInstruction } from '../../logging/methodsCalledLogger';
+import { ChromeDebugSession } from '../../chromeDebugSession';
+import { CommandText } from '../requests';
+
+export enum ScenarioType {
+    Launch,
+    Attach
+}
+
+// TODO: This file needs a lot of work. We need to improve/simplify all this code when possible
+
+export class UnconnectedCDA implements IDebugAdapterState {
+    private readonly _session = new DelayMessagesUntilInitializedSession(new DoNotPauseWhileSteppingSession(this._basicSession));
+
+    constructor(
+        private readonly _extensibilityPoints: IExtensibilityPoints,
+        private readonly _basicSession: ChromeDebugSession,
+        private readonly _clientCapabilities: IClientCapabilities,
+        private readonly _chromeConnectionClass: typeof ChromeConnection
+    ) {
+    }
+
+    public processRequest(requestName: CommandText, args: unknown, telemetryPropertyCollector?: ITelemetryPropertyCollector): Promise<unknown> {
+        switch (requestName) {
+            case 'launch':
+                return this.launch(<ILaunchRequestArgs>args, telemetryPropertyCollector);
+            case 'attach':
+                return this.attach(<IAttachRequestArgs>args, telemetryPropertyCollector);
+            default:
+                throw new Error(`The unconnected debug adapter is not prepared to respond to the request ${requestName}`);
+        }
+    }
+
+    public async launch(args: ILaunchRequestArgs, telemetryPropertyCollector?: ITelemetryPropertyCollector, _requestSeq?: number): Promise<IDebugAdapterState> {
+        return this.createConnection(ScenarioType.Launch, args, telemetryPropertyCollector);
+    }
+
+    public async attach(args: IAttachRequestArgs, telemetryPropertyCollector?: ITelemetryPropertyCollector, _requestSeq?: number): Promise<IDebugAdapterState> {
+        const updatedArgs = Object.assign({}, { port: 9229 }, args);
+        return this.createConnection(ScenarioType.Attach, updatedArgs, telemetryPropertyCollector);
+    }
+
+    private parseLoggingConfiguration(args: ILaunchRequestArgs | IAttachRequestArgs): ILoggingConfiguration {
+        const traceMapping: { [key: string]: Logger.LogLevel | undefined } = { true: Logger.LogLevel.Warn, verbose: Logger.LogLevel.Verbose };
+        const traceValue = args.trace && traceMapping[args.trace.toString().toLowerCase()];
+        return { logLevel: traceValue, logFilePath: args.logFilePath, shouldLogTimestamps: args.logTimestamps };
+    }
+
+    private async createConnection(scenarioType: ScenarioType, args: ILaunchRequestArgs | IAttachRequestArgs, telemetryPropertyCollector?: ITelemetryPropertyCollector): Promise<IDebugAdapterState> {
+        if (this._clientCapabilities.pathFormat !== 'path') {
+            throw errors.pathFormat();
+        }
+
+        utils.setCaseSensitivePaths(this._clientCapabilities.clientID !== 'visualstudio'); // TODO: Find a way to remove this
+
+        const di = new DependencyInjection(this._extensibilityPoints.componentCustomizationCallback);
+        const logging = new Logging().install(this._extensibilityPoints, this.parseLoggingConfiguration(args));
+        di.configureValue(TYPES.ILogger, logging);
+
+        const chromeConnection = new (this._chromeConnectionClass)(undefined, args.targetFilter || this._extensibilityPoints.targetFilter);
+
+        const diContainer = this.getDIContainer(di, chromeConnection, args, scenarioType);
+
+        const debugeeLauncher = diContainer.createComponent<IDebuggeeLauncher>(TYPES.IDebuggeeLauncher);
+
+        diContainer.unconfigure(TYPES.IDebuggeeLauncher); // TODO: Remove this line and do this properly
+        diContainer.configureValue(TYPES.IDebuggeeLauncher, debugeeLauncher); // TODO: Remove this line and do this properly
+
+        const result = await debugeeLauncher.launch(args, telemetryPropertyCollector);
+        await chromeConnection.attach(result.address, result.port, result.url, args.timeout, args.extraCRDPChannelPort);
+
+        if (chromeConnection.api === undefined) {
+            throw new Error('Expected the Chrome API object to be properly initialized by now');
+        }
+
+        diContainer.configureValue(TYPES.ChromeConnection, chromeConnection);
+        diContainer.configureValue(TYPES.CDTPClient, chromeConnection.api);
+
+        const newState = di.createClassWithDI<ConnectedCDA>(ConnectedCDA);
+        await newState.install();
+
+        const domainsEnabler = di.createComponent<IDomainsEnabler>(TYPES.IDomainsEnabler);
+        await domainsEnabler.enableDomains(); // Enables all the domains that were registered
+        await chromeConnection.api.Runtime.runIfWaitingForDebugger();
+
+        this._session.sendEvent(new InitializedEvent());
+
+        return newState;
+    }
+
+    private getDIContainer(diContainer: DependencyInjection, chromeConnection: ChromeConnection, args: ILaunchRequestArgs | IAttachRequestArgs, scenarioType: ScenarioType): DependencyInjection {
+        const configuration = this.createConfiguration(args, scenarioType);
+        const workspace = args.pathMapping['/'];
+        const workspaceRegexp = utils.pathToRegex(workspace);
+        const replacements = [
+            new ReplacementInstruction(new RegExp(workspaceRegexp, 'gi'), '%ws%'),
+        ];
+        const chromeUrl = (<any>args).url;
+        if (chromeUrl) {
+            replacements.push(new ReplacementInstruction(new RegExp((<any>args).url, 'gi'), '%url%'));
+            const uri = Uri.parse(chromeUrl);
+            const websitePath = path.dirname(uri.path);
+            const websiteNoSeparator = websitePath[websitePath.length] === '/' ? websitePath.substr(0, -1) : websitePath;
+            const website = uri.with({ path: websiteNoSeparator, query: '' }).toString();
+            replacements.push(new ReplacementInstruction(new RegExp(website, 'gi'), '%website%'));
+        }
+        const loggingConfiguration = new MethodsCalledLoggerConfiguration(replacements);
+        return diContainer
+            .bindAll(loggingConfiguration)
+            .configureClass(TYPES.IDebugeeRunner, this._extensibilityPoints.debugeeRunner)
+            .configureClass(TYPES.IDebuggeeLauncher, this._extensibilityPoints.debugeeLauncher)
+            .configureValue(TYPES.ISession, this._session)
+            .configureValue(TYPES.ConnectedCDAConfiguration, configuration);
+    }
+
+    private createConfiguration(args: ILaunchRequestArgs | IAttachRequestArgs, scenarioType: ScenarioType): ConnectedCDAConfiguration {
+        return new ConnectedCDAConfiguration(this._extensibilityPoints, this.parseLoggingConfiguration(args), this._session, this._clientCapabilities, this._chromeConnectionClass, scenarioType, args);
+    }
+}

--- a/src/chrome/client/chromeDebugAdapter/uninitializedCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/uninitializedCDA.ts
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as nls from 'vscode-nls';
+import { ChromeConnection } from '../../chromeConnection';
+import { DebugProtocol } from 'vscode-debugprotocol';
+import { UnconnectedCDA } from './unconnectedCDA';
+import { IExtensibilityPoints } from '../../extensibility/extensibilityPoints';
+import { ChromeDebugSession } from '../../chromeDebugSession';
+import { CommandText } from '../requests';
+import { IDebugAdapterState, IInitializeRequestArgs, ITelemetryPropertyCollector } from '../../../debugAdapterInterfaces';
+let localize = nls.loadMessageBundle(); // Initialize to an unlocalized version until we know which locale to use
+
+export class UninitializedCDA implements IDebugAdapterState {
+    constructor(
+        private readonly _extensibilityPoints: IExtensibilityPoints,
+        private readonly _session: ChromeDebugSession,
+        private readonly _chromeConnectionClass: typeof ChromeConnection
+    ) {
+    }
+
+    public processRequest(requestName: CommandText, args: unknown, telemetryPropertyCollector?: ITelemetryPropertyCollector): Promise<unknown> {
+        switch (requestName) {
+            case 'initialize':
+                return this.initialize(<IInitializeRequestArgs>args, telemetryPropertyCollector);
+            default:
+                throw new Error(`The uninitialized debug adapter is not prepared to respond to the request ${requestName}`);
+        }
+    }
+
+    public async initialize(args: IInitializeRequestArgs, _telemetryPropertyCollector?: ITelemetryPropertyCollector, _requestSeq?: number): Promise<{ capabilities: DebugProtocol.Capabilities, newState: IDebugAdapterState }> {
+        if (args.locale) {
+            localize = nls.config({ locale: args.locale })(); // Replace with the proper locale
+        }
+
+        const exceptionBreakpointFilters = [
+            {
+                label: localize('exceptions.all', 'All Exceptions'),
+                filter: 'all',
+                default: false
+            },
+            {
+                label: localize('exceptions.uncaught', 'Uncaught Exceptions'),
+                filter: 'uncaught',
+                default: false
+            }
+        ];
+
+        if (this._extensibilityPoints.isPromiseRejectExceptionFilterEnabled) {
+            exceptionBreakpointFilters.push({
+                label: localize('exceptions.promise_rejects', 'Promise Rejects'),
+                filter: 'promise_reject',
+                default: false
+            });
+        }
+
+        // This debug adapter supports two exception breakpoint filters
+        const capabilities = {
+            exceptionBreakpointFilters,
+            supportsConfigurationDoneRequest: true,
+            supportsSetVariable: true,
+            supportsConditionalBreakpoints: true,
+            supportsCompletionsRequest: true,
+            supportsHitConditionalBreakpoints: true,
+            supportsRestartFrame: true,
+            supportsExceptionInfoRequest: true,
+            supportsDelayedStackTraceLoading: true,
+            supportsValueFormattingOptions: true,
+            supportsEvaluateForHovers: true,
+            supportsLoadedSourcesRequest: true
+        };
+
+        const newState = new UnconnectedCDA(this._extensibilityPoints, this._session, args, this._chromeConnectionClass);
+        return { capabilities, newState };
+    }
+}

--- a/src/chrome/client/clientLifecycleRequestsHandler.ts
+++ b/src/chrome/client/clientLifecycleRequestsHandler.ts
@@ -1,0 +1,30 @@
+import { TelemetryPropertyCollector } from '../../telemetry';
+import { inject, injectable } from 'inversify';
+import { TYPES } from '../dependencyInjection.ts/types';
+import { ChromeDebugLogic } from '../chromeDebugAdapter';
+import { IDebuggeeRunner } from '../debugeeStartup/debugeeLauncher';
+import { StepProgressEventsEmitter } from '../../executionTimingsReporter';
+import { ICommandHandlerDeclarer, ICommandHandlerDeclaration, CommandHandlerDeclaration } from '../internal/features/components';
+
+@injectable()
+export class ClientLifecycleRequestsHandler implements ICommandHandlerDeclarer {
+    private readonly events = new StepProgressEventsEmitter();
+
+    constructor(
+        @inject(TYPES.ChromeDebugLogic) protected readonly _chromeDebugAdapter: ChromeDebugLogic,
+        @inject(TYPES.IDebugeeRunner) public readonly _debugeeRunner: IDebuggeeRunner,
+    ) {
+    }
+
+    public getCommandHandlerDeclarations(): ICommandHandlerDeclaration[] {
+        return CommandHandlerDeclaration.fromLiteralObject({
+            configurationDone: () => this.configurationDone(),
+            shutdown: () => this._chromeDebugAdapter.shutdown(),
+            disconnect: () => this._chromeDebugAdapter.disconnect(),
+        });
+    }
+    public async configurationDone(): Promise<void> {
+        await this._debugeeRunner.run(new TelemetryPropertyCollector());
+        this.events.emitMilestoneReached('RequestedNavigateToUserPage'); // TODO DIEGO: Make sure this is reported
+    }
+}

--- a/src/chrome/client/delayMessagesUntilInitializedSession.ts
+++ b/src/chrome/client/delayMessagesUntilInitializedSession.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { DebugProtocol } from 'vscode-debugprotocol';
+import { InitializedEvent } from 'vscode-debugadapter';
+import { BaseWrappedSession } from './session';
+
+export class DelayMessagesUntilInitializedSession extends BaseWrappedSession {
+    private _hasSentInitializedMessage = false;
+    private _eventsWaitingInitialization: DebugProtocol.Event[] = [];
+
+    public sendEvent(event: DebugProtocol.Event): void {
+        if (this._hasSentInitializedMessage) {
+            super.sendEvent(event);
+        } else if (event instanceof InitializedEvent) {
+            this._wrappedSession.sendEvent(event);
+            this._hasSentInitializedMessage = true;
+            this._eventsWaitingInitialization.forEach(storedEvent =>
+                this._wrappedSession.sendEvent(storedEvent));
+            this._eventsWaitingInitialization = [];
+        } else {
+            this._eventsWaitingInitialization.push(event);
+        }
+    }
+}

--- a/src/chrome/client/doNotPauseWhileSteppingSession.ts
+++ b/src/chrome/client/doNotPauseWhileSteppingSession.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as utils from '../../utils';
+import { BaseWrappedSession } from './session';
+import { DebugProtocol } from 'vscode-debugprotocol';
+
+const steppingRequests = {
+    continue: true,
+    next: true,
+    stepIn: true,
+    stepOut: true,
+    pause: true,
+    restartFrame: true,
+};
+
+export class DoNotPauseWhileSteppingSession extends BaseWrappedSession {
+    private readonly _onFlightSteppingRequests = new Set<Promise<void>>();
+
+    public async dispatchRequest(request: DebugProtocol.Request): Promise<void> {
+        const response = this._wrappedSession.dispatchRequest(request);
+        if (this.isSteppingRequest(request)) {
+            // We track the on-flight stepping requests
+            this._onFlightSteppingRequests.add(response);
+            const finallyHandler = () => { this._onFlightSteppingRequests.delete(response); };
+            return response.then(finallyHandler, finallyHandler);
+        } else {
+            return await response;
+        }
+    }
+
+    public async sendEvent(event: DebugProtocol.Event): Promise<void> {
+        if (event.event === 'stopped') {
+            // If this is a stopped event, we try to wait until there are no stepping requests in flight, or we timeout
+            await utils.promiseTimeout(this.waitUntilThereAreNoOnFlightSteppingRequests(), /*timeoutMs=*/300);
+        }
+
+        this._wrappedSession.sendEvent(event);
+    }
+
+    private isSteppingRequest(request: DebugProtocol.Request): boolean {
+        return !!(steppingRequests as any)[request.command];
+    }
+
+    private async waitUntilThereAreNoOnFlightSteppingRequests(): Promise<void> {
+        while (this._onFlightSteppingRequests.size > 0) {
+            const onFlightRequests = Array.from(this._onFlightSteppingRequests.keys());
+            const noFailOnFlightRequests = onFlightRequests.map(promise => promise.catch(_ => { }));
+            await Promise.all(noFailOnFlightRequests);
+            // After we waited for all the on flight requests, a new request might just have appeared, so we check and wait again if needed
+        }
+    }
+}

--- a/src/chrome/client/handlesRegistry.ts
+++ b/src/chrome/client/handlesRegistry.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { ILoadedSource } from '../internal/sources/loadedSource';
+import { IBPRecipe } from '../internal/breakpoints/bpRecipe';
+import { BidirectionalMap } from '../collections/bidirectionalMap';
+import { injectable } from 'inversify';
+import { IStackTracePresentationRow } from '../internal/stackTraces/stackTracePresentationRow';
+import { ISource } from '../internal/sources/source';
+
+export class BidirectionalHandles<T> {
+    private readonly _idToObject = new BidirectionalMap<number, T>();
+
+    constructor(private _nextHandle: number) { }
+
+    public getObjectById(id: number): T {
+        return this._idToObject.getByLeft(id);
+    }
+
+    public getIdByObject(obj: T): number {
+        const id = this._idToObject.tryGettingByRight(obj);
+        if (id !== undefined) {
+            return id;
+        } else {
+            const newId = this._nextHandle++;
+            this._idToObject.set(newId, obj);
+            return newId;
+        }
+    }
+
+    public toString(): string {
+        return this._idToObject.toString();
+    }
+}
+
+const prefixMultiplier = 1000000;
+
+@injectable()
+export class HandlesRegistry {
+    // TODO DIEGO: V1 reseted the frames on an onPaused event. Figure out if that is the right thing to do
+    // We use different prefixes so it's easier to identify the IDs in the logs...
+    public readonly breakpoints = new BidirectionalHandles<IBPRecipe<ISource>>(888 * prefixMultiplier);
+    public readonly frames = new BidirectionalHandles<IStackTracePresentationRow>(123 * prefixMultiplier);
+    public readonly sources = new BidirectionalHandles<ILoadedSource>(555 * prefixMultiplier);
+
+    public toString(): string {
+        return `Handles {\nBPs:\n${this.breakpoints}\nFrames:\n${this.frames}\nSources:\n${this.sources}\n}`;
+    }
+}

--- a/src/chrome/client/locationInSourceToClientConverter.ts
+++ b/src/chrome/client/locationInSourceToClientConverter.ts
@@ -1,0 +1,26 @@
+import { HandlesRegistry } from './handlesRegistry';
+import { LocationInLoadedSource } from '../internal/locations/location';
+import { SourceToClientConverter } from './sourceToClientConverter';
+import { DebugProtocol } from 'vscode-debugprotocol';
+import { LineColTransformer } from '../../transformers/lineNumberTransformer';
+
+interface IClientLocationInSource {
+    source: DebugProtocol.Source;
+    line: number;
+    column: number;
+}
+
+export class LocationInSourceToClientConverter {
+    private readonly _sourceToClientConverter = new SourceToClientConverter(this._handlesRegistry);
+
+    constructor(
+        private readonly _handlesRegistry: HandlesRegistry,
+        private readonly _lineColTransformer: LineColTransformer) { }
+
+    public async toLocationInSource<T = {}>(locationInSource: LocationInLoadedSource, objectToUpdate: T): Promise<T & IClientLocationInSource> {
+        const source = await this._sourceToClientConverter.toSource(locationInSource.source);
+        const clientLocationInSource = { source, line: locationInSource.position.lineNumber, column: locationInSource.position.columnNumber };
+        this._lineColTransformer.convertDebuggerLocationToClient(clientLocationInSource);
+        return Object.assign(objectToUpdate, clientLocationInSource);
+    }
+}

--- a/src/chrome/client/requests.ts
+++ b/src/chrome/client/requests.ts
@@ -1,0 +1,6 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+export const AvailableCommands = new Set(['runInTerminal', 'initialize', 'configurationDone', 'launch', 'attach', 'restart', 'disconnect', 'terminate', 'setBreakpoints', 'setFunctionBreakpoints', 'setExceptionBreakpoints', 'continue', 'next', 'stepIn', 'stepOut', 'stepBack', 'reverseContinue', 'restartFrame', 'goto', 'pause', 'stackTrace', 'scopes', 'variables', 'setVariable', 'source', 'threads', 'terminateThreads', 'modules', 'loadedSources', 'evaluate', 'setExpression', 'stepInTargets', 'gotoTargets', 'completions', 'exceptionInfo', 'toggleSkipFileStatus']);
+export type CommandText = 'runInTerminal' | 'initialize' | 'configurationDone' | 'launch' | 'attach' | 'restart' | 'disconnect' | 'terminate' | 'setBreakpoints' | 'setFunctionBreakpoints' | 'setExceptionBreakpoints' | 'continue' | 'next' | 'stepIn' | 'stepOut' | 'stepBack' | 'reverseContinue' | 'restartFrame' | 'goto' | 'pause' | 'stackTrace' | 'scopes' | 'variables' | 'setVariable' | 'source' | 'threads' | 'terminateThreads' | 'modules' | 'loadedSources' | 'evaluate' | 'setExpression' | 'stepInTargets' | 'gotoTargets' | 'completions' | 'exceptionInfo';

--- a/src/chrome/client/session.ts
+++ b/src/chrome/client/session.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { DebugProtocol } from 'vscode-debugprotocol';
+
+export interface ISession {
+    sendEvent(event: DebugProtocol.Event): void;
+    shutdown(): void;
+    sendRequest(command: string, args: any, timeout: number, cb: (response: DebugProtocol.Response) => void): void;
+    dispatchRequest(request: DebugProtocol.Request): Promise<void>;
+}
+
+export abstract class BaseWrappedSession implements ISession {
+    constructor(protected readonly _wrappedSession: ISession) { }
+
+    public dispatchRequest(request: DebugProtocol.Request): Promise<void> {
+        return this._wrappedSession.dispatchRequest(request);
+    }
+
+    public sendRequest(command: string, args: any, timeout: number, cb: (response: DebugProtocol.Response) => void): void {
+        this._wrappedSession.sendRequest(command, args, timeout, cb);
+    }
+
+    public sendEvent(event: DebugProtocol.Event): void {
+        this._wrappedSession.sendEvent(event);
+    }
+
+    public shutdown(): void {
+        this._wrappedSession.shutdown();
+    }
+}

--- a/src/chrome/client/sourceToClientConverter.ts
+++ b/src/chrome/client/sourceToClientConverter.ts
@@ -1,0 +1,23 @@
+import * as pathModule from 'path';
+import * as utils from '../../utils';
+import { ILoadedSource } from '../internal/sources/loadedSource';
+import { Source } from 'vscode-debugadapter';
+import { HandlesRegistry } from './handlesRegistry';
+
+export class SourceToClientConverter {
+    constructor(private readonly _handlesRegistry: HandlesRegistry) { }
+
+    public async toSource(loadedSource: ILoadedSource): Promise<Source> {
+        const exists = await utils.existsAsync(loadedSource.identifier.canonicalized);
+
+        // if the path exists, do not send the sourceReference
+        // new Source sends 0 for undefined
+        const source: Source = {
+            name: pathModule.basename(loadedSource.identifier.textRepresentation),
+            path: loadedSource.identifier.textRepresentation,
+            sourceReference: exists ? undefined : this._handlesRegistry.sources.getIdByObject(loadedSource),
+        };
+
+        return source;
+    }
+}

--- a/src/chrome/debugeeStartup/debugeeLauncher.ts
+++ b/src/chrome/debugeeStartup/debugeeLauncher.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { ITelemetryPropertyCollector } from '../../telemetry';
+import { ILaunchRequestArgs } from '../../debugAdapterInterfaces';
+
+export interface ILaunchResult {
+    address?: string;
+    port?: number;
+    url?: string;
+}
+
+export interface IDebuggeeLauncher  {
+    launch(args: ILaunchRequestArgs, telemetryPropertyCollector: ITelemetryPropertyCollector): Promise<ILaunchResult>;
+}
+
+export interface IDebuggeeRunner  {
+    run(telemetryPropertyCollector: ITelemetryPropertyCollector): Promise<void>;
+}

--- a/src/chrome/dependencyInjection.ts/di.ts
+++ b/src/chrome/dependencyInjection.ts/di.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Container, interfaces } from 'inversify';
+// TODO: Readd after we merge this file import { bindAll } from './bind';
+import { MethodsCalledLoggerConfiguration } from '../logging/methodsCalledLogger';
+
+export type GetComponentByID = <T>(identifier: interfaces.ServiceIdentifier<T>) => T;
+export type ComponentCustomizationCallback = <T>(identifier: interfaces.ServiceIdentifier<T>, injectable: T, getComponentById: GetComponentByID) => T;
+
+// Hides the current DI framework from the rest of our implementation
+export class DependencyInjection {
+    private readonly _container = new Container({ autoBindInjectable: true, defaultScope: 'Singleton' });
+
+    constructor(/* Will be used after we merge bind.ts*/ _componentCustomizationCallback: ComponentCustomizationCallback) {
+    }
+
+    public configureClass<T>(interfaceClass: interfaces.Newable<T> | symbol, value: interfaces.Newable<T>): this {
+        this._container.bind(interfaceClass).to(value).inSingletonScope();
+        return this;
+    }
+
+    public unconfigure<T>(interfaceClass: interfaces.Newable<T> | symbol): this {
+        this._container.unbind(interfaceClass);
+        return this;
+    }
+
+    public configureValue<T>(valueClass: interfaces.Newable<T> | symbol, value: T): this {
+        this._container.bind(valueClass).toConstantValue(value);
+        return this;
+    }
+
+    public createClassWithDI<T>(classToCreate: interfaces.Newable<T>): T {
+        return this._container.get(classToCreate);
+    }
+
+    public createComponent<T>(componentIdentifier: symbol): T {
+        return this._container.get(componentIdentifier);
+    }
+
+    public bindAll(_loggingConfiguration: MethodsCalledLoggerConfiguration): this {
+        // TODO: Readd after we merge bind.ts bindAll(loggingConfiguration, this._container, this._componentCustomizationCallback);
+        return this;
+    }
+}

--- a/src/chrome/dependencyInjection.ts/types.ts
+++ b/src/chrome/dependencyInjection.ts/types.ts
@@ -7,7 +7,6 @@ import 'reflect-metadata';
 // TODO: Add all necesary types so we can use inversifyjs to create our components
 const TYPES = {
     ISession: Symbol.for('ISession'),
-    communicator: Symbol.for('communicator'),
     CDTPClient: Symbol.for('chromeConnection.api'),
     IDOMInstrumentationBreakpoints: Symbol.for('IDOMInstrumentationBreakpoints'),
     IEventsToClientReporter: Symbol.for('IEventsToClientReporter'),
@@ -17,8 +16,7 @@ const TYPES = {
     IAsyncDebuggingConfiguration: Symbol.for('IAsyncDebuggingConfiguration'),
     IStackTracePresentationLogicProvider: Symbol.for('IStackTracePresentationLogicProvider'),
     IScriptSources: Symbol.for('IScriptSources'),
-    EventsConsumedByConnectedCDA: Symbol.for('EventsConsumedByConnectedCDA'),
-    ICDTPDebuggerEventsProvider: Symbol.for('ICDTPDebuggerEventsProvider'),
+    ICDTPDebuggeeExecutionEventsProvider: Symbol.for('ICDTPDebuggeeExecutionEventsProvider'),
     IDebugeeSteppingController: Symbol.for('IDebugeeSteppingController'),
     IDebuggeeLauncher: Symbol.for('IDebuggeeLauncher'),
     ChromeDebugLogic: Symbol.for('ChromeDebugLogic'),
@@ -56,6 +54,9 @@ const TYPES = {
     ILogEventsProvider: Symbol.for('ILogEventsProvider'),
     IBlackboxPatternsConfigurer: Symbol.for('IBlackboxPatternsConfigurer'),
     IDomainsEnabler: Symbol.for('IDomainsEnabler'),
+    ILogger: Symbol.for('ILogger'),
+    ICommandHandlerDeclarer: Symbol.for('ICommandHandlerDeclarer'),
+    IDebuggeePausedHandler: Symbol.for('IDebuggeePausedHandler'),
 };
 
 export { TYPES };

--- a/src/chrome/extensibility/extensibilityPoints.ts
+++ b/src/chrome/extensibility/extensibilityPoints.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { ChromeConnection, ITargetFilter } from '../chromeConnection';
+import { BasePathTransformer } from '../../transformers/basePathTransformer';
+import { BaseSourceMapTransformer } from '../../transformers/baseSourceMapTransformer';
+import { LineColTransformer } from '../../transformers/lineNumberTransformer';
+import { ILaunchRequestArgs, IAttachRequestArgs } from '../../debugAdapterInterfaces';
+import { interfaces } from 'inversify';
+import { IDebuggeeLauncher, IDebuggeeRunner } from '../debugeeStartup/debugeeLauncher';
+import { IConnectedCDAConfiguration } from '../client/chromeDebugAdapter/cdaConfiguration';
+import { ComponentCustomizationCallback } from '../dependencyInjection.ts/di';
+
+export interface IExtensibilityPoints {
+    componentCustomizationCallback: ComponentCustomizationCallback;
+    isPromiseRejectExceptionFilterEnabled: boolean;
+    debugeeLauncher: interfaces.Newable<IDebuggeeLauncher>;
+    debugeeRunner: interfaces.Newable<IDebuggeeRunner>;
+
+    targetFilter?: ITargetFilter;
+    logFilePath: string;
+
+    chromeConnection?: typeof ChromeConnection;
+    pathTransformer?: { new(configuration: IConnectedCDAConfiguration): BasePathTransformer };
+    sourceMapTransformer?: { new(configuration: IConnectedCDAConfiguration): BaseSourceMapTransformer };
+    lineColTransformer?: { new(configuration: IConnectedCDAConfiguration): LineColTransformer };
+
+    updateArguments<T extends ILaunchRequestArgs | IAttachRequestArgs>(argumentsFromClient: T): T;
+}
+
+export class OnlyProvideCustomLauncherExtensibilityPoints implements IExtensibilityPoints {
+    public readonly isPromiseRejectExceptionFilterEnabled = false;
+
+    targetFilter?: ITargetFilter;
+    chromeConnection?: typeof ChromeConnection;
+    pathTransformer?: new (configuration: IConnectedCDAConfiguration) => BasePathTransformer;
+    sourceMapTransformer?: new (configuration: IConnectedCDAConfiguration) => BaseSourceMapTransformer;
+    lineColTransformer?: new (configuration: IConnectedCDAConfiguration) => LineColTransformer;
+
+    constructor(
+        public readonly logFilePath: string,
+        public readonly debugeeLauncher: interfaces.Newable<IDebuggeeLauncher>,
+        public readonly debugeeRunner: interfaces.Newable<IDebuggeeRunner>,
+        public readonly componentCustomizationCallback: ComponentCustomizationCallback) {
+    }
+
+    public updateArguments<T extends ILaunchRequestArgs | IAttachRequestArgs>(argumentsFromClient: T): T {
+        return argumentsFromClient;
+    }
+}

--- a/src/chrome/internal/features/components.ts
+++ b/src/chrome/internal/features/components.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { ConnectedCDAConfiguration } from '../../client/chromeDebugAdapter/cdaConfiguration';
+import { PromiseOrNot } from '../../utils/promises';
+import { CommandText } from '../../client/requests';
+
+export interface IComponentWithAsyncInitialization {
+    install(): Promise<this>;
+}
+
+export interface IConfigurableComponent {
+    configure(configuration: ConnectedCDAConfiguration): Promise<this>;
+}
+
+export interface ICommandHandlerDeclaration {
+    readonly commandName: CommandText;
+    readonly commandHandler: RequestHandler;
+}
+
+export type RequestHandler = (args: any) => PromiseOrNot<unknown>;
+export class CommandHandlerDeclaration implements ICommandHandlerDeclaration {
+    public constructor(
+        public readonly commandName: CommandText,
+        public readonly commandHandler: RequestHandler
+    ) { }
+
+    public static fromLiteralObject(mappings: { [requestName: string]: RequestHandler }): CommandHandlerDeclaration[] {
+        return Object.keys(mappings).map(requestName => new CommandHandlerDeclaration(<CommandText>requestName, mappings[requestName]));
+    }
+}
+
+export interface ICommandHandlerDeclarer {
+    getCommandHandlerDeclarations(): PromiseOrNot<ICommandHandlerDeclaration[]>;
+}

--- a/src/chrome/internal/services/logging.ts
+++ b/src/chrome/internal/services/logging.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Logger, logger } from 'vscode-debugadapter';
+import { IExtensibilityPoints } from '../../extensibility/extensibilityPoints';
+
+export interface ILoggingConfiguration {
+    logLevel?: Logger.LogLevel;
+    shouldLogTimestamps: boolean;
+    logFilePath: string;
+}
+
+export class Logging {
+    public verbose(entry: string): void {
+        logger.verbose(entry);
+    }
+
+    public install(extensibilityPoints: IExtensibilityPoints, configuration: ILoggingConfiguration): this {
+        this.configure(extensibilityPoints, configuration);
+        return this;
+    }
+
+    public configure(extensibilityPoints: IExtensibilityPoints, configuration: ILoggingConfiguration): void {
+        const logToFile = !!configuration.logLevel;
+
+        // The debug configuration provider should have set logFilePath on the launch config. If not, default to 'true' to use the
+        // "legacy" log file path from the CDA subclass
+        const logFilePath = configuration.logFilePath || extensibilityPoints.logFilePath || logToFile;
+        logger.setup(configuration.logLevel || Logger.LogLevel.Warn, logFilePath, configuration.shouldLogTimestamps);
+    }
+}

--- a/src/chrome/internal/sources/sourceResolver.ts
+++ b/src/chrome/internal/sources/sourceResolver.ts
@@ -6,8 +6,7 @@ import { ILoadedSource } from './loadedSource';
 import { ISource, SourceToBeResolvedViaPath } from './source';
 import { newResourceIdentifierMap, IResourceIdentifier } from './resourceIdentifier';
 import { IComponent } from '../features/feature';
-import { injectable, inject } from 'inversify';
-import { TYPES } from '../../dependencyInjection.ts/types';
+import { injectable } from 'inversify';
 import { IScript } from '../scripts/script';
 
 // TODO: Remove next line and use the import instead
@@ -30,7 +29,7 @@ export class SourceResolver implements IComponent {
     private _pathToSource = newResourceIdentifierMap<ILoadedSource>();
 
     constructor(
-        @inject(TYPES.EventsConsumedByConnectedCDA) private readonly _dependencies: IEventsConsumedBySourceResolver) { }
+        private readonly _dependencies: IEventsConsumedBySourceResolver) { }
 
     public tryResolving<R>(sourceIdentifier: IResourceIdentifier,
         succesfulAction: (resolvedSource: ILoadedSource) => R,

--- a/src/chrome/logging/methodsCalledLogger.ts
+++ b/src/chrome/logging/methodsCalledLogger.ts
@@ -1,0 +1,103 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+import * as _ from 'lodash';
+import { printTopLevelObjectDescription } from './printObjectDescription';
+import { logger } from 'vscode-debugadapter';
+
+enum Synchronicity {
+    Sync,
+    Async
+}
+
+enum Outcome {
+    Succesful,
+    Failure
+}
+
+export class ReplacementInstruction {
+    public constructor(
+        public readonly pattern: RegExp,
+        public readonly replacement: string) { }
+}
+
+export class MethodsCalledLoggerConfiguration {
+    public constructor(readonly replacements: ReplacementInstruction[]) { }
+}
+
+export class MethodsCalledLogger<T extends object> {
+    constructor(
+        private readonly _configuration: MethodsCalledLoggerConfiguration,
+        private readonly _objectToWrap: T,
+        private readonly _objectToWrapName: string) {
+    }
+
+    public wrapped(): T {
+        const handler = {
+            get: <K extends keyof T>(target: T, propertyKey: K, _receiver: any) => {
+                const originalPropertyValue = target[propertyKey];
+                if (typeof originalPropertyValue === 'function') {
+                    return (...args: any) => {
+                        try {
+                            const result = originalPropertyValue.apply(target, args);
+                            if (!result || !result.then) {
+                                this.logCall(propertyKey, Synchronicity.Sync, args, Outcome.Succesful, result);
+                                return result;
+                            } else {
+                                return result.then((promiseResult: unknown) => {
+                                    this.logCall(propertyKey, Synchronicity.Async, args, Outcome.Succesful, promiseResult);
+                                    return promiseResult;
+                                }, (rejection: unknown) => {
+                                    this.logCall(propertyKey, Synchronicity.Async, args, Outcome.Failure, rejection);
+                                    return rejection;
+                                });
+                            }
+                        } catch (exception) {
+                            this.logCall(propertyKey, Synchronicity.Sync, args, Outcome.Failure, exception);
+                            throw exception;
+                        }
+                    };
+                } else {
+                    return originalPropertyValue;
+                }
+            }
+        };
+
+        return new Proxy<T>(this._objectToWrap, handler);
+    }
+
+    private printMethodCall(propertyKey: PropertyKey, methodCallArguments: any[]): string {
+        return `${this._objectToWrapName}.${String(propertyKey)}(${this.printArguments(methodCallArguments)})`;
+    }
+
+    private printMethodResponse(outcome: Outcome, resultOrException: unknown): string {
+        return `${outcome === Outcome.Succesful ? '->' : 'threw'} ${this.printObject(resultOrException)}`;
+    }
+
+    private printMethodSynchronicity(synchronicity: Synchronicity): string {
+        return `${synchronicity === Synchronicity.Sync ? '' : ' async'}`;
+    }
+
+    private logCall(propertyKey: PropertyKey, synchronicity: Synchronicity, methodCallArguments: any[], outcome: Outcome, resultOrException: unknown): void {
+        const message = `${this.printMethodCall(propertyKey, methodCallArguments)} ${this.printMethodSynchronicity(synchronicity)}  ${this.printMethodResponse(outcome, resultOrException)}`;
+        logger.verbose(message);
+    }
+
+    private printArguments(methodCallArguments: any[]): string {
+        return methodCallArguments.map(methodCallArgument => this.printObject(methodCallArgument)).join(', ');
+    }
+
+    private printObject(objectToPrint: unknown): string {
+        const description = printTopLevelObjectDescription(objectToPrint);
+        const printtedReduced = _.reduce(Array.from(this._configuration.replacements),
+            (text, replacement) =>
+                text.replace(replacement.pattern, replacement.replacement),
+            description);
+
+        return printtedReduced;
+    }
+}
+
+export function wrapWithMethodLogger<T extends object>(objectToWrap: T, objectToWrapName = `${objectToWrap}`): T {
+    return new MethodsCalledLogger(new MethodsCalledLoggerConfiguration([]), objectToWrap, objectToWrapName).wrapped();
+}

--- a/src/chrome/logging/printObjectDescription.ts
+++ b/src/chrome/logging/printObjectDescription.ts
@@ -1,0 +1,58 @@
+import * as _ from 'lodash';
+
+export function printTopLevelObjectDescription(objectToPrint: unknown) {
+    return printObjectDescription(objectToPrint, printFirstLevelProperties);
+}
+
+export function printObjectDescription(objectToPrint: unknown, fallbackPrintDescription = (obj: unknown) => `${obj}`) {
+    let printted = `<logic to print this object doesn't exist>`;
+    if (!objectToPrint) {
+        printted = `${objectToPrint}`;
+    } else if (typeof objectToPrint === 'object') {
+        // Proxies throw an exception when toString is called, so we need to check this first
+        if (typeof (<any>objectToPrint).on === 'function') {
+            // This is a noice-json-rpc proxy
+            printted = 'CDTP Proxy';
+        } else {
+            const toString = objectToPrint.toString();
+            if (toString !== '[object Object]') {
+                printted = toString;
+            } else if (isJSONObject(objectToPrint)) {
+                printted = JSON.stringify(objectToPrint);
+            } else if (objectToPrint.constructor === Object) {
+                printted = fallbackPrintDescription(objectToPrint);
+            } else {
+                printted = `${objectToPrint}(${objectToPrint.constructor.name})`;
+            }
+        }
+    } else if (typeof objectToPrint === 'function') {
+        if (objectToPrint.name) {
+            printted = objectToPrint.name;
+        } else {
+            const functionSourceCode = objectToPrint.toString();
+
+            // Find param => or (param1, param2)
+            const parenthesisIndex = _.findIndex(functionSourceCode, character => character === ')' || character === '=');
+            const functionParameters = functionSourceCode.substr(functionSourceCode[0] === '(' ? 1 : 0, parenthesisIndex - 1);
+            printted = `Anonymous function: ${functionParameters}`;
+        }
+    } else {
+        printted = `${objectToPrint}`;
+    }
+
+    return printted;
+}
+
+function isJSONObject(objectToPrint: any): boolean {
+    if (objectToPrint.constructor === Object) {
+        const values = _.values(objectToPrint);
+        return values.every(value => value.constructor === Object);
+    } else {
+        return false;
+    }
+}
+
+function printFirstLevelProperties(objectToPrint: any): string {
+    const printtedProeprties = Object.keys(objectToPrint).map(key => `${key}: ${printObjectDescription(objectToPrint[key])}`);
+    return `{ ${printtedProeprties.join(', ')} }`;
+}


### PR DESCRIPTION
gulpfile updated to v4
ConnectedCDAConfiguration this class is meant to have all the configuration that we use at runtime in a single place
ChromeDebugAdapter (v2): New version of the debug adapter. It's split into three states: Uninitialized, Unconnected and Connected.
ConnectedCDA: Handles the requests when we are connected to Chrome. The components implement the ICommandHandlerDeclarer interface to register requests they support here.
UnconnectedCDA: Handles the launch/attach requests, and creates the ConnectedCDA instance that we'll use at runtime (This class/code still needs a lot of work).
UninitializedCDA: Handles the initialize request, and responds the client capabilities.
DelayMessagesUntilInitializedSession: The protocol doesn't support sending events before we send the initialized message. This classes stores the events that are generated before that happens, and sends them after we send the initialized message.
DoNotPauseWhileSteppingSession: This classes ensures that we'll wait until step requests finish before we send a stopped event to the client.
BidirectionalHandles: Class to store the handles/ids that we send in the vs code protocol messages
IDebuggeeLauncher/IDebuggeeRunner: Classes that each debugger must implement to tell -core how to launch and run the debuggee
DependencyInjection: We use this class to hide the actual DI framework that we use, in case we decide to change to a different framework later
IExtensibilityPoints: In v2 each debugger will use the extensibility points to add, or modify the behavior of -core for it's particular debugger. (This class/code is still a work in progress)
Logging: We plan to use this service instead of the global logger. service.
MethodsCalledLogger: Proxy Wrapper to automatically log the calls to an object. We wrap all the DependencyInjection components with these, to log all the calls that are made between each component. (This class/code is still a work in progress)
PrintObjectDescription: This class figures out the best way to print an object (This is useful when the object doesn't have a custom .toString() implementation) (This class/code is still a work in progress)
