### PR TITLE
Set breakpoints model

### DIFF
--- a/src/chrome/communication/channel.ts
+++ b/src/chrome/communication/channel.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { RequestChannelIdentifier } from './requestsCommunicator';
+import { NamespaceReverseLookupCreator, NamespaceTree } from '../utils/namespaceReverseLookupCreator';
+import { NotificationChannelIdentifier } from './notificationsCommunicator';
+import { IChannelIdentifier } from './channelIdentifier';
+
+type ChannelIdentifierNamespace = NamespaceTree<IChannelIdentifier>;
+
+const registeredChannels: ChannelIdentifierNamespace = {};
+export function registerChannels(channel: ChannelIdentifierNamespace, name: string): void {
+    registeredChannels[name] = channel;
+}
+
+let channelToNameMapping: Map<IChannelIdentifier, string> | null = null;
+
+function isChannelIdentifier(obj: any): obj is IChannelIdentifier {
+    return obj instanceof NotificationChannelIdentifier || obj instanceof RequestChannelIdentifier;
+}
+
+export function getChannelName(channel: IChannelIdentifier): string {
+    if (channelToNameMapping === null) {
+        channelToNameMapping = new NamespaceReverseLookupCreator(registeredChannels, isChannelIdentifier, '').create();
+    }
+
+    return channelToNameMapping.get(channel);
+}

--- a/src/chrome/communication/channelIdentifier.ts
+++ b/src/chrome/communication/channelIdentifier.ts
@@ -1,0 +1,7 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+export interface IChannelIdentifier {
+
+}

--- a/src/chrome/communication/communicator.ts
+++ b/src/chrome/communication/communicator.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { NotificationsCommunicator, NotificationChannelIdentifier, PublisherFunction, SubscriberFunction, PublisherWithParamsFunction } from './notificationsCommunicator';
+import { RequestsCommunicator, RequestChannelIdentifier, RequestHandlerCallback } from './requestsCommunicator';
+import { IExecutionLogger } from '../logging/executionLogger';
+import { PromiseOrNot } from '../utils/promises';
+
+export interface ICommunicator {
+    getPublisher<Notification, Response>(notificationChannelIdentifier: NotificationChannelIdentifier<Notification, Response>): PublisherFunction<Notification, Response>;
+    getSubscriber<Notification, Response>(notificationChannelIdentifier: NotificationChannelIdentifier<Notification, Response>): SubscriberFunction<Notification, Response>;
+    subscribe<Notification>(notificationChannelIdentifier: NotificationChannelIdentifier<Notification>, listener: (notification: Notification) => void): void;
+    registerHandler<Request, Response>(requestChannelIdentifier: RequestChannelIdentifier<Request, Response>, handler: (request: Request) => PromiseOrNot<Response>): void;
+    getRequester<Request, Response>(requestChannelIdentifier: RequestChannelIdentifier<Request, Response>): RequestHandlerCallback<Request, Response>;
+}
+
+/**
+ * Small strongly typed event-dispatcher system
+ */
+export class Communicator implements ICommunicator {
+    private readonly _notificationsCommunicator = new NotificationsCommunicator();
+    private readonly _requestsCommunicator = new RequestsCommunicator();
+
+    public getPublisher<Notification, Response>(notificationChannelIdentifier: NotificationChannelIdentifier<Notification, Response>): PublisherFunction<Notification, Response> {
+        return this._notificationsCommunicator.getPublisher(notificationChannelIdentifier);
+    }
+
+    public getSubscriber<Notification, Response>(notificationChannelIdentifier: NotificationChannelIdentifier<Notification, Response>): SubscriberFunction<Notification, Response> {
+        return this._notificationsCommunicator.getSubscriber(notificationChannelIdentifier);
+    }
+
+    public subscribe<Notification>(notificationChannelIdentifier: NotificationChannelIdentifier<Notification>, listener: (notification: Notification) => void): void {
+        return this._notificationsCommunicator.subscribe(notificationChannelIdentifier, listener);
+    }
+
+    public registerHandler<Request, Response>(requestChannelIdentifier: RequestChannelIdentifier<Request, Response>, handler: (request: Request) => PromiseOrNot<Response>): void {
+        this._requestsCommunicator.registerHandler(requestChannelIdentifier, handler);
+    }
+
+    public getRequester<Request, Response>(requestChannelIdentifier: RequestChannelIdentifier<Request, Response>): RequestHandlerCallback<Request, Response> {
+        return this._requestsCommunicator.getRequester(requestChannelIdentifier);
+    }
+}
+
+export class LoggingCommunicator implements ICommunicator {
+    constructor(private readonly _wrappedCommunicator: ICommunicator, private readonly _logger: IExecutionLogger) { }
+
+    public getPublisher<Notification, Response>(notificationChannelIdentifier: NotificationChannelIdentifier<Notification, Response>): PublisherFunction<Notification, Response> {
+        const publisher = this._wrappedCommunicator.getPublisher(notificationChannelIdentifier) as PublisherWithParamsFunction<Notification, Response>;
+        return (notification => {
+            return this._logger.logAsyncFunctionCall(`Communicator\\Publish: ${notificationChannelIdentifier}`, publisher, notification);
+        }) as PublisherFunction<Notification, Response>;
+    }
+
+    public getRequester<Request, Response>(requestChannelIdentifier: RequestChannelIdentifier<Request, Response>): RequestHandlerCallback<Request, Response> {
+        const requester = this._wrappedCommunicator.getRequester(requestChannelIdentifier);
+        return ((request) => {
+            return this._logger.logAsyncFunctionCall(`Communicator\\Request: ${requestChannelIdentifier}`, requester, request);
+        }) as RequestHandlerCallback<Request, Response>;
+    }
+
+    public getSubscriber<Notification, Response>(notificationChannelIdentifier: NotificationChannelIdentifier<Notification, Response>): SubscriberFunction<Notification, Response> {
+        return this._wrappedCommunicator.getSubscriber(notificationChannelIdentifier);
+    }
+
+    public subscribe<Notification>(notificationChannelIdentifier: NotificationChannelIdentifier<Notification>, listener: (notification: Notification) => void): void {
+        this._wrappedCommunicator.subscribe(notificationChannelIdentifier, listener);
+    }
+
+    public registerHandler<Request, Response>(requestChannelIdentifier: RequestChannelIdentifier<Request, Response>, handler: (request: Request) => Response): void {
+        this._wrappedCommunicator.registerHandler(requestChannelIdentifier, handler);
+    }
+}

--- a/src/chrome/communication/notificationsCommunicator.ts
+++ b/src/chrome/communication/notificationsCommunicator.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { ValidatedMap } from '../collections/validatedMap';
+import { IChannelIdentifier } from './channelIdentifier';
+import { getChannelName } from './channel';
+import { Listeners } from './listeners';
+import { PromiseOrNot } from '../utils/promises';
+
+type ResponsesArray<T> = T extends void
+    ? void
+    : T[];
+
+export type NotificationListener<Notification, Response> = (notification: Notification) => PromiseOrNot<Response>;
+export type PublisherWithParamsFunction<Notification, Response> = (notification: Notification) => PromiseOrNot<ResponsesArray<Response>>;
+export type PublisherFunction<Notification, Response> = Notification extends void
+    ? () => PromiseOrNot<ResponsesArray<Response>>
+    : PublisherWithParamsFunction<Notification, Response>;
+export type SubscriberFunction<Notification, Response> = (listener: NotificationListener<Notification, Response>) => void;
+
+// We need the template parameter to force the Communicator to be "strongly typed" from the client perspective
+export class NotificationChannelIdentifier<_Notification, _Response = void> implements IChannelIdentifier {
+    [Symbol.toStringTag]: 'NotificationChannelIdentifier' = 'NotificationChannelIdentifier';
+
+    constructor(public readonly identifierSymbol: Symbol = Symbol()) { }
+
+    public toString(): string {
+        return getChannelName(this);
+    }
+}
+
+class NotificationChannel<Notification, Response> {
+    public readonly listeners = new Listeners<Notification, PromiseOrNot<Response>>();
+    public readonly publisher: Publisher<Notification, Response> = new Publisher<Notification, Response>(this);
+
+    constructor(public readonly identifier: NotificationChannelIdentifier<Notification, Response>) { }
+
+    public toString(): string {
+        return `${this.identifier}`;
+    }
+}
+
+export class Publisher<Notification, Response> {
+    constructor(private readonly notificationChannel: NotificationChannel<Notification, Response>) { }
+
+    public async publish(notification: Notification): Promise<Response[]> {
+        if (this.notificationChannel.listeners.hasListeners()) {
+            return await Promise.all(this.notificationChannel.listeners.call(notification));
+        } else {
+            throw new Error(`Can't publish ${this.notificationChannel.identifier} because no listeners are registered`);
+        }
+    }
+
+    public toString(): string {
+        return `${this.notificationChannel} publisher`;
+    }
+}
+
+export class NotificationsCommunicator {
+    private readonly _identifierToChannel = new ValidatedMap<NotificationChannelIdentifier<any, any>, NotificationChannel<any, any>>();
+
+    public getPublisher<Notification, Response>(notificationChannelIdentifier: NotificationChannelIdentifier<Notification, Response>): PublisherFunction<Notification, Response> {
+        const publisher = this.getChannel(notificationChannelIdentifier).publisher;
+        return (notification => publisher.publish(notification)) as PublisherFunction<Notification, Response>;
+    }
+
+    public getSubscriber<Notification, Response>(notificationChannelIdentifier: NotificationChannelIdentifier<Notification, Response>): SubscriberFunction<Notification, Response> {
+        const channelListeners = this.getChannel(notificationChannelIdentifier).listeners;
+        return listener => channelListeners.add(listener);
+    }
+
+    public subscribe<Notification, Response>(notificationChannelIdentifier: NotificationChannelIdentifier<Notification, Response>, listener: (notification: Notification) => Response): void {
+        this.getChannel(notificationChannelIdentifier).listeners.add(listener);
+    }
+
+    private getChannel<Notification, Response>(notificationChannelIdentifier: NotificationChannelIdentifier<Notification, Response>): NotificationChannel<Notification, Response> {
+        return this._identifierToChannel.getOrAdd(notificationChannelIdentifier, () => new NotificationChannel<Notification, Response>(notificationChannelIdentifier));
+    }
+}

