### PR TITLE
Refactor the disconnecting logic to work on v2

### DIFF
--- a/src/chrome/client/chromeDebugAdapter/chromeDebugAdapterV2.ts
+++ b/src/chrome/client/chromeDebugAdapter/chromeDebugAdapterV2.ts
@@ -9,10 +9,12 @@ import { IDebugAdapter, IDebugAdapterState, ITelemetryPropertyCollector } from '
 import { CommandText } from '../requests';
 import { createDIContainer } from './cdaDIContainerCreator';
 import { TYPES } from '../../dependencyInjection.ts/types';
+import { TerminatingCDA } from './terminatingCDA';
+import { logger } from '../../..';
 
 export class ChromeDebugAdapter implements IDebugAdapter, IObservableEvents<IStepStartedEventsEmitter & IFinishedStartingUpEventsEmitter>{
     public readonly events = new StepProgressEventsEmitter();
-    private readonly _diContainer = createDIContainer(this._rawDebugSession, this._debugSessionOptions).bindAll();
+    private readonly _diContainer = createDIContainer(this, this._rawDebugSession, this._debugSessionOptions).bindAll();
 
     // TODO: Find a better way to initialize the component instead of using waitUntilInitialized
     private waitUntilInitialized = Promise.resolve(<UninitializedCDA>null);
@@ -43,5 +45,10 @@ export class ChromeDebugAdapter implements IDebugAdapter, IObservableEvents<ISte
                 // For all other messages where the state doesn't change, we don't need to do anything
                 return response;
         }
+    }
+
+    public async disconnect(terminatingCDA: TerminatingCDA): Promise<void> {
+        this._state = terminatingCDA;
+        this._state = await terminatingCDA.disconnect(); // This should change the state to TerminatedCDA
     }
 }

--- a/src/chrome/client/chromeDebugAdapter/connectedCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/connectedCDA.ts
@@ -3,6 +3,7 @@
  *--------------------------------------------------------*/
 
 import { Protocol as CDTP } from 'devtools-protocol';
+import * as sourceMapUtils from '../../../sourceMaps/sourceMapUtils';
 import { inject, injectable, multiInject } from 'inversify';
 import { ChromeDebugLogic } from '../../chromeDebugAdapter';
 import { TYPES } from '../../dependencyInjection.ts/types';
@@ -10,33 +11,48 @@ import { ICommandHandlerDeclarer, CommandHandlerDeclaration, IServiceComponent }
 import { BaseCDAState } from './baseCDAState';
 import { IDomainsEnabler } from '../../cdtpDebuggee/infrastructure/cdtpDomainsEnabler';
 import { IRuntimeStarter } from '../../cdtpDebuggee/features/cdtpRuntimeStarter';
-import { InitializedEvent } from 'vscode-debugadapter';
+import { InitializedEvent, logger, TerminatedEvent } from 'vscode-debugadapter';
 import { ISession } from '../session';
+import { telemetry } from '../../../telemetry';
+import { ChromeConnection } from '../../chromeConnection';
+import { IRestartRequestArgs, ILaunchRequestArgs } from '../../../debugAdapterInterfaces';
+import { ConnectedCDAConfiguration } from './cdaConfiguration';
+import { ChromeDebugAdapter } from './chromeDebugAdapterV2';
+import { TerminatingCDAProvider, TerminatingReason } from './terminatingCDA';
 
 export type ConnectedCDAProvider = (protocolApi: CDTP.ProtocolApi) => ConnectedCDA;
 
 @injectable()
 export class ConnectedCDA extends BaseCDAState {
     public static SCRIPTS_COMMAND = '.scripts';
+    private _ignoreNextDisconnectedFromWebSocket = false;
 
     constructor(
-        @inject(TYPES.ChromeDebugLogic) private readonly _chromeDebugAdapter: ChromeDebugLogic,
+        @inject(TYPES.ChromeDebugLogic) private readonly _chromeDebugAdapterLogic: ChromeDebugLogic,
         @inject(TYPES.IDomainsEnabler) private readonly _domainsEnabler: IDomainsEnabler,
         @inject(TYPES.IRuntimeStarter) private readonly _runtimeStarter: IRuntimeStarter,
         @inject(TYPES.ISession) private readonly _session: ISession,
+        @inject(TYPES.ConnectedCDAConfiguration) private readonly _configuration: ConnectedCDAConfiguration,
+        @inject(TYPES.ChromeConnection) private readonly _chromeConnection: ChromeConnection,
+        @inject(TYPES.TerminatingCDAProvider) private readonly _terminatingCDAProvider: TerminatingCDAProvider,
+        @inject(TYPES.ChromeDebugAdapter) private readonly _chromeDebugAdapter: ChromeDebugAdapter,
         @multiInject(TYPES.IServiceComponent) private readonly _serviceComponents: IServiceComponent[],
         @multiInject(TYPES.ICommandHandlerDeclarer) requestHandlerDeclarers: ICommandHandlerDeclarer[]
     ) {
         super(requestHandlerDeclarers, {
             'initialize': () => { throw new Error('The debug adapter is already initialized. Calling initialize again is not supported.'); },
             'launch': () => { throw new Error("Can't launch  to a new target while connected to a previous target"); },
-            'attach': () => { throw new Error("Can't attach to a new target while connected to a previous target"); }
+            'attach': () => { throw new Error("Can't attach to a new target while connected to a previous target"); },
+            'disconnect': async () => {
+                this._ignoreNextDisconnectedFromWebSocket = true;
+                await this.disconnect(TerminatingReason.DisconnectedFromWebsocket);
+            },
         });
     }
 
     public async install(): Promise<this> {
         await super.install();
-        await this._chromeDebugAdapter.install();
+        await this._chromeDebugAdapterLogic.install();
         await this._domainsEnabler.enableDomains(); // Enables all the domains that were registered
 
         for (const serviceComponent of this._serviceComponents) {
@@ -45,6 +61,21 @@ export class ConnectedCDA extends BaseCDAState {
 
         await this._runtimeStarter.runIfWaitingForDebugger();
         this._session.sendEvent(new InitializedEvent());
+
+        this._chromeConnection.onClose(() => {
+            if (!this._ignoreNextDisconnectedFromWebSocket) {
+                // When the client requests a disconnect, we kill Chrome, which will in turn disconnect the websocket, so we'll also get this event.
+                // To avoid processing the same disconnect twice, we ignore the first disconnect from websocket after the client requests a disconnect
+                this.disconnect(TerminatingReason.DisconnectedFromWebsocket);
+                this._ignoreNextDisconnectedFromWebSocket = false;
+            }
+        });
         return this;
+    }
+
+    public async disconnect(reason: TerminatingReason): Promise<void> {
+        const terminatingCDA = this._terminatingCDAProvider(reason);
+        await terminatingCDA.install();
+        this._chromeDebugAdapter.disconnect(terminatingCDA);
     }
 }

--- a/src/chrome/client/chromeDebugAdapter/disconnectedCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/disconnectedCDA.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { injectable } from 'inversify';
+import { BaseCDAState } from './baseCDAState';
+
+@injectable()
+export class DisconnectedCDA extends BaseCDAState {
+    constructor() {
+        super([], {});
+    }
+}

--- a/src/chrome/client/chromeDebugAdapter/terminatingCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/terminatingCDA.ts
@@ -1,0 +1,88 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as sourceMapUtils from '../../../sourceMaps/sourceMapUtils';
+import { inject, injectable, multiInject } from 'inversify';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { ICommandHandlerDeclarer, CommandHandlerDeclaration, IServiceComponent } from '../../internal/features/components';
+import { BaseCDAState } from './baseCDAState';
+import { logger, TerminatedEvent } from 'vscode-debugadapter';
+import { ISession } from '../session';
+import { telemetry } from '../../../telemetry';
+import { ChromeConnection } from '../../chromeConnection';
+import { IRestartRequestArgs, ILaunchRequestArgs } from '../../../debugAdapterInterfaces';
+import { ConnectedCDAConfiguration } from './cdaConfiguration';
+import { DisconnectedCDA } from './disconnectedCDA';
+import { IDebuggeeRunner, IDebuggeeLauncher } from '../../debugeeStartup/debugeeLauncher';
+
+export enum TerminatingReason {
+    DisconnectedFromWebsocket,
+    ClientRequestedToDisconnect
+}
+
+export type TerminatingCDAProvider = (reason: TerminatingReason) => TerminatingCDA;
+export class TerminatingCDA extends BaseCDAState {
+    constructor(
+        @inject(TYPES.ISession) private readonly _session: ISession,
+        @inject(TYPES.ConnectedCDAConfiguration) private readonly _configuration: ConnectedCDAConfiguration,
+        @inject(TYPES.ChromeConnection) private readonly _chromeConnection: ChromeConnection,
+        @inject(TYPES.TerminatingReason) private readonly _reason: TerminatingReason,
+        @inject(TYPES.IDebuggeeRunner) public readonly _debuggeeRunner: IDebuggeeRunner,
+        @inject(TYPES.IDebuggeeLauncher) public readonly _debuggeeLauncher: IDebuggeeLauncher,
+    ) {
+        super([], {});
+    }
+
+    /* __GDPR__
+         "ClientRequest/disconnect" : {
+             "${include}": [
+                 "${IExecutionResultTelemetryProperties}",
+                 "${DebugCommonProperties}"
+             ]
+         }
+     */
+    public async disconnect(): Promise<DisconnectedCDA> {
+        telemetry.reportEvent('FullSessionStatistics/SourceMaps/Overrides', { aspNetClientAppFallbackCount: sourceMapUtils.getAspNetFallbackCount() });
+
+        // TODO: Wait until we don't have any more requests in flight.
+        // TODO: Figure out if we need to do the stops before or after the shutdown and terminateSession
+        await this._debuggeeRunner.stop();
+        await this._debuggeeLauncher.stop();
+
+        this.shutdown();
+        this.terminateSession(this._reason === TerminatingReason.DisconnectedFromWebsocket ? 'Got disconnect request' : 'Disconnected from websocket');
+
+        return new DisconnectedCDA();
+    }
+
+    public shutdown(): void {
+        // this._batchTelemetryReporter.finalize();
+        this._session.shutdown();
+    }
+
+    public async terminateSession(reason: string, restart?: IRestartRequestArgs): Promise<void> {
+        logger.log(`Terminated: ${reason}`);
+
+        logger.log(`Waiting for any pending steps or log messages.`);
+        // TODO: Add logic so the client won't exist while there are actions in flight
+        // await this._currentStep;
+        // await this._currentLogMessage;
+        logger.log(`Current step and log messages complete`);
+
+        /* __GDPR__
+           "debugStopped" : {
+              "reason" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+              "${include}": [ "${DebugCommonProperties}" ]
+           }
+         */
+        telemetry.reportEvent('debugStopped', { reason });
+        if ((<ILaunchRequestArgs>this._configuration.args).noDebug) {
+            this._session.sendEvent(new TerminatedEvent(restart));
+        }
+
+        if (this._chromeConnection.isAttached) {
+            this._chromeConnection.close();
+        }
+    }
+}

--- a/src/chrome/client/clientLifecycleRequestsHandler.ts
+++ b/src/chrome/client/clientLifecycleRequestsHandler.ts
@@ -18,11 +18,10 @@ export class ClientLifecycleRequestsHandler implements ICommandHandlerDeclarer {
 
     public getCommandHandlerDeclarations(): ICommandHandlerDeclaration[] {
         return CommandHandlerDeclaration.fromLiteralObject({
-            configurationDone: () => this.configurationDone(),
-            shutdown: () => this._chromeDebugAdapter.shutdown(),
-            disconnect: () => this._chromeDebugAdapter.disconnect(),
+            configurationDone: () => this.configurationDone()
         });
     }
+
     public async configurationDone(): Promise<void> {
         await this._debuggeeRunner.run(new TelemetryPropertyCollector());
         this.events.emitMilestoneReached('RequestedNavigateToUserPage'); // TODO DIEGO: Make sure this is reported

--- a/src/chrome/debugeeStartup/debugeeLauncher.ts
+++ b/src/chrome/debugeeStartup/debugeeLauncher.ts
@@ -11,10 +11,12 @@ export interface ILaunchResult {
     url?: string;
 }
 
-export interface IDebuggeeLauncher  {
+export interface IDebuggeeLauncher {
     launch(args: ILaunchRequestArgs, telemetryPropertyCollector: ITelemetryPropertyCollector): Promise<ILaunchResult>;
+    stop(): Promise<void>;
 }
 
-export interface IDebuggeeRunner  {
+export interface IDebuggeeRunner {
     run(telemetryPropertyCollector: ITelemetryPropertyCollector): Promise<void>;
+    stop(): Promise<void>;
 }

--- a/src/chrome/dependencyInjection.ts/bind.ts
+++ b/src/chrome/dependencyInjection.ts/bind.ts
@@ -64,6 +64,8 @@ import { ConnectedCDA } from '../client/chromeDebugAdapter/connectedCDA';
 import { CDTPPausedOverlayConfigurer } from '../cdtpDebuggee/features/cdtpPausedOverlayConfigurer';
 import { SupportedDomains } from '../internal/domains/supportedDomains';
 import { CDTPSchemaProvider } from '../cdtpDebuggee/features/cdtpSchemaProvider';
+import { TerminatingCDA } from '../client/chromeDebugAdapter/terminatingCDA';
+import { DisconnectedCDA } from '../client/chromeDebugAdapter/disconnectedCDA';
 
 // TODO: This file needs a lot of work. We need to improve/simplify all this code when possible
 
@@ -133,6 +135,7 @@ export function bindAll(loggingConfiguration: MethodsCalledLoggerConfiguration, 
     bind(loggingConfiguration, di, TYPES.IPausedOverlayConfigurer, CDTPPausedOverlayConfigurer, callback);
     bind(loggingConfiguration, di, TYPES.ISupportedDomains, SupportedDomains, callback);
     bind(loggingConfiguration, di, TYPES.ISchemaProvider, CDTPSchemaProvider, callback);
+    bind(loggingConfiguration, di, TYPES.TerminatingCDA, TerminatingCDA, callback);
 }
 
 function bind<T extends object>(configuration: MethodsCalledLoggerConfiguration, container: Container, serviceIdentifier: interfaces.ServiceIdentifier<T>, newable: interfaces.Newable<T>, callback: ComponentCustomizationCallback): void {

--- a/src/chrome/dependencyInjection.ts/types.ts
+++ b/src/chrome/dependencyInjection.ts/types.ts
@@ -7,6 +7,8 @@ import 'reflect-metadata';
 // TODO: Add all necesary types so we can use inversifyjs to create our components
 const TYPES = {
     ISession: Symbol.for('ISession'),
+    ChromeDebugAdapter: Symbol.for('ChromeDebugAdapter'),
+    TerminatingReason: Symbol.for('TerminatingReason'),
     CDTPClient: Symbol.for('chromeConnection.api'),
     IDOMInstrumentationBreakpoints: Symbol.for('IDOMInstrumentationBreakpoints'),
     IEventsToClientReporter: Symbol.for('IEventsToClientReporter'),
@@ -64,8 +66,10 @@ const TYPES = {
     UnconnectedCDA: Symbol.for('UnconnectedCDA'),
     ConnectingCDA: Symbol.for('ConnectingCDA'),
     ConnectedCDA: Symbol.for('ConnectedCDA'),
+    TerminatingCDA: Symbol.for('TerminatingCDA'),
     UnconnectedCDAProvider: Symbol.for('UnconnectedCDAProvider'),
     ConnectedCDAProvider: Symbol.for('ConnectedCDAProvider'),
+    TerminatingCDAProvider: Symbol.for('TerminatingCDAProvider'),
     ConnectingCDAProvider: Symbol.for('ConnectingCDAProvider'),
     IChromeDebugSessionOpts: Symbol.for('IChromeDebugSessionOpts'),
     IClientCapabilities: Symbol.for('IClientCapabilities'),


### PR DESCRIPTION
Refactored the disconnecting logic to work on v2 to fix the integration tests which were failing because we were leaving Chrome instances running.
This logic is working sometimes, so the integration tests are still failing.
I'm merging this logic for the time being, and I added code to kill all instances of chrome after each integration test finishes.
TODO: We need to fix this logic and/or the test logic to make the integration tests close Chrome successfully