--- a/src/chrome/communication/requestsCommunicator.ts
+++ b/src/chrome/communication/requestsCommunicator.ts
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { ValidatedMap } from '../collections/validatedMap';
+import { IChannelIdentifier } from './channelIdentifier';
+import { getChannelName } from './channel';
+import { PromiseOrNot } from '../utils/promises';
+
+export type RequestHandlerCallback<Request, Response> =
+    Request extends void
+    ? () => Promise<Response> :
+    NonVoidRequestHandler<Request, Response>;
+
+export type NonVoidRequestHandler<Request, Response> = (request: Request) => Promise<Response>;
+
+// We need the template parameter to force the Communicator to be "strongly typed" from the client perspective
+export class RequestChannelIdentifier<_Request, _Response> implements IChannelIdentifier {
+    [Symbol.toStringTag]: 'RequestChannelIdentifier' = 'RequestChannelIdentifier';
+
+    constructor(public readonly identifierSymbol: Symbol = Symbol()) { }
+
+    public toString(): string {
+        return getChannelName(this);
+    }
+}
+
+interface IRequestHandler<Request, Response> {
+    isRegistered(): boolean;
+    call(request: Request): Promise<Response>;
+}
+
+class NoRegisteredRequestHandler<Request, Response> implements IRequestHandler<Request, Response> {
+    constructor(private readonly _channel: RequestChannel<Request, Response>) { }
+
+    public isRegistered(): boolean {
+        return false;
+    }
+
+    public call(request: Request): Promise<Response> {
+        throw new Error(`Can't execute request <${request}> because no handler has yet registered to handle requests for channel <${this._channel}>`);
+    }
+}
+
+class RegisteredRequestHandler<Request, Response> implements IRequestHandler<Request, Response> {
+    constructor(private readonly _callback: RequestHandlerCallback<Request, Response>) { }
+
+    public isRegistered(): boolean {
+        return true;
+    }
+
+    public call(request: Request): Promise<Response> {
+        return (this._callback as NonVoidRequestHandler<Request, Response>)(request);
+    }
+}
+
+class RequestChannel<Request, Response> {
+    public readonly requester: Requester<Request, Response> = new Requester<Request, Response>(this);
+    public handler: IRequestHandler<Request, Response> = new NoRegisteredRequestHandler(this);
+
+    constructor(private readonly _identifier: RequestChannelIdentifier<Request, Response>) { }
+
+    public toString(): string {
+        return `#${this._identifier}`;
+    }
+}
+
+export class Requester<Request, Response> {
+    constructor(private readonly _requestChannel: RequestChannel<Request, Response>) { }
+
+    public request(request: Request): Promise<Response> {
+        return this._requestChannel.handler.call(request);
+    }
+}
+
+export class RequestsCommunicator {
+    private readonly _identifierToChannel = new ValidatedMap<RequestChannelIdentifier<any, any>, RequestChannel<any, any>>();
+
+    public registerHandler<Request, Response>(requestChannelIdentifier: RequestChannelIdentifier<Request, Response>,
+        handler: (request: Request) => PromiseOrNot<Response>): void {
+        const existingHandler = this.getChannel(requestChannelIdentifier).handler;
+        if (!existingHandler.isRegistered()) {
+            this.getChannel(requestChannelIdentifier).handler = new RegisteredRequestHandler(handler as RequestHandlerCallback<Request, Response>);
+        } else {
+            throw new Error(`Can't register a handler for ${requestChannelIdentifier} because a handler has already been registered (${existingHandler})`);
+        }
+    }
+
+    public getRequester<Request, Response>(requestChannelIdentifier: RequestChannelIdentifier<Request, Response>): RequestHandlerCallback<Request, Response> {
+        const requester = this.getChannel(requestChannelIdentifier).requester;
+        return ((request: Request) => requester.request(request)) as RequestHandlerCallback<Request, Response>;
+    }
+
+    private getChannel<Request, Response>(requestChannelIdentifier: RequestChannelIdentifier<Request, Response>): RequestChannel<Request, Response> {
+        return this._identifierToChannel.getOrAdd(requestChannelIdentifier, () => new RequestChannel<Request, Response>(requestChannelIdentifier));
+    }
+}

--- a/src/chrome/internal/breakpoints/bpRecipeStatus.ts
+++ b/src/chrome/internal/breakpoints/bpRecipeStatus.ts
@@ -4,7 +4,7 @@
 
 import { LocationInLoadedSource } from '../locations/location';
 import { printArray } from '../../collections/printing';
-import { BPRecipeIsBoundInRuntimeLocation, BPRecipeIsUnboundInRuntimeLocation } from './bpRecipeStatusForRuntimeLocation';
+import { BPRecipeIsBoundInRuntimeLocation, BPRecipeIsUnbound } from './bpRecipeStatusForRuntimeLocation';
 import { BPRecipeInSource } from './bpRecipeInSource';
 import { breakWhileDebugging } from '../../../validation';
 
@@ -45,7 +45,7 @@ export class BPRecipeHasBoundSubstatuses implements IBPRecipeStatus {
     constructor(
         public readonly recipe: BPRecipeInSource,
         public readonly boundSubstatuses: BPRecipeIsBoundInRuntimeLocation[],
-        public readonly unboundSubstatuses: BPRecipeIsUnboundInRuntimeLocation[]) {
+        public readonly unboundSubstatuses: BPRecipeIsUnbound[]) {
         if (this.boundSubstatuses.length === 0) {
             breakWhileDebugging();
             throw new Error(`At least one bound substatus was expected`);
@@ -75,7 +75,7 @@ export class BPRecipeHasOnlyUnboundSubstatuses implements IBPRecipeStatus {
 
     constructor(
         public readonly recipe: BPRecipeInSource,
-        public readonly unboundSubstatuses: BPRecipeIsUnboundInRuntimeLocation[]) {
+        public readonly unboundSubstatuses: BPRecipeIsUnbound[]) {
         if (this.unboundSubstatuses.length === 0) {
             breakWhileDebugging();
             throw new Error(`At least the substatus for a single runtime source was expected`);
@@ -95,7 +95,7 @@ export class BPRecipeHasOnlyUnboundSubstatuses implements IBPRecipeStatus {
     }
 }
 
-export function createBPRecipieStatus(recipe: BPRecipeInSource, boundSubstatuses: BPRecipeIsBoundInRuntimeLocation[], unboundSubstatuses: BPRecipeIsUnboundInRuntimeLocation[]): IBPRecipeStatus {
+export function createBPRecipieStatus(recipe: BPRecipeInSource, boundSubstatuses: BPRecipeIsBoundInRuntimeLocation[], unboundSubstatuses: BPRecipeIsUnbound[]): IBPRecipeStatus {
     if (boundSubstatuses.length > 0) {
         return new BPRecipeHasBoundSubstatuses(recipe, boundSubstatuses, unboundSubstatuses);
     } else if (unboundSubstatuses.length > 0) {

--- a/src/chrome/internal/breakpoints/bpRecipeStatusForRuntimeLocation.ts
+++ b/src/chrome/internal/breakpoints/bpRecipeStatusForRuntimeLocation.ts
@@ -9,12 +9,11 @@ export interface IBPRecipeSingleLocationStatus {
     isVerified(): boolean;
 }
 
-export class BPRecipeIsUnboundInRuntimeLocation implements IBPRecipeSingleLocationStatus {
+export class BPRecipeIsUnbound implements IBPRecipeSingleLocationStatus {
     [ImplementsBPRecipeSingleLocationStatus] = 'IBPRecipeSingleLocationStatus';
 
     constructor(
         public readonly recipe: BPRecipeInSource,
-        public readonly locationInRuntimeSource: LocationInLoadedSource,
         public readonly error: Error) {
     }
 
@@ -24,7 +23,7 @@ export class BPRecipeIsUnboundInRuntimeLocation implements IBPRecipeSingleLocati
 
     public toString(): string {
         // `The JavaScript code associated with this source file hasn't been loaded into the debuggee yet`
-        return `${this.recipe} at ${this.locationInRuntimeSource} is unbound because ${this.error}`;
+        return `${this.recipe} is unbound because ${this.error}`;
     }
 }
 

--- a/src/chrome/internal/breakpoints/features/bpRecipeAtLoadedSourceLogic.ts
+++ b/src/chrome/internal/breakpoints/features/bpRecipeAtLoadedSourceLogic.ts
@@ -1,0 +1,141 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as _ from 'lodash';
+import * as chromeUtils from '../../../chromeUtils';
+import { IDebuggeeBreakpointsSetter } from '../../../cdtpDebuggee/features/cdtpDebuggeeBreakpointsSetter';
+import { IBreakpointFeaturesSupport } from '../../../cdtpDebuggee/features/cdtpBreakpointFeaturesSupport';
+import { IEventsToClientReporter } from '../../../client/eventsToClientReporter';
+import { ReasonType } from '../../../stoppedEvent';
+import { CDTPBreakpoint } from '../../../cdtpDebuggee/cdtpPrimitives';
+import { DebuggeeBPRsSetForClientBPRFinder } from '../registries/debuggeeBPRsSetForClientBPRFinder';
+import { BPRecipeInLoadedSource } from '../BaseMappedBPRecipe';
+import { ConditionalPause, AlwaysPause } from '../bpActionWhenHit';
+import { PausedEvent } from '../../../cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider';
+import { BPRecipe } from '../bpRecipe';
+import { ISource } from '../../sources/source';
+import { LocationInScript, Position } from '../../locations/location';
+import { createColumnNumber, createLineNumber } from '../../locations/subtypes';
+import { RangeInResource } from '../../locations/rangeInScript';
+import { logger } from 'vscode-debugadapter/lib/logger';
+import { asyncMap } from '../../../collections/async';
+import { wrapWithMethodLogger } from '../../../logging/methodsCalledLogger';
+import { BaseNotifyClientOfPause, IActionToTakeWhenPaused, NoActionIsNeededForThisPause } from '../../features/actionToTakeWhenPaused';
+import { IDebuggeePausedHandler } from '../../features/debuggeePausedHandler';
+import { IBreakpointsEventsPublisher } from './BreakpointsEventSystem';
+import { BPRecipeIsUnbound } from '../bpRecipeStatusForRuntimeLocation';
+
+export class HitBreakpoint extends BaseNotifyClientOfPause {
+    protected reason: ReasonType = 'breakpoint';
+
+    constructor(protected readonly _eventsToClientReporter: IEventsToClientReporter) {
+        super();
+    }
+}
+
+export interface IBreakpointsInLoadedSource {
+    addBreakpointAtLoadedSource(bpRecipe: BPRecipeInLoadedSource<ConditionalPause | AlwaysPause>): Promise<CDTPBreakpoint[]>;
+    removeDebuggeeBPRs(clientBPRecipe: BPRecipe<ISource>): Promise<void>;
+}
+
+/**
+ * Handles setting breakpoints on sources that are associated with scripts already loaded
+ */
+export class BPRecipeAtLoadedSourceLogic implements IBreakpointsInLoadedSource {
+    private readonly doesTargetSupportColumnBreakpointsCached: Promise<boolean>;
+    private readonly _publishDebuggeeBPRecipeAdded = this._breakpointsEventsPublisher.publisherForDebuggeeBPRecipeAdded();
+    private readonly _publishDebuggeeBPRecipeRemoved = this._breakpointsEventsPublisher.publisherForDebuggeeBPRecipeRemoved();
+    private readonly _publishBPRecipeIsUnbound = this._breakpointsEventsPublisher.publisherForBPRecipeIsUnbound();
+
+    public readonly withLogging = wrapWithMethodLogger(this);
+
+    constructor(
+        private readonly _breakpointsEventsPublisher: IBreakpointsEventsPublisher,
+        private readonly _breakpointFeaturesSupport: IBreakpointFeaturesSupport,
+        private readonly _bpRecipesRegistry: DebuggeeBPRsSetForClientBPRFinder,
+        private readonly _targetBreakpoints: IDebuggeeBreakpointsSetter,
+        private readonly _eventsToClientReporter: IEventsToClientReporter,
+        private readonly _debuggeePausedHandler: IDebuggeePausedHandler) {
+        this.doesTargetSupportColumnBreakpointsCached = this._breakpointFeaturesSupport.supportsColumnBreakpoints;
+        this._debuggeePausedHandler.registerActionProvider(paused => this.withLogging.onProvideActionForWhenPaused(paused));
+    }
+
+    public async onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
+        if (paused.hitBreakpoints && paused.hitBreakpoints.length > 0) {
+            // TODO DIEGO: Improve this to consider breakpoints where we shouldn't pause
+            return new HitBreakpoint(this._eventsToClientReporter);
+        } else {
+            return new NoActionIsNeededForThisPause(this);
+        }
+    }
+
+    public async addBreakpointAtLoadedSource(bpRecipe: BPRecipeInLoadedSource<ConditionalPause | AlwaysPause>): Promise<CDTPBreakpoint[]> {
+        try {
+            const bpsInScriptRecipe = bpRecipe.mappedToScript();
+
+            const breakpoints = _.flatten(await asyncMap(bpsInScriptRecipe, async bpInScriptRecipe => {
+                const bestLocation = await this.considerColumnAndSelectBestBPLocation(bpInScriptRecipe.location);
+                const bpRecipeInBestLocation = bpInScriptRecipe.withLocationReplaced(bestLocation);
+
+                const runtimeSource = bpInScriptRecipe.location.script.runtimeSource;
+
+                let breakpoints: CDTPBreakpoint[];
+                if (!runtimeSource.doesScriptHasUrl()) {
+                    breakpoints = [await this._targetBreakpoints.setBreakpoint(bpRecipeInBestLocation)];
+                } else {
+                    /**
+                     * If the script is a local file path, we *need* to transform it into an url to be able to set the breakpoint
+                     *
+                     * If the script has an URL and it's not a local file path, then we could actually leave it as-is.
+                     * We transform it into a regexp anyway to add a GUID to it, so CDTP will let us add the same breakpoint/recipe two times (using different guids).
+                     * That way we can always add the new breakpoints for a file, before removing the old ones (except if the script doesn't have an URL)
+                     */
+                    breakpoints = await this._targetBreakpoints.setBreakpointByUrlRegexp(bpRecipeInBestLocation.mappedToUrlRegexp());
+                }
+
+                for (const breakpoint of breakpoints) {
+                    // The onBreakpointResolvedSyncOrAsync handler will notify us that a breakpoint was bound, and send the status update to the client if neccesary
+                    await this._publishDebuggeeBPRecipeAdded(breakpoint.recipe);
+                }
+
+                return breakpoints;
+            }));
+            return breakpoints;
+        }
+        catch (exception) {
+            this._publishBPRecipeIsUnbound(new BPRecipeIsUnbound(bpRecipe.unmappedBPRecipe, exception)); // We publish it so the breakpoint itself will have this information in the tooltip
+            throw exception; // We throw the exceptio so the call that the client made will fail
+        }
+    }
+
+    public async removeDebuggeeBPRs(clientBPRecipe: BPRecipe<ISource>): Promise<void> {
+        const debuggeeBPRecipes = this._bpRecipesRegistry.findDebuggeeBPRsSet(clientBPRecipe);
+        await asyncMap(debuggeeBPRecipes, async bpr => {
+            await this._targetBreakpoints.removeBreakpoint(bpr);
+            await this._publishDebuggeeBPRecipeRemoved(bpr);
+        });
+    }
+
+    private async considerColumnAndSelectBestBPLocation(location: LocationInScript): Promise<LocationInScript> {
+        if (await this.doesTargetSupportColumnBreakpointsCached) {
+            const thisLineStart = new Position(location.position.lineNumber, createColumnNumber(0));
+            const nextLineStart = new Position(createLineNumber(location.position.lineNumber + 1), createColumnNumber(0));
+            const thisLineRange = new RangeInResource(location.script, thisLineStart, nextLineStart);
+
+            const possibleLocations = await this._targetBreakpoints.getPossibleBreakpoints(thisLineRange);
+
+            if (possibleLocations.length > 0) {
+                const bestLocation = chromeUtils.selectBreakpointLocation(location.position.lineNumber, location.position.columnNumber, possibleLocations);
+                logger.verbose(`PossibleBreakpoints: Best location for ${location} is ${bestLocation}`);
+                return bestLocation;
+            }
+        }
+
+        return location;
+    }
+
+    public toString(): string {
+        return 'BPRecipeAtLoadedSourceLogic';
+    }
+}

--- a/src/chrome/internal/breakpoints/features/bpsDeltaCalculator.ts
+++ b/src/chrome/internal/breakpoints/features/bpsDeltaCalculator.ts
@@ -1,0 +1,119 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { BPRecipe } from '../bpRecipe';
+import { BPRecipeInSource } from '../bpRecipeInSource';
+import { BPRecipesInSource } from '../bpRecipes';
+import { ISource } from '../../sources/source';
+import { ILoadedSource } from '../../sources/loadedSource';
+import { IBPActionWhenHit } from '../bpActionWhenHit';
+import { SetUsingProjection } from '../../../collections/setUsingProjection';
+import assert = require('assert');
+import { ValidatedSet } from '../../../collections/validatedSet';
+import { printArray } from '../../../collections/printing';
+
+function canonicalizeBPLocation(breakpoint: BPRecipeInSource): string {
+    return `${breakpoint.location.position.lineNumber}:${breakpoint.location.position.columnNumber}[${breakpoint.bpActionWhenHit}]`;
+}
+
+/**
+ * Calculates the difference between two sets of breakpoint recipes. We use this to figure out which breakpoint recipes we need to add and remove for a client request
+ */
+export class BPRsDeltaCalculator {
+    private readonly _currentBPRecipes: SetUsingProjection<BPRecipeInSource, string>;
+
+    constructor(
+        public readonly requestedSourceIdentifier: ISource,
+        private readonly _requestedBPRecipes: BPRecipesInSource,
+        currentBPRecipes: BPRecipeInSource[]) {
+        this._currentBPRecipes = new SetUsingProjection(canonicalizeBPLocation, currentBPRecipes);
+    }
+
+    public calculate(): BPRsDeltaInRequestedSource {
+        const match = {
+            matchesForRequested: [] as BPRecipeInSource[], // Every iteration we'll add either the existing BP match, or the new BP as it's own match here
+            requestedToAdd: [] as BPRecipeInSource[], // Every time we don't find an existing match BP, we'll add the desired BP here
+            existingToLeaveAsIs: [] as BPRecipeInSource[], // Every time we do find an existing match BP, we'll add the existing BP here
+            existingToRemove: [] as BPRecipeInSource[] // Calculated at the end of the algorithm by doing (existingBreakpoints - existingToLeaveAsIs)
+        };
+
+        this._requestedBPRecipes.breakpoints.forEach(requestedBP => {
+            const existingMatch = this._currentBPRecipes.tryGetting(requestedBP);
+
+            let matchingBreakpoint;
+            if (existingMatch !== undefined) {
+                assert(requestedBP.isEquivalentTo(existingMatch), `The existing match ${existingMatch} is expected to be equivalent to the requested BP ${requestedBP}`);
+                match.existingToLeaveAsIs.push(existingMatch);
+                matchingBreakpoint = existingMatch;
+            } else {
+                match.requestedToAdd.push(requestedBP);
+                matchingBreakpoint = requestedBP;
+            }
+            match.matchesForRequested.push(matchingBreakpoint);
+        });
+
+        const setOfExistingToLeaveAsIs = new ValidatedSet(match.existingToLeaveAsIs);
+
+        match.existingToRemove = Array.from(this._currentBPRecipes).filter(bp => !setOfExistingToLeaveAsIs.has(bp));
+
+        // Do some minor validations of the result just in case
+        const delta = new BPRsDeltaInRequestedSource(this.requestedSourceIdentifier, match.matchesForRequested,
+            match.requestedToAdd, match.existingToRemove, match.existingToLeaveAsIs);
+        this.validateResult(delta);
+        return delta;
+    }
+
+    private validateResult(match: BPRsDeltaInRequestedSource): void {
+        let errorMessage = '';
+        if (match.matchesForRequested.length !== this._requestedBPRecipes.breakpoints.length) {
+            errorMessage += 'Expected the matches for desired breakpoints list to have the same length as the desired breakpoints list\n';
+        }
+
+        if (match.requestedToAdd.length + match.existingToLeaveAsIs.length !== this._requestedBPRecipes.breakpoints.length) {
+            errorMessage += 'Expected the desired breakpoints to add plus the existing breakpoints to leave as-is to have the same quantity as the total desired breakpoints\n';
+        }
+
+        if (match.existingToLeaveAsIs.length + match.existingToRemove.length !== this._currentBPRecipes.size) {
+            errorMessage += 'Expected the existing breakpoints to leave as-is plus the existing breakpoints to remove to have the same quantity as the total existing breakpoints\n';
+        }
+
+        if (errorMessage !== '') {
+            const matchJson = {
+                matchesForRequested: this.printLocations(match.matchesForRequested),
+                requestedToAdd: this.printLocations(match.requestedToAdd),
+                existingToRemove: this.printLocations(match.existingToRemove),
+                existingToLeaveAsIs: this.printLocations(match.existingToLeaveAsIs)
+            };
+
+            const additionalDetails = `\nDesired breakpoints = ${JSON.stringify(this._requestedBPRecipes.breakpoints.map(canonicalizeBPLocation))}`
+                + `\Existing breakpoints = ${JSON.stringify(Array.from(this._currentBPRecipes).map(canonicalizeBPLocation))}`
+                + `\nMatch = ${JSON.stringify(matchJson)}`;
+            throw new Error(errorMessage + `\nmatch: ${additionalDetails}`);
+        }
+    }
+
+    private printLocations(bpRecipes: BPRecipeInSource<IBPActionWhenHit>[]): string[] {
+        return bpRecipes.map(bpRecipe => `${bpRecipe.location.position}`);
+    }
+
+    public toString(): string {
+        return `BPs Delta Calculator {\n\tRequested BPs: ${this._requestedBPRecipes}\n\tExisting BPs: ${this._currentBPRecipes}\n}`;
+    }
+}
+
+export abstract class BPRsDeltaCommonLogic<TResource extends ILoadedSource | ISource> {
+    constructor(public readonly resource: TResource,
+        public readonly matchesForRequested: BPRecipe<TResource>[],
+        public readonly requestedToAdd: BPRecipe<TResource>[],
+        public readonly existingToRemove: BPRecipe<TResource>[],
+        public readonly existingToLeaveAsIs: BPRecipe<TResource>[]) { }
+
+    public toString(): string {
+        return `${printArray('New BPs', this.requestedToAdd)}\n${printArray('BPs to remove', this.existingToRemove)}\n${printArray('BPs to keep', this.existingToLeaveAsIs)}`;
+    }
+}
+
+export class BPRsDeltaInRequestedSource extends BPRsDeltaCommonLogic<ISource> { }
+
+export class BPRsDeltaInLoadedSource extends BPRsDeltaCommonLogic<ILoadedSource> { }

--- a/src/chrome/internal/breakpoints/features/breakpointsEventSystem.ts
+++ b/src/chrome/internal/breakpoints/features/breakpointsEventSystem.ts
@@ -1,0 +1,79 @@
+import { CDTPBPRecipe, CDTPBreakpoint } from '../../../cdtpDebuggee/cdtpPrimitives';
+import { BPRecipeInSource } from '../bpRecipeInSource';
+import { Communicator } from '../../../communication/communicator';
+import { BreakpointsEvents } from './breakpointsEvents';
+import { PublisherWithParamsFunction } from '../../../communication/notificationsCommunicator';
+import { BPRecipeIsUnbound } from '../bpRecipeStatusForRuntimeLocation';
+
+export interface IBreakpointsEventsListener {
+    listenForOnClientBPRecipeAdded(listener: (bpRecipie: BPRecipeInSource) => void): void;
+    listenForOnClientBPRecipeRemoved(listener: (bpRecipie: BPRecipeInSource) => void): void;
+    listenForOnDebuggeeBPRecipeAdded(listener: (bpRecipie: CDTPBPRecipe) => void): void;
+    listenForOnDebuggeeBPRecipeRemoved(listener: (bpRecipie: CDTPBPRecipe) => void): void;
+    listenForOnBreakpointIsBound(listener: (breakpoint: CDTPBreakpoint) => void): void;
+    listenForOnBPRecipeIsUnbound(listener: (bpRecipieIsUnbound: BPRecipeIsUnbound) => void): void;
+}
+
+export interface IBreakpointsEventsPublisher {
+    publisherForClientBPRecipeAdded(): void;
+    publisherForClientBPRecipeRemoved(): PublisherWithParamsFunction<BPRecipeInSource, void>;
+    publisherForDebuggeeBPRecipeAdded(): PublisherWithParamsFunction<CDTPBPRecipe, void>;
+    publisherForDebuggeeBPRecipeRemoved(): PublisherWithParamsFunction<CDTPBPRecipe, void>;
+    publisherForBreakpointIsBound(): PublisherWithParamsFunction<CDTPBreakpoint, void>;
+    publisherForBPRecipeIsUnbound(): PublisherWithParamsFunction<BPRecipeIsUnbound, void>;
+}
+
+/**
+ * Make a nice interface for the event system for the breakpoints logic, so that code doesn't need to deal directly with the event system
+ */
+export class BreakpointsEventSystem implements IBreakpointsEventsListener, IBreakpointsEventsPublisher {
+    private readonly _communicator = new Communicator();
+
+    public listenForOnClientBPRecipeAdded(listener: (bpRecipie: BPRecipeInSource) => void): void {
+        this._communicator.subscribe(BreakpointsEvents.OnClientBPRecipeAdded, listener);
+    }
+
+    public listenForOnClientBPRecipeRemoved(listener: (bpRecipie: BPRecipeInSource) => void): void {
+        this._communicator.subscribe(BreakpointsEvents.OnClientBPRecipeRemoved, listener);
+    }
+
+    public listenForOnDebuggeeBPRecipeAdded(listener: (bpRecipie: CDTPBPRecipe) => void): void {
+        this._communicator.subscribe(BreakpointsEvents.OnDebuggeeBPRecipeAdded, listener);
+    }
+
+    public listenForOnDebuggeeBPRecipeRemoved(listener: (bpRecipie: CDTPBPRecipe) => void): void {
+        this._communicator.subscribe(BreakpointsEvents.OnDebuggeeBPRecipeRemoved, listener);
+    }
+
+    public listenForOnBreakpointIsBound(listener: (breakpoint: CDTPBreakpoint) => void): void {
+        this._communicator.subscribe(BreakpointsEvents.OnBreakpointIsBound, listener);
+    }
+
+    public listenForOnBPRecipeIsUnbound(listener: (bpRecipieIsUnbound: BPRecipeIsUnbound) => void): void {
+        this._communicator.subscribe(BreakpointsEvents.OnBPRecipeIsUnboundForRuntimeSource, listener);
+    }
+
+    public publisherForClientBPRecipeAdded(): PublisherWithParamsFunction<BPRecipeInSource, void> {
+        return this._communicator.getPublisher(BreakpointsEvents.OnClientBPRecipeAdded);
+    }
+
+    public publisherForClientBPRecipeRemoved(): PublisherWithParamsFunction<BPRecipeInSource, void> {
+        return this._communicator.getPublisher(BreakpointsEvents.OnClientBPRecipeRemoved);
+    }
+
+    public publisherForDebuggeeBPRecipeAdded(): PublisherWithParamsFunction<CDTPBPRecipe, void> {
+        return this._communicator.getPublisher(BreakpointsEvents.OnDebuggeeBPRecipeAdded);
+    }
+
+    public publisherForDebuggeeBPRecipeRemoved(): PublisherWithParamsFunction<CDTPBPRecipe, void> {
+        return this._communicator.getPublisher(BreakpointsEvents.OnDebuggeeBPRecipeRemoved);
+    }
+
+    public publisherForBreakpointIsBound(): PublisherWithParamsFunction<CDTPBreakpoint, void> {
+        return this._communicator.getPublisher(BreakpointsEvents.OnBreakpointIsBound);
+    }
+
+    public publisherForBPRecipeIsUnbound(): PublisherWithParamsFunction<BPRecipeIsUnbound, void> {
+        return this._communicator.getPublisher(BreakpointsEvents.OnBPRecipeIsUnboundForRuntimeSource);
+    }
+}

--- a/src/chrome/internal/breakpoints/features/breakpointsEvents.ts
+++ b/src/chrome/internal/breakpoints/features/breakpointsEvents.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { NotificationChannelIdentifier } from '../../../communication/notificationsCommunicator';
+import { registerChannels } from '../../../communication/channel';
+import { BPRecipeInSource } from '../bpRecipeInSource';
+import { CDTPBPRecipe, CDTPBreakpoint } from '../../../cdtpDebuggee/cdtpPrimitives';
+import { BPRecipeIsUnbound } from '../bpRecipeStatusForRuntimeLocation';
+
+const _breakpointsEvents = {
+    OnClientBPRecipeAdded: new NotificationChannelIdentifier<BPRecipeInSource>(),
+    OnClientBPRecipeRemoved: new NotificationChannelIdentifier<BPRecipeInSource>(),
+    OnDebuggeeBPRecipeAdded: new NotificationChannelIdentifier<CDTPBPRecipe>(),
+    OnDebuggeeBPRecipeRemoved: new NotificationChannelIdentifier<CDTPBPRecipe>(),
+    OnBreakpointIsBound: new NotificationChannelIdentifier<CDTPBreakpoint>(),
+    OnBPRecipeIsUnboundForRuntimeSource: new NotificationChannelIdentifier<BPRecipeIsUnbound>(),
+};
+
+export const BreakpointsEvents: Readonly<typeof _breakpointsEvents> = _breakpointsEvents;
+registerChannels(BreakpointsEvents, 'BreakpointsEvents');

--- a/src/chrome/internal/breakpoints/features/breakpointsUpdater.ts
+++ b/src/chrome/internal/breakpoints/features/breakpointsUpdater.ts
@@ -1,0 +1,131 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { BPRecipesInSource, BPRecipesInLoadedSource } from '../bpRecipes';
+import { ExistingBPsForJustParsedScriptSetter } from './existingBPsForJustParsedScriptSetter';
+import { asyncMap } from '../../../collections/async';
+import { IBPRecipeStatus } from '../bpRecipeStatus';
+import { CurrentBPRecipesForSourceRegistry } from '../registries/currentBPRecipesForSourceRegistry';
+import { BreakpointsSetForScriptFinder } from '../registries/breakpointsSetForScriptFinder';
+import { BPRecipeAtLoadedSourceLogic } from './bpRecipeAtLoadedSourceLogic';
+import { IEventsToClientReporter } from '../../../client/eventsToClientReporter';
+import { PauseScriptLoadsToSetBPs } from './pauseScriptLoadsToSetBPs';
+import { inject, injectable } from 'inversify';
+import { TYPES } from '../../../dependencyInjection.ts/types';
+import { IDebuggeeBreakpointsSetter } from '../../../cdtpDebuggee/features/cdtpDebuggeeBreakpointsSetter';
+import { BPRsDeltaInRequestedSource } from './bpsDeltaCalculator';
+import { ConnectedCDAConfiguration } from '../../../client/chromeDebugAdapter/cdaConfiguration';
+import { IScriptParsedProvider } from '../../../cdtpDebuggee/eventsProviders/cdtpOnScriptParsedEventProvider';
+import { DebuggeeBPRsSetForClientBPRFinder } from '../registries/debuggeeBPRsSetForClientBPRFinder';
+import { BPRecipeInSource } from '../bpRecipeInSource';
+import { IDOMInstrumentationBreakpointsSetter } from '../../../cdtpDebuggee/features/cdtpDOMInstrumentationBreakpointsSetter';
+import { IDebuggeeExecutionController } from '../../../cdtpDebuggee/features/cdtpDebugeeExecutionController';
+import { IDebuggeeRuntimeVersionProvider } from '../../../cdtpDebuggee/features/cdtpDebugeeRuntimeVersionProvider';
+import { IBreakpointFeaturesSupport } from '../../../cdtpDebuggee/features/cdtpBreakpointFeaturesSupport';
+import { wrapWithMethodLogger } from '../../../logging/methodsCalledLogger';
+import { ITelemetryPropertyCollector } from '../../../../telemetry';
+import { IDebuggeePausedHandler } from '../../features/debuggeePausedHandler';
+import { BreakpointsEventSystem } from './breakpointsEventSystem';
+import { BPRecipeStatusCalculator } from '../registries/bpRecipeStatusCalculator';
+
+/**
+ * Update the breakpoint recipes for a particular source
+ */
+@injectable()
+export class BreakpointsUpdater {
+    private readonly _breakpointsEventSystem = new BreakpointsEventSystem();
+    private readonly _publishClientBPRecipeAdded = this._breakpointsEventSystem.publisherForClientBPRecipeAdded();
+    private readonly _publishClientBPRecipeRemoved = this._breakpointsEventSystem.publisherForClientBPRecipeRemoved();
+    private readonly _publishBreakpointIsBound = this._breakpointsEventSystem.publisherForBreakpointIsBound();
+
+    private readonly _clientCurrentBPRecipesRegistry = wrapWithMethodLogger(new CurrentBPRecipesForSourceRegistry(), 'ClientCurrentBPRecipesRegistry');
+    private readonly _debuggeeBPRsSetForClientBPRFinder = wrapWithMethodLogger(new DebuggeeBPRsSetForClientBPRFinder(this._breakpointsEventSystem), 'DebuggeeBPRsSetForClientBPRFinder');
+    private readonly _breakpointsSetForScriptFinder = wrapWithMethodLogger(new BreakpointsSetForScriptFinder(this._breakpointsEventSystem), 'BreakpointsSetForScriptFinder');
+    private readonly _bpRecipeStatusCalculator = wrapWithMethodLogger(new BPRecipeStatusCalculator(this._breakpointsEventSystem,
+        { onBPRecipeStatusChanged: bpRecipe => this.onBPRecipeStatusChanged(bpRecipe) }), 'BPRecipeStatusCalculator');
+
+    private readonly _breakpointsInLoadedSource = new BPRecipeAtLoadedSourceLogic(this._breakpointsEventSystem, this._breakpointFeaturesSupport, this._debuggeeBPRsSetForClientBPRFinder,
+        this._targetBreakpoints, this._eventsToClientReporter, this._debuggeePausedHandler).withLogging;
+
+    private readonly _existingBPsForJustParsedScriptSetter = new ExistingBPsForJustParsedScriptSetter(this._scriptParsedProvider, this._debuggeeBPRsSetForClientBPRFinder, this._clientCurrentBPRecipesRegistry, this._breakpointsInLoadedSource).withLogging;
+
+    private readonly _bpsWhileLoadingLogic: PauseScriptLoadsToSetBPs = new PauseScriptLoadsToSetBPs(this._debuggeePausedHandler, this._domInstrumentationBreakpoints, this._debugeeExecutionControl, this._eventsToClientReporter,
+        this._debugeeVersionProvider, this._existingBPsForJustParsedScriptSetter, this._breakpointsSetForScriptFinder).withLogging;
+
+    private _isBpsWhileLoadingEnable: boolean;
+
+    constructor(
+        @inject(TYPES.IDebuggeePausedHandler) private readonly _debuggeePausedHandler: IDebuggeePausedHandler,
+        @inject(TYPES.ITargetBreakpoints) private readonly _debuggeeBreakpoints: IDebuggeeBreakpointsSetter,
+        @inject(TYPES.ConnectedCDAConfiguration) private readonly _configuration: ConnectedCDAConfiguration,
+        @inject(TYPES.IScriptParsedProvider) private readonly _scriptParsedProvider: IScriptParsedProvider,
+        @inject(TYPES.IDOMInstrumentationBreakpoints) private readonly _domInstrumentationBreakpoints: IDOMInstrumentationBreakpointsSetter,
+        @inject(TYPES.IDebuggeeExecutionControl) private readonly _debugeeExecutionControl: IDebuggeeExecutionController,
+        @inject(TYPES.IEventsToClientReporter) protected readonly _eventsToClientReporter: IEventsToClientReporter,
+        @inject(TYPES.IBreakpointFeaturesSupport) private readonly _breakpointFeaturesSupport: IBreakpointFeaturesSupport,
+        @inject(TYPES.ITargetBreakpoints) private readonly _targetBreakpoints: IDebuggeeBreakpointsSetter,
+        @inject(TYPES.IDebuggeeVersionProvider) protected readonly _debugeeVersionProvider: IDebuggeeRuntimeVersionProvider) {
+        this._bpsWhileLoadingLogic.install();
+        this._debuggeeBreakpoints.onBreakpointResolvedSyncOrAsync(breakpoint => this._publishBreakpointIsBound(breakpoint));
+        this.configure();
+    }
+
+    protected onBPRecipeStatusChanged(bpRecipe: BPRecipeInSource): void {
+        const bpRecipeStatus = this._bpRecipeStatusCalculator.statusOfBPRecipe(bpRecipe);
+        this._eventsToClientReporter.sendBPStatusChanged({ reason: 'changed', bpRecipeStatus: bpRecipeStatus });
+    }
+
+    public async updateBreakpointsForFile(requestedBPs: BPRecipesInSource, _?: ITelemetryPropertyCollector): Promise<IBPRecipeStatus[]> {
+        const bpsDelta = this._clientCurrentBPRecipesRegistry.updateBPRecipesAndCalculateDelta(requestedBPs);
+        const requestedBPsToAdd = new BPRecipesInSource(bpsDelta.resource, bpsDelta.requestedToAdd);
+        for (const requestedBP of bpsDelta.requestedToAdd) {
+            await this._publishClientBPRecipeAdded(requestedBP);
+        }
+
+        await requestedBPsToAdd.tryResolving(
+            async requestedBPsToAddInLoadedSources => {
+                // Match desired breakpoints to existing breakpoints
+                if (requestedBPsToAddInLoadedSources.source.doesScriptHasUrl()) {
+                    await this.addNewBreakpointsForFile(requestedBPsToAddInLoadedSources);
+                    await this.removeDeletedBreakpointsFromFile(bpsDelta);
+                } else {
+                    // TODO: We need to pause-update-resume the debugger here to avoid a race condition
+                    await this.removeDeletedBreakpointsFromFile(bpsDelta);
+                    await this.addNewBreakpointsForFile(requestedBPsToAddInLoadedSources);
+                }
+            },
+            () => {
+                /**
+                 * TODO: Implement setting breakpoints using an heuristic when we cannot resolve the source
+                 * const existingUnboundBPs = bpsDelta.existingToLeaveAsIs.filter(bp => !this._bpRecipeStatusCalculator.statusOfBPRecipe(bp).isVerified());
+                 * const requestedBPsPendingToAdd = new BPRecipesInSource(bpsDelta.resource, bpsDelta.requestedToAdd.concat(existingUnboundBPs));
+                 */
+                if (this._isBpsWhileLoadingEnable) {
+                    this._bpsWhileLoadingLogic.enableIfNeccesary();
+                }
+            });
+
+        return bpsDelta.matchesForRequested.map(bpRecipe => this._bpRecipeStatusCalculator.statusOfBPRecipe(bpRecipe));
+    }
+
+    private async removeDeletedBreakpointsFromFile(bpsDelta: BPRsDeltaInRequestedSource) {
+        await asyncMap(bpsDelta.existingToRemove, async (existingBPToRemove) => {
+            await this._breakpointsInLoadedSource.removeDebuggeeBPRs(existingBPToRemove);
+            this._publishClientBPRecipeRemoved(existingBPToRemove);
+        });
+    }
+
+    private async addNewBreakpointsForFile(requestedBPsToAddInLoadedSources: BPRecipesInLoadedSource) {
+        await asyncMap(requestedBPsToAddInLoadedSources.breakpoints, async (requestedBP) => {
+            // DIEGO TODO: Do we need to do one breakpoint at a time to avoid issues on CDTP, or can we do them in parallel now that we use a different algorithm?
+            await this._breakpointsInLoadedSource.addBreakpointAtLoadedSource(requestedBP);
+        });
+    }
+
+    public configure(): this {
+        this._isBpsWhileLoadingEnable = this._configuration.args.breakOnLoadStrategy !== 'off';
+        return this;
+
+    }
+}

--- a/src/chrome/internal/breakpoints/features/existingBPsForJustParsedScriptSetter.ts
+++ b/src/chrome/internal/breakpoints/features/existingBPsForJustParsedScriptSetter.ts
@@ -1,0 +1,91 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { ILoadedSource } from '../../sources/loadedSource';
+import { asyncMap } from '../../../collections/async';
+import { promiseDefer, IPromiseDefer } from '../../../../utils';
+import { IBreakpointsInLoadedSource } from './bpRecipeAtLoadedSourceLogic';
+import { IScriptParsedProvider } from '../../../cdtpDebuggee/eventsProviders/cdtpOnScriptParsedEventProvider';
+import { DebuggeeBPRsSetForClientBPRFinder } from '../registries/debuggeeBPRsSetForClientBPRFinder';
+import { CurrentBPRecipesForSourceRegistry } from '../registries/currentBPRecipesForSourceRegistry';
+import { ValidatedMap } from '../../../collections/validatedMap';
+import { BPRecipeInSource } from '../bpRecipeInSource';
+import { wrapWithMethodLogger } from '../../../logging/methodsCalledLogger';
+import { IBPActionWhenHit } from '../bpActionWhenHit';
+import { BPRecipeInScript } from '../baseMappedBPRecipe';
+import { LocationInLoadedSource } from '../../locations/location';
+import { IScript } from '../../scripts/script';
+
+/**
+ * Set all the neccesary debuggee breakpoint recipes for a script that was just parsed
+ */
+export class ExistingBPsForJustParsedScriptSetter {
+    private readonly _scriptToBPsAreSetDefer = new ValidatedMap<IScript, IPromiseDefer<void>>();
+
+    public readonly withLogging = wrapWithMethodLogger(this);
+
+    constructor(
+        private readonly _scriptParsedProvider: IScriptParsedProvider,
+        private readonly _debuggeeBPRsSetForClientBPRFinder: DebuggeeBPRsSetForClientBPRFinder,
+        private readonly _clientCurrentBPRecipesRegistry: CurrentBPRecipesForSourceRegistry,
+        private readonly _breakpointsInLoadedSource: IBreakpointsInLoadedSource) {
+        this._scriptParsedProvider.onScriptParsed(scriptParsed => this.withLogging.setBPsForScript(scriptParsed.script));
+    }
+
+    public waitUntilBPsAreSet(script: IScript): Promise<void> {
+        const doesScriptHaveAnyBPRecipes = script.allSources.find(source => this._clientCurrentBPRecipesRegistry.bpRecipesForSource(source.identifier).length >= 1);
+        if (doesScriptHaveAnyBPRecipes) {
+            return this.finishedSettingBPsForScriptDefer(script).promise;
+        } else {
+            const defer = this._scriptToBPsAreSetDefer.tryGetting(script);
+            return Promise.resolve(defer && defer.promise);
+        }
+    }
+
+    private finishedSettingBPsForScriptDefer(script: IScript): IPromiseDefer<void> {
+        return this._scriptToBPsAreSetDefer.getOrAdd(script, () => promiseDefer<void>());
+    }
+
+    private async setBPsForScript(justParsedScript: IScript): Promise<void> {
+        const defer = this.finishedSettingBPsForScriptDefer(justParsedScript);
+        await asyncMap(justParsedScript.allSources, source => this.withLogging.setBPsFromSourceIntoScript(source, justParsedScript));
+        defer.resolve();
+    }
+
+    private async setBPsFromSourceIntoScript(sourceWhichMayHaveBPs: ILoadedSource, justParsedScript: IScript): Promise<void> {
+        const bpRecipesInSource = this._clientCurrentBPRecipesRegistry.bpRecipesForSource(sourceWhichMayHaveBPs.identifier);
+
+        for (const bpRecipe of bpRecipesInSource) {
+            await this.withLogging.setBPFromSourceIntoScriptIfNeeded(bpRecipe, justParsedScript, sourceWhichMayHaveBPs);
+        }
+    }
+
+    private async setBPFromSourceIntoScriptIfNeeded(bpRecipe: BPRecipeInSource<IBPActionWhenHit>, justParsedScript: IScript, sourceWhichMayHaveBPs: ILoadedSource<string>) {
+        const debuggeeBPRecipes = this._debuggeeBPRsSetForClientBPRFinder.findDebuggeeBPRsSet(bpRecipe);
+        const bpRecepieResolved = bpRecipe.resolvedWithLoadedSource(sourceWhichMayHaveBPs);
+        const runtimeLocationsWhichAlreadyHaveThisBPR = debuggeeBPRecipes.map(recipe => recipe.runtimeSourceLocation);
+
+        const bprInScripts = bpRecepieResolved.mappedToScript().filter(b => b.location.script === justParsedScript);
+        await this.withLogging.setBPRsInScriptIfNeeded(bprInScripts, runtimeLocationsWhichAlreadyHaveThisBPR, bpRecipe);
+    }
+
+    private async setBPRsInScriptIfNeeded(bprInScripts: BPRecipeInScript[], runtimeLocationsWhichAlreadyHaveThisBPR: LocationInLoadedSource[], bpRecipe: BPRecipeInSource<IBPActionWhenHit>) {
+        for (const bprInScript of bprInScripts) {
+            await this.withLogging.setBPRInScriptFromSourceIntoScriptIfNeeded(bprInScript, runtimeLocationsWhichAlreadyHaveThisBPR, bpRecipe);
+        }
+    }
+
+    private async setBPRInScriptFromSourceIntoScriptIfNeeded(bprInScript: BPRecipeInScript, runtimeLocationsWhichAlreadyHaveThisBPR: LocationInLoadedSource[], bpRecipe: BPRecipeInSource<IBPActionWhenHit>): Promise<void> {
+        const bprInRuntimeSource = bprInScript.mappedToRuntimeSource();
+
+        // Was the breakpoint already set for the runtime source of this script? (This will happen if we include the same script twice in the same debuggee)
+        if (!runtimeLocationsWhichAlreadyHaveThisBPR.some(location => location.isEquivalentTo(bprInRuntimeSource.location))) {
+            await this._breakpointsInLoadedSource.addBreakpointAtLoadedSource(bprInRuntimeSource);
+        }
+    }
+
+    public toString(): string {
+        return `ExistingBPsForJustParsedScriptSetter`;
+    }
+}

--- a/src/chrome/internal/breakpoints/features/hitCountBreakpoints.ts
+++ b/src/chrome/internal/breakpoints/features/hitCountBreakpoints.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { IBPRecipe } from '../bpRecipe';
+import { BPRecipeInSource } from '../bpRecipeInSource';
+import { PauseOnHitCount } from '../bpActionWhenHit';
+import { ValidatedMap } from '../../../collections/validatedMap';
+import { HitCountConditionParser, HitCountConditionFunction } from './hitCountConditionParser';
+import { BaseNotifyClientOfPause, ActionToTakeWhenPausedProvider, IActionToTakeWhenPaused, NoActionIsNeededForThisPause } from '../../features/actionToTakeWhenPaused';
+import { ReasonType } from '../../../stoppedEvent';
+import { injectable, inject } from 'inversify';
+import { IEventsToClientReporter } from '../../../client/eventsToClientReporter';
+import { TYPES } from '../../../dependencyInjection.ts/types';
+import { PausedEvent } from '../../../cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider';
+import { ScriptOrSourceOrURLOrURLRegexp } from '../../locations/location';
+import { IDebuggeePausedHandler } from '../../features/debuggeePausedHandler';
+
+export interface IHitCountBreakpointsDependencies {
+    registerAddBPRecipeHandler(handlerRequirements: (bpRecipe: BPRecipeInSource) => boolean,
+        handler: (bpRecipe: BPRecipeInSource) => Promise<void>): void;
+
+    addBPRecipe(bpRecipe: BPRecipeInSource): Promise<void>;
+    notifyBPWasHit(bpRecipe: BPRecipeInSource): Promise<void>;
+
+    registerActionToTakeWhenPausedProvider(listener: ActionToTakeWhenPausedProvider): void;
+    publishGoingToPauseClient(): void;
+}
+
+class NotAbstained { }
+
+class HitCountBPData {
+    private _hitCount = 0;
+
+    constructor(
+        private readonly _voter: unknown,
+        public readonly hitBPRecipe: BPRecipeInSource<PauseOnHitCount>,
+        private readonly _shouldPauseCondition: HitCountConditionFunction) { }
+
+    public notifyBPHit(): object {
+        return this._shouldPauseCondition(this._hitCount++)
+            ? new NotAbstained()
+            : new NoActionIsNeededForThisPause(this._voter);
+    }
+}
+
+export class HitAndSatisfiedCountBPCondition extends BaseNotifyClientOfPause {
+    protected reason: ReasonType = 'breakpoint';
+
+    constructor(protected readonly _eventsToClientReporter: IEventsToClientReporter) {
+        super();
+    }
+}
+
+// TODO DIEGO: Install and use this feature
+/**
+ * Implement the hit count breakpoints feature
+ */
+@injectable()
+export class HitCountBreakpoints {
+    private readonly underlyingToBPRecipe = new ValidatedMap<IBPRecipe<ScriptOrSourceOrURLOrURLRegexp>, HitCountBPData>();
+
+    constructor(
+        private readonly _dependencies: IHitCountBreakpointsDependencies,
+        @inject(TYPES.IDebuggeePausedHandler) private readonly _debuggeePausedHandler: IDebuggeePausedHandler,
+        @inject(TYPES.IEventsToClientReporter) private readonly _eventsToClientReporter: IEventsToClientReporter) {
+        this._dependencies.registerAddBPRecipeHandler(
+            bpRecipe => bpRecipe.bpActionWhenHit instanceof PauseOnHitCount,
+            bpRecipe => this.addBPRecipe(bpRecipe as BPRecipeInSource<PauseOnHitCount>));
+        this._debuggeePausedHandler.registerActionProvider(paused => this.onProvideActionForWhenPaused(paused));
+    }
+
+    private async addBPRecipe(bpRecipe: BPRecipeInSource<PauseOnHitCount>): Promise<void> {
+        const underlyingBPRecipe = bpRecipe.withAlwaysBreakAction();
+        const shouldPauseCondition = new HitCountConditionParser(bpRecipe.bpActionWhenHit.pauseOnHitCondition).parse();
+        this._dependencies.addBPRecipe(underlyingBPRecipe);
+        this.underlyingToBPRecipe.set(underlyingBPRecipe, new HitCountBPData(this, bpRecipe, shouldPauseCondition));
+    }
+
+    public async onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
+        const hitCountBPData = paused.hitBreakpoints.map(hitBPRecipe =>
+            this.underlyingToBPRecipe.tryGetting(hitBPRecipe.unmappedBPRecipe)).filter(bpRecipe => bpRecipe !== undefined);
+
+        const individualDecisions = hitCountBPData.map(data => data.notifyBPHit());
+        return individualDecisions.some(v => !(v instanceof NoActionIsNeededForThisPause))
+            ? new HitAndSatisfiedCountBPCondition(this._eventsToClientReporter)
+            : new NoActionIsNeededForThisPause(this);
+    }
+}

--- a/src/chrome/internal/breakpoints/features/hitCountConditionParser.ts
+++ b/src/chrome/internal/breakpoints/features/hitCountConditionParser.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+export type HitCountConditionFunction = (numHits: number) => boolean;
+
+export class HitCountConditionParser {
+    private readonly HIT_COUNT_CONDITION_PATTERN = /^(>|>=|=|<|<=|%)?\s*([0-9]+)$/;
+    private patternMatches: RegExpExecArray | undefined;
+
+    constructor(private readonly _hitCountCondition: string) { }
+
+    public parse(): HitCountConditionFunction {
+        this.patternMatches = this.HIT_COUNT_CONDITION_PATTERN.exec(this._hitCountCondition.trim());
+        if (this.patternMatches && this.patternMatches.length >= 3) {
+            // eval safe because of the regex, and this is only a string that the current user will type in
+            /* tslint:disable:no-function-constructor-with-string-args */
+            const shouldPause: HitCountConditionFunction = <any>new Function('numHits', this.javaScriptCodeToEvaluateCondition());
+            /* tslint:enable:no-function-constructor-with-string-args */
+            return shouldPause;
+        } else {
+            throw new Error(`Didn't recognize <${this._hitCountCondition}> as a valid hit count condition`);
+        }
+    }
+
+    private javaScriptCodeToEvaluateCondition() {
+        const operator = this.parseOperator();
+        const value = this.parseValue();
+        const javaScriptCode = operator === '%'
+            ? `return (numHits % ${value}) === 0;`
+            : `return numHits ${operator} ${value};`;
+        return javaScriptCode;
+    }
+
+    private parseValue(): string {
+        return this.patternMatches[2];
+    }
+
+    private parseOperator(): string {
+        let op = this.patternMatches[1] || '>=';
+        if (op === '=')
+            op = '==';
+        return op;
+    }
+}

--- a/src/chrome/internal/breakpoints/features/pauseScriptLoadsToSetBPs.ts
+++ b/src/chrome/internal/breakpoints/features/pauseScriptLoadsToSetBPs.ts
@@ -1,0 +1,123 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { IComponentWithAsyncInitialization } from '../../features/components';
+import { BaseNotifyClientOfPause, IActionToTakeWhenPaused, NoActionIsNeededForThisPause, BasePauseShouldBeAutoResumed } from '../../features/actionToTakeWhenPaused';
+import { ReasonType } from '../../../stoppedEvent';
+import { IEventsToClientReporter } from '../../../client/eventsToClientReporter';
+import { IDebuggeeExecutionController } from '../../../cdtpDebuggee/features/cdtpDebugeeExecutionController';
+import { ExistingBPsForJustParsedScriptSetter } from './existingBPsForJustParsedScriptSetter';
+import { BreakpointsSetForScriptFinder } from '../registries/breakpointsSetForScriptFinder';
+import { IDOMInstrumentationBreakpointsSetter } from '../../../cdtpDebuggee/features/cdtpDOMInstrumentationBreakpointsSetter';
+import { IDebuggeeRuntimeVersionProvider } from '../../../cdtpDebuggee/features/cdtpDebugeeRuntimeVersionProvider';
+import { PausedEvent } from '../../../cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider';
+import { wrapWithMethodLogger } from '../../../logging/methodsCalledLogger';
+import { IDebuggeePausedHandler } from '../../features/debuggeePausedHandler';
+
+export class HitStillPendingBreakpoint extends BaseNotifyClientOfPause {
+    protected reason: ReasonType = 'breakpoint';
+
+    constructor(protected readonly _eventsToClientReporter: IEventsToClientReporter) {
+        super();
+    }
+}
+
+export class PausedWhileLoadingScriptToResolveBreakpoints extends BasePauseShouldBeAutoResumed {
+    constructor(protected readonly _debuggeeExecutionControl: IDebuggeeExecutionController) {
+        super();
+    }
+}
+
+/// TODO: Move this to a browser-shared package
+/**
+ * Pause the scripts after they are parsed, so we have time to set all the breakpoint recipes for that script before resuming the execution,
+ * thus eliminating the race condition we'd have without this feature, and warranting that all breakpoint recipes for a source will be hit
+ * (Currently this only works for scripts that are added to the DOM)
+ */
+export class PauseScriptLoadsToSetBPs implements IComponentWithAsyncInitialization {
+    private readonly stopsWhileScriptsLoadInstrumentationName = 'scriptFirstStatement';
+    private _isInstrumentationEnabled = false;
+    private _scriptFirstStatementStopsBeforeFile: boolean;
+
+    public readonly withLogging = wrapWithMethodLogger(this);
+
+    constructor(
+        private readonly _debuggeePausedHandler: IDebuggeePausedHandler,
+        private readonly _domInstrumentationBreakpoints: IDOMInstrumentationBreakpointsSetter,
+        private readonly _debugeeExecutionControl: IDebuggeeExecutionController,
+        private readonly _eventsToClientReporter: IEventsToClientReporter,
+        private readonly _debugeeVersionProvider: IDebuggeeRuntimeVersionProvider,
+        private readonly _existingBPsForJustParsedScriptSetter: ExistingBPsForJustParsedScriptSetter,
+        private readonly _breakpointsRegistry: BreakpointsSetForScriptFinder,
+    ) {
+        this._debuggeePausedHandler.registerActionProvider(paused => this.withLogging.onProvideActionForWhenPaused(paused));
+    }
+
+    public async enableIfNeccesary(): Promise<void> {
+        if (this._isInstrumentationEnabled === false) {
+            await this.startPausingOnScriptFirstStatement();
+        }
+    }
+
+    // TODO: Figure out if and when we can disable break on load for performance reasons
+    public async disableIfNeccesary(): Promise<void> {
+        if (this._isInstrumentationEnabled === true) {
+            await this.stopPausingOnScriptFirstStatement();
+        }
+    }
+
+    private async onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
+        if (this.isInstrumentationPause(paused)) {
+            await this._existingBPsForJustParsedScriptSetter.waitUntilBPsAreSet(paused.callFrames[0].location.script);
+
+            // If we pause before starting the script, we can just resume, and we'll a breakpoint if it's on 0,0
+            if (!this._scriptFirstStatementStopsBeforeFile) {
+                // On Chrome 69 we pause inside the script, so we need to check if there is a breakpoint at 0,0 that we need to use
+                const breakpoints = this._breakpointsRegistry.tryGettingBreakpointAtLocation(paused.callFrames[0].location);
+                if (breakpoints.length > 0) {
+                    return new HitStillPendingBreakpoint(this._eventsToClientReporter);
+                }
+            }
+
+            return new PausedWhileLoadingScriptToResolveBreakpoints(this._debugeeExecutionControl);
+        } else {
+            return new NoActionIsNeededForThisPause(this);
+        }
+    }
+
+    private async startPausingOnScriptFirstStatement(): Promise<void> {
+        try {
+            this._isInstrumentationEnabled = true;
+            await this._domInstrumentationBreakpoints.setInstrumentationBreakpoint({ eventName: this.stopsWhileScriptsLoadInstrumentationName });
+        } catch (exception) {
+            this._isInstrumentationEnabled = false;
+            throw exception;
+        }
+    }
+
+    private async stopPausingOnScriptFirstStatement(): Promise<void> {
+        await this._domInstrumentationBreakpoints.removeInstrumentationBreakpoint({ eventName: this.stopsWhileScriptsLoadInstrumentationName });
+        this._isInstrumentationEnabled = false;
+    }
+
+    private isInstrumentationPause(notification: PausedEvent): boolean {
+        return (notification.reason === 'EventListener' && notification.data.eventName.startsWith('instrumentation:')) ||
+            (notification.reason === 'ambiguous' && Array.isArray(notification.data.reasons) &&
+                notification.data.reasons.every((r: any) => r.reason === 'EventListener' && r.auxData.eventName.startsWith('instrumentation:')));
+    }
+
+    public async install(): Promise<this> {
+        // TODO DIEGO: Figure out exactly when we want to block on the browser version
+        // On version 69 Chrome stopped sending an extra event for DOM Instrumentation: See https://bugs.chromium.org/p/chromium/issues/detail?id=882909
+        // On Chrome 68 we were relying on that event to make Break on load work on breakpoints on the first line of a file. On Chrome 69 we need an alternative way to make it work.
+        // TODO: Reenable the code that uses Versions.Target.Version when this fails
+        const runtimeVersion = await this._debugeeVersionProvider.version();
+        this._scriptFirstStatementStopsBeforeFile = !runtimeVersion.isAtLeastVersion('69.0.0');
+        return this;
+    }
+
+    public toString(): string {
+        return 'PauseScriptLoadsToSetBPs';
+    }
+}

--- a/src/chrome/internal/breakpoints/features/setBreakpointsRequestHandler.ts
+++ b/src/chrome/internal/breakpoints/features/setBreakpointsRequestHandler.ts
@@ -1,0 +1,86 @@
+import { injectable, inject } from 'inversify';
+import { ICommandHandlerDeclaration, CommandHandlerDeclaration, ICommandHandlerDeclarer } from '../../features/components';
+import { DebugProtocol } from 'vscode-debugprotocol';
+import { BreakpointsUpdater } from './breakpointsUpdater';
+import { ISetBreakpointsResponseBody, ITelemetryPropertyCollector } from '../../../../debugAdapterInterfaces';
+import { BPRecipesInSource } from '../bpRecipes';
+import { asyncMap } from '../../../collections/async';
+import { ClientSourceParser } from '../../../client/clientSourceParser';
+import { BPRecipieStatusToClientConverter } from './bpRecipieStatusToClientConverter';
+import { BPRecipeInSource } from '../bpRecipeInSource';
+import { LocationInSource, Position } from '../../locations/location';
+import { ConditionalPause, AlwaysPause, IBPActionWhenHit } from '../bpActionWhenHit';
+import { ISource } from '../../sources/source';
+import { TYPES } from '../../../dependencyInjection.ts/types';
+import { HandlesRegistry } from '../../../client/handlesRegistry';
+import { LineColTransformer } from '../../../../transformers/lineNumberTransformer';
+import { createLineNumber, createColumnNumber } from '../../locations/subtypes';
+import { SourceResolver } from '../../sources/sourceResolver';
+
+@injectable()
+export class SetBreakpointsRequestHandler implements ICommandHandlerDeclarer {
+    private readonly _clientSourceParser = new ClientSourceParser(this._handlesRegistry, this._sourcesResolver);
+    private readonly _bpRecipieStatusToClientConverter = new BPRecipieStatusToClientConverter(this._handlesRegistry, this._lineColTransformer);
+
+    public constructor(
+        @inject(TYPES.BreakpointsLogic) protected readonly _breakpointsLogic: BreakpointsUpdater,
+        @inject(HandlesRegistry) private readonly _handlesRegistry: HandlesRegistry,
+        @inject(TYPES.LineColTransformer) private readonly _lineColTransformer: LineColTransformer,
+        private readonly _sourcesResolver: SourceResolver) { }
+
+    public async setBreakpoints(args: DebugProtocol.SetBreakpointsArguments, telemetryPropertyCollector?: ITelemetryPropertyCollector): Promise<ISetBreakpointsResponseBody> {
+        if (args.breakpoints) {
+            const desiredBPRecipes = this.toBPRecipes(args);
+            const bpRecipesStatus = await this._breakpointsLogic.updateBreakpointsForFile(desiredBPRecipes, telemetryPropertyCollector);
+            return { breakpoints: await asyncMap(bpRecipesStatus, bprs => this._bpRecipieStatusToClientConverter.toBreakpoint(bprs)) };
+        } else {
+            throw new Error(`Expected the set breakpoints arguments to have a list of breakpoints yet it was ${args.breakpoints}`);
+        }
+    }
+
+    private toBPRecipes(args: DebugProtocol.SetBreakpointsArguments): BPRecipesInSource {
+        const source = this._clientSourceParser.toSource(args.source);
+        const breakpoints = args.breakpoints.map(breakpoint => this.toBPRecipe(source, breakpoint));
+        return new BPRecipesInSource(source, breakpoints);
+    }
+
+    private toBPRecipe(source: ISource, clientBreakpoint: DebugProtocol.SourceBreakpoint): BPRecipeInSource {
+        return new BPRecipeInSource(
+            new LocationInSource(source, this.toLocation(clientBreakpoint)),
+            this.toBPActionWhenHit(clientBreakpoint));
+    }
+
+    private toBPActionWhenHit(actionWhenHit: { condition?: string; hitCondition?: string; logMessage?: string; }): IBPActionWhenHit {
+        let howManyDefined = 0;
+        howManyDefined += actionWhenHit.condition ? 1 : 0;
+        howManyDefined += actionWhenHit.hitCondition ? 1 : 0;
+        howManyDefined += actionWhenHit.logMessage ? 1 : 0;
+        if (howManyDefined === 0) {
+            return new AlwaysPause();
+        } else if (howManyDefined === 1) {
+            if (actionWhenHit.condition) {
+                return new ConditionalPause(actionWhenHit.condition);
+            } else if (actionWhenHit.hitCondition) {
+                return new ConditionalPause(actionWhenHit.hitCondition);
+            } else if (actionWhenHit.logMessage) {
+                return new ConditionalPause(actionWhenHit.logMessage);
+            } else {
+                throw new Error(`Couldn't parse the desired action when hit for the breakpoint: 'condition' (${actionWhenHit.condition}), 'hitCondition' (${actionWhenHit.hitCondition}) or 'logMessage' (${actionWhenHit.logMessage})`);
+            }
+        } else { // howManyDefined >= 2
+            throw new Error(`Expected a single one of 'condition' (${actionWhenHit.condition}), 'hitCondition' (${actionWhenHit.hitCondition}) and 'logMessage' (${actionWhenHit.logMessage}) to be defined, yet multiple were defined.`);
+        }
+    }
+
+    private toLocation(location: { line: number; column?: number; }): Position {
+        const lineNumber = createLineNumber(this._lineColTransformer.convertClientLineToDebugger(location.line));
+        const columnNumber = location.column !== undefined ? createColumnNumber(this._lineColTransformer.convertClientColumnToDebugger(location.column)) : undefined;
+        return new Position(lineNumber, columnNumber);
+    }
+
+    public getCommandHandlerDeclarations(): ICommandHandlerDeclaration[] {
+        return CommandHandlerDeclaration.fromLiteralObject({
+            setBreakpoints: args => this.setBreakpoints(args)
+        });
+    }
+}

--- a/src/chrome/internal/breakpoints/registries/bpRecipeStatusCalculator.ts
+++ b/src/chrome/internal/breakpoints/registries/bpRecipeStatusCalculator.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { createBPRecipieStatus, IBPRecipeStatus } from '../bpRecipeStatus';
+import { LocationInLoadedSource } from '../../locations/location';
+import { CDTPBreakpoint } from '../../../cdtpDebuggee/cdtpPrimitives';
+import { ValidatedMap, IValidatedMap } from '../../../collections/validatedMap';
+import { BPRecipeInSource } from '../bpRecipeInSource';
+import { BPRecipeIsUnbound, BPRecipeIsBoundInRuntimeLocation } from '../bpRecipeStatusForRuntimeLocation';
+import { IBreakpointsEventsListener } from '../features/breakpointsEventSystem';
+import { printMap } from '../../../collections/printing';
+import { ValidatedMultiMap } from '../../../collections/validatedMultiMap';
+
+export interface IBPRecipeStatusCalculatorGeneratedEventsListener {
+    onBPRecipeStatusChanged(bpRecipeInSource: BPRecipeInSource): void;
+}
+
+/**
+ * Calculates the status (Bound vs Unbound) for a BPRecipe. This class needs to be aware that a Client BP Recipe might generate multiple Debuggee BP Recipes
+ */
+export class BPRecipeStatusCalculator {
+    private readonly _recipeToStatusAtLocation = new ValidatedMap<BPRecipeInSource, IValidatedMap<LocationInLoadedSource, BPRecipeIsBoundInRuntimeLocation>>();
+    private readonly _recipeToUnboundStatus = new ValidatedMultiMap<BPRecipeInSource, BPRecipeIsUnbound>();
+
+    public constructor(
+        breakpointsEventsListener: IBreakpointsEventsListener,
+        private readonly _generatedEventsListener: IBPRecipeStatusCalculatorGeneratedEventsListener) {
+        breakpointsEventsListener.listenForOnClientBPRecipeAdded(clientBPRecipe => this.onClientBPRecipeAdded(clientBPRecipe));
+        breakpointsEventsListener.listenForOnClientBPRecipeRemoved(clientBPRecipe => this.onClientBPRecipeRemoved(clientBPRecipe));
+        breakpointsEventsListener.listenForOnBreakpointIsBound(breakpoint => this.onBreakpointIsBound(breakpoint));
+        breakpointsEventsListener.listenForOnBPRecipeIsUnbound(bpRecipeIsUnbound => this.onBPRecipeIsUnbound(bpRecipeIsUnbound));
+    }
+
+    public statusOfBPRecipe(bpRecipe: BPRecipeInSource): IBPRecipeStatus {
+        const boundSubstatuses = Array.from(this._recipeToStatusAtLocation.get(bpRecipe).values());
+        const unboundSubstatuses = Array.from(this._recipeToUnboundStatus.get(bpRecipe));
+
+        return createBPRecipieStatus(bpRecipe, boundSubstatuses, unboundSubstatuses);
+    }
+
+    private onClientBPRecipeAdded(bpRecipe: BPRecipeInSource): void {
+        this._recipeToStatusAtLocation.set(bpRecipe, new ValidatedMap<LocationInLoadedSource, BPRecipeIsBoundInRuntimeLocation>());
+        this._recipeToUnboundStatus.addKeyIfNotExistant(bpRecipe);
+    }
+
+    private onBreakpointIsBound(breakpoint: CDTPBreakpoint): void {
+        const bpRecipe = breakpoint.recipe.unmappedBPRecipe;
+        const locationInRuntimeSource = breakpoint.actualLocation.mappedToRuntimeSource();
+        const runtimeSourceToBPRStatus = this._recipeToStatusAtLocation.get(bpRecipe);
+
+        runtimeSourceToBPRStatus.set(locationInRuntimeSource, new BPRecipeIsBoundInRuntimeLocation(bpRecipe, locationInRuntimeSource, [breakpoint.mappedToSource()]));
+        this._generatedEventsListener.onBPRecipeStatusChanged(bpRecipe);
+    }
+
+    private onBPRecipeIsUnbound(bpRecipeIsUnbound: BPRecipeIsUnbound): void {
+        this._recipeToUnboundStatus.add(bpRecipeIsUnbound.recipe, bpRecipeIsUnbound);
+        this._generatedEventsListener.onBPRecipeStatusChanged(bpRecipeIsUnbound.recipe);
+    }
+
+    private onClientBPRecipeRemoved(bpRecipe: BPRecipeInSource): void {
+        this._recipeToStatusAtLocation.delete(bpRecipe);
+        this._recipeToUnboundStatus.delete(bpRecipe);
+    }
+
+    public toString(): string {
+        return `${printMap(`BPRecipe status calculator:`, this._recipeToStatusAtLocation)} ${printMap(`Unbound bps:`, this._recipeToUnboundStatus)}`;
+    }
+}

--- a/src/chrome/internal/breakpoints/registries/breakpointsSetForScriptFinder.ts
+++ b/src/chrome/internal/breakpoints/registries/breakpointsSetForScriptFinder.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { ValidatedMultiMap } from '../../../collections/validatedMultiMap';
+import { LocationInScript } from '../../locations/location';
+import { CDTPBreakpoint } from '../../../cdtpDebuggee/cdtpPrimitives';
+import { IScript } from '../../scripts/script';
+import { IBreakpointsEventsListener } from '../features/breakpointsEventSystem';
+
+/**
+ * Find the list of breakpoints that we set for a particular script
+ */
+export class BreakpointsSetForScriptFinder {
+    private readonly _scriptToBreakpoints = new ValidatedMultiMap<IScript, CDTPBreakpoint>();
+
+    public constructor(breakpointsEventsListener: IBreakpointsEventsListener, ) {
+        breakpointsEventsListener.listenForOnBreakpointIsBound(breakpoint => this.onBreakpointIsBound(breakpoint));
+    }
+
+    private onBreakpointIsBound(breakpoint: CDTPBreakpoint): void {
+        this._scriptToBreakpoints.add(breakpoint.actualLocation.script, breakpoint);
+    }
+
+    public tryGettingBreakpointAtLocation(locationInScript: LocationInScript): CDTPBreakpoint[] {
+        const breakpoints = this._scriptToBreakpoints.tryGetting(locationInScript.script) || new Set();
+        const bpsAtLocation = [];
+        for (const bp of breakpoints) {
+            if (bp.actualLocation.isSameAs(locationInScript)) {
+                bpsAtLocation.push(bp);
+            }
+        }
+
+        return bpsAtLocation;
+    }
+
+    public toString(): string {
+        return `Breakpoints recipe status Registry:\nRecipe to breakpoints: ${this._scriptToBreakpoints}`;
+    }
+}

--- a/src/chrome/internal/breakpoints/registries/currentBPRecipesForSourceRegistry.ts
+++ b/src/chrome/internal/breakpoints/registries/currentBPRecipesForSourceRegistry.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { BPRecipeInSource } from '../bpRecipeInSource';
+import { BPRecipesInSource } from '../bpRecipes';
+import { BPRsDeltaCalculator, BPRsDeltaInRequestedSource } from '../features/bpsDeltaCalculator';
+import { newResourceIdentifierMap, IResourceIdentifier } from '../../sources/resourceIdentifier';
+
+/**
+ * Store the current list of breakpoint recipes for a particular source
+ */
+export class CurrentBPRecipesForSourceRegistry {
+    private readonly _requestedSourcePathToCurrentBPRecipes = newResourceIdentifierMap<BPRecipeInSource[]>();
+
+    public updateBPRecipesAndCalculateDelta(requestedBPRecipes: BPRecipesInSource): BPRsDeltaInRequestedSource {
+        const bpsDelta = this.calculateBPSDeltaFromExistingBPs(requestedBPRecipes);
+        this.storeCurrentBPRecipes(requestedBPRecipes.source.sourceIdentifier, bpsDelta.matchesForRequested);
+        return bpsDelta;
+    }
+
+    public bpRecipesForSource(sourcePath: IResourceIdentifier<string>): BPRecipeInSource[] {
+        return this._requestedSourcePathToCurrentBPRecipes.getOr(sourcePath, () => []);
+    }
+
+    private calculateBPSDeltaFromExistingBPs(requestedBPRecipes: BPRecipesInSource): BPRsDeltaInRequestedSource {
+        const bpRecipesInSource = this.bpRecipesForSource(requestedBPRecipes.requestedSourcePath);
+        return new BPRsDeltaCalculator(requestedBPRecipes.source, requestedBPRecipes, bpRecipesInSource).calculate();
+    }
+
+    private storeCurrentBPRecipes(requestedSourceIdentifier: IResourceIdentifier, bpRecipes: BPRecipeInSource[]): void {
+        this._requestedSourcePathToCurrentBPRecipes.setAndReplaceIfExist(requestedSourceIdentifier, Array.from(bpRecipes));
+    }
+
+    public toString(): string {
+        return `Current BP recipes for source registry {${this._requestedSourcePathToCurrentBPRecipes}}`;
+    }
+}

--- a/src/chrome/internal/breakpoints/registries/debuggeeBPRsSetForClientBPRFinder.ts
+++ b/src/chrome/internal/breakpoints/registries/debuggeeBPRsSetForClientBPRFinder.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { ISource } from '../../sources/source';
+import { IBPRecipe } from '../bpRecipe';
+import { CDTPBPRecipe } from '../../../cdtpDebuggee/cdtpPrimitives';
+import { ValidatedMultiMap } from '../../../collections/validatedMultiMap';
+import { IBreakpointsEventsListener } from '../features/breakpointsEventSystem';
+
+type ClientBPRecipe = IBPRecipe<ISource>;
+type DebuggeeBPRecipe = CDTPBPRecipe;
+
+/**
+ * Find all the debuggee breakpoint recipes we set for a particular client breakpoint recipe
+ */
+export class DebuggeeBPRsSetForClientBPRFinder {
+    private readonly _clientBPRToDebuggeeBPRItSet = new ValidatedMultiMap<ClientBPRecipe, DebuggeeBPRecipe>();
+
+    public constructor(breakpointsEventsListener: IBreakpointsEventsListener) {
+        breakpointsEventsListener.listenForOnClientBPRecipeAdded(clientBPRecipe => this.clientBPRWasAdded(clientBPRecipe));
+        breakpointsEventsListener.listenForOnDebuggeeBPRecipeAdded(debuggeeBPRecipe => this.debuggeeBPRsWasAdded(debuggeeBPRecipe));
+        breakpointsEventsListener.listenForOnDebuggeeBPRecipeRemoved(debuggeeBPRecipe => this.debuggeeBPRsWasRemoved(debuggeeBPRecipe));
+        breakpointsEventsListener.listenForOnClientBPRecipeRemoved(clientBPRecipe => this.clientBPRWasRemoved(clientBPRecipe));
+    }
+
+    public findDebuggeeBPRsSet(clientBPRecipe: ClientBPRecipe): DebuggeeBPRecipe[] {
+        // TODO: Review if it's okay to use getOr here, or if we should use get instead
+        return Array.from(this._clientBPRToDebuggeeBPRItSet.getOr(clientBPRecipe, () => new Set()));
+    }
+
+    private clientBPRWasAdded(clientBPRecipe: ClientBPRecipe): void {
+        this._clientBPRToDebuggeeBPRItSet.addKeyIfNotExistant(clientBPRecipe);
+    }
+
+    private debuggeeBPRsWasAdded(debuggeeBPRecipe: DebuggeeBPRecipe): void {
+        /**
+         * If we load the same script two times, we'll try to register the same client BP
+         * with the same debuggee BP twice, so we need to allow duplicates
+         */
+        this._clientBPRToDebuggeeBPRItSet.addAndIgnoreDuplicates(debuggeeBPRecipe.unmappedBPRecipe, debuggeeBPRecipe);
+    }
+
+    private debuggeeBPRsWasRemoved(debuggeeBPRecipe: DebuggeeBPRecipe): void {
+        this._clientBPRToDebuggeeBPRItSet.removeValue(debuggeeBPRecipe.unmappedBPRecipe, debuggeeBPRecipe);
+    }
+
+    private clientBPRWasRemoved(clientBPRecipe: ClientBPRecipe): void {
+        const debuggeBPRecipies = this._clientBPRToDebuggeeBPRItSet.get(clientBPRecipe);
+        if (debuggeBPRecipies.size >= 1) {
+            throw new Error(`Tried to remove a Client breakpoint recipe (${clientBPRecipe}) which still had some `
+                + `associated debuggee breakpoint recipes (${debuggeBPRecipies})`);
+        }
+
+        this._clientBPRToDebuggeeBPRItSet.delete(clientBPRecipe);
+    }
+
+    public toString(): string {
+        return `Debuggee BPRs set for Client BPR finder: ${this._clientBPRToDebuggeeBPRItSet}`;
+    }
+}

--- a/src/chrome/logging/executionLogger.ts
+++ b/src/chrome/logging/executionLogger.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { PromiseOrNot } from '../utils/promises';
+import { Logging } from '../internal/services/logging';
+
+export interface IExecutionLogger {
+    logAsyncFunctionCall<T, R>(description: string, functionToCall: (parameters: T) => PromiseOrNot<R>, parameters: T): PromiseOrNot<R>;
+}
+
+/**
+ * Utility class used by the communicator component to log the event-communications
+ */
+export class ExecutionLogger implements IExecutionLogger {
+    private _depth = 0;
+
+    constructor(private readonly _logging: Logging) { }
+
+    public async logAsyncFunctionCall<T, R>(description: string, functionToCall: (parameters: T) => PromiseOrNot<R>, parameters: T): Promise<R> {
+        this._logging.verbose(`${this.indentationForDepth()}${description}(${this.printParameters(parameters)})`);
+        this._depth++;
+        try {
+            const result = await functionToCall(parameters);
+            this._depth--;
+            this._logging.verbose(`${this.indentationForDepth()}${description} = ${this.printResult(result)}`);
+            return result;
+        } catch (exception) {
+            this._depth--;
+            this._logging.verbose(`${this.indentationForDepth()}${description} throws ${this.printException(exception)}`);
+            throw exception;
+        }
+    }
+
+    private indentationForDepth(): string {
+        return '  '.repeat(this._depth);
+    }
+
+    private printParameters<T>(parameters: T): string {
+        return `${parameters}`;
+    }
+
+    private printResult<T>(parameters: T): string {
+        return `${parameters}`;
+    }
+
+    private printException(exception: unknown): string {
+        return `${exception}`;
+    }
+}

--- a/src/chrome/utils/namespaceReverseLookupCreator.ts
+++ b/src/chrome/utils/namespaceReverseLookupCreator.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+export type NamespaceTree<T> = { [name: string]: NamespaceTree<T> | T };
+
+/**
+ * Utility to obtain the full path names for a set of objects stored in a tree like structure
+ */
+export class NamespaceReverseLookupCreator<T> {
+    private readonly _leafToNameMapping = new Map<T, string>();
+
+    constructor(
+        private readonly _root: NamespaceTree<T>,
+        private readonly _isLeaf: (node: NamespaceTree<T> | T) => node is T,
+        private readonly _namesPrefix: string) { }
+
+    public create(): Map<T, string> {
+        this.exploreLeaf(this._root, this._namesPrefix);
+        return this._leafToNameMapping;
+    }
+
+    private exploreLeaf(currentRoot: NamespaceTree<T>, namePrefix: string): void {
+        for (const propertyNamme in currentRoot) {
+            const propertyName = namePrefix ? `${namePrefix}.${propertyNamme}` : propertyNamme;
+            const propertyValue = currentRoot[propertyNamme];
+            if (this._isLeaf(propertyValue)) {
+                this._leafToNameMapping.set(propertyValue as T, propertyName);
+            } else {
+                this.exploreLeaf(propertyValue, propertyName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
BPRecipeAtLoadedSourceLogic: Handles setting breakpoints on sources associated with scripts that are already loaded
BPRsDeltaCalculator: Calculates the difference between two sets of breakpoint recipes, to find out which breakpoints were added, and removed
BPRecipeStatusCalculator: Calculats the current status of a BPRecipe (Bound vs Unbound)
BreakpointsEventSystem: Mini-event system to hide how the events work from the breakpoint's logic
BreakpointsUpdater: Handles updating the breakpoints for a particular source
ExistingBPsForJustParsedScriptSetter: Handles adding the neccesary breakpoints to a script that was just parsed
HitCountBreakpoints: Handles hit count breakpoint (This is not currently working/being used)
PauseScriptLoadsToSetBPs: Implements the break-on-load feature. When we load a script, we pause on it until we've set all the breakpoints for that script
BreakpointsSetForScriptFinder : Finds the breakpoints that were set for a particular script
CurrentBPRecipesForSourceRegistry : Stores the BP Recipies currently set for a source
DebuggeeBPRsSetForClientBPRFinder : Finds all the debuggee BPRs that were set for a client BPR
ExecutionLogger: Class that the event dispatcher framework uses for logging (We'll probably refactor/delete this)
Communicator : Main class of the event dispatcher component
NamespaceReverseLookupCreator: Utility used for the communicator to generate better error messages

Added a small component to publish typed events used in the set breakpoints feature (This component is way overkill for what I'm using it right now. Initially I was using that component instead of the DependencyInjection framework so it supports much more many things that what we are using it for atm. Given that it's already working, I'm leaving it as-is for the time being).
