### PR TITLE
Enable strict null type checking

### DIFF
--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpOnScriptParsedEventProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpOnScriptParsedEventProvider.ts
@@ -161,7 +161,7 @@ abstract class ScriptCreator {
         return script;
     }
 
-    private sourceMap(): Promise<SourceMap> {
+    private sourceMap(): Promise<SourceMap | null> {
         return this._sourceMapTransformer.scriptParsed(this.runtimeSourcePath.canonicalized, this._scriptParsedEvent.sourceMapURL);
     }
 
@@ -174,7 +174,7 @@ abstract class ScriptCreator {
         return sourceMapper.sources.map((path: string) => this.obtainLoadedSource(parseResourceIdentifier(path), SourceScriptRelationship.Unknown));
     }
 
-    private sourceMapper(script: IScript, sourceMap: SourceMap): IMappedSourcesMapper {
+    private sourceMapper(script: IScript, sourceMap: SourceMap | null): IMappedSourcesMapper {
         const sourceMapper = sourceMap
             ? new MappedSourcesMapper(script, sourceMap)
             : new NoMappedSourcesMapper(script);

--- a/src/chrome/cdtpDebuggee/features/cdtpDebugeeStateInspector.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpDebugeeStateInspector.ts
@@ -7,10 +7,10 @@ import { Protocol as CDTP } from 'devtools-protocol';
 import { CDTPCallFrameRegistry } from '../registries/cdtpCallFrameRegistry';
 import { injectable, inject } from 'inversify';
 import { TYPES } from '../../dependencyInjection.ts/types';
-import { ScriptCallFrame } from '../../internal/stackTraces/callFrame';
+import { ScriptCallFrame, CallFrameWithState } from '../../internal/stackTraces/callFrame';
 
 export interface IEvaluateOnCallFrameRequest {
-    readonly frame: ScriptCallFrame;
+    readonly frame: ScriptCallFrame<CallFrameWithState>;
     readonly expression: string;
     readonly objectGroup?: string;
     readonly includeCommandLineAPI?: boolean;

--- a/src/chrome/cdtpDebuggee/features/cdtpDebugeeStateSetter.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpDebugeeStateSetter.ts
@@ -6,14 +6,14 @@
 import { CDTPCallFrameRegistry } from '../registries/cdtpCallFrameRegistry';
 import { TYPES } from '../../dependencyInjection.ts/types';
 import { injectable, inject } from 'inversify';
-import { ScriptCallFrame } from '../../internal/stackTraces/callFrame';
+import { ScriptCallFrame, CallFrameWithState } from '../../internal/stackTraces/callFrame';
 import { integer } from '../cdtpPrimitives';
 
 export interface ISetVariableValueRequest {
     readonly scopeNumber: integer;
     readonly variableName: string;
     readonly newValue: CDTP.Runtime.CallArgument;
-    readonly frame: ScriptCallFrame;
+    readonly frame: ScriptCallFrame<CallFrameWithState>;
 }
 
 export interface IDebuggeeStateSetter {

--- a/src/chrome/cdtpDebuggee/features/cdtpDebugeeSteppingController.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpDebugeeSteppingController.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------*/
 
 import { Protocol as CDTP } from 'devtools-protocol';
-import { ScriptCallFrame } from '../../internal/stackTraces/callFrame';
+import { ScriptCallFrame, CallFrameWithState } from '../../internal/stackTraces/callFrame';
 import { CDTPCallFrameRegistry } from '../registries/cdtpCallFrameRegistry';
 import { injectable, inject } from 'inversify';
 import { TYPES } from '../../dependencyInjection.ts/types';
@@ -12,7 +12,7 @@ export interface IDebuggeeSteppingController {
     stepOver(): Promise<void>;
     stepInto(params: { breakOnAsyncCall: boolean }): Promise<void>;
     stepOut(): Promise<void>;
-    restartFrame(callFrame: ScriptCallFrame): Promise<CDTP.Debugger.RestartFrameResponse>;
+    restartFrame(callFrame: ScriptCallFrame<CallFrameWithState>): Promise<CDTP.Debugger.RestartFrameResponse>;
     pauseOnAsyncCall(params: CDTP.Debugger.PauseOnAsyncCallRequest): Promise<void>;
 }
 
@@ -40,7 +40,7 @@ export class CDTPDebuggeeSteppingController implements IDebuggeeSteppingControll
         return this.api.Debugger.stepOut();
     }
 
-    public restartFrame(frame: ScriptCallFrame): Promise<CDTP.Debugger.RestartFrameResponse> {
+    public restartFrame(frame: ScriptCallFrame<CallFrameWithState>): Promise<CDTP.Debugger.RestartFrameResponse> {
         return this.api.Debugger.restartFrame({ callFrameId: this._callFrameRegistry.getFrameId(frame) });
     }
 }

--- a/src/chrome/cdtpDebuggee/features/cdtpDebuggeeBreakpointsSetter.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpDebuggeeBreakpointsSetter.ts
@@ -25,7 +25,7 @@ import { BPRecipeInScript, BPRecipeInUrl, BPRecipeInUrlRegexp, IBPRecipeForRunti
 import { ConditionalPause } from '../../internal/breakpoints/bpActionWhenHit';
 import { singleElementOfArray } from '../../collections/utilities';
 
-type SetBPInCDTPCall<TResource extends CDTPSupportedResources> = (resource: TResource, position: Position, cdtpConditionField: string) => Promise<CDTP.Debugger.SetBreakpointByUrlResponse>;
+type SetBPInCDTPCall<TResource extends CDTPSupportedResources> = (resource: TResource, position: Position, cdtpConditionField?: string) => Promise<CDTP.Debugger.SetBreakpointByUrlResponse>;
 export type OnBreakpointResolvedListener = (breakpoint: CDTPBreakpoint) => void;
 
 export interface IDebuggeeBreakpointsSetter {

--- a/src/chrome/cdtpDebuggee/infrastructure/cdtpDomainsEnabler.ts
+++ b/src/chrome/cdtpDebuggee/infrastructure/cdtpDomainsEnabler.ts
@@ -75,7 +75,12 @@ class GatheringDomainsToEnableDuringStartup implements IState {
     }
 
     private getDomainName(api: IEnableableApi<unknown, unknown>): string {
-        return _.findKey(this.protocolApi, api);
+        const name = _.findKey(this.protocolApi, api);
+        if (name !== undefined) {
+            return name;
+        } else {
+            throw new Error(`Couldn't get the domain name for ${api}`);
+        }
     }
 }
 
@@ -97,7 +102,7 @@ export class CDTPDomainsEnabler implements IDomainsEnabler {
     constructor(@inject(TYPES.CDTPClient) private readonly _protocolApi: CDTP.ProtocolApi) { }
 
     public registerToEnable<T extends IEnableableApi<EnableParameters, EnableResponse>, EnableParameters, EnableResponse>
-        (api: T, parameters: EnableParameters): Promise<EnableResponse> {
+        (api: T, parameters?: EnableParameters): Promise<EnableResponse> {
         return this._state.registerToEnable(api, parameters);
     }
 

--- a/src/chrome/cdtpDebuggee/registries/cdtpCallFrameRegistry.ts
+++ b/src/chrome/cdtpDebuggee/registries/cdtpCallFrameRegistry.ts
@@ -4,18 +4,18 @@
 
  import { Protocol as CDTP } from 'devtools-protocol';
 import { ValidatedMap } from '../../collections/validatedMap';
-import { ScriptCallFrame } from '../../internal/stackTraces/callFrame';
+import { ScriptCallFrame, CallFrameWithState } from '../../internal/stackTraces/callFrame';
 import { injectable } from 'inversify';
 
 @injectable()
 export class CDTPCallFrameRegistry {
-    private readonly _callFrameToId = new ValidatedMap<ScriptCallFrame, CDTP.Debugger.CallFrameId>();
+    private readonly _callFrameToId = new ValidatedMap<ScriptCallFrame<CallFrameWithState>, CDTP.Debugger.CallFrameId>();
 
-    public registerFrameId(callFrameId: CDTP.Debugger.CallFrameId, frame: ScriptCallFrame): void {
+    public registerFrameId(callFrameId: CDTP.Debugger.CallFrameId, frame: ScriptCallFrame<CallFrameWithState>): void {
         this._callFrameToId.set(frame, callFrameId);
     }
 
-    public getFrameId(frame: ScriptCallFrame): CDTP.Debugger.CallFrameId {
+    public getFrameId(frame: ScriptCallFrame<CallFrameWithState>): CDTP.Debugger.CallFrameId {
         return this._callFrameToId.get(frame);
     }
 }

--- a/src/chrome/chromeDebugSession.ts
+++ b/src/chrome/chromeDebugSession.ts
@@ -115,7 +115,7 @@ export class ChromeDebugSession extends LoggingDebugSession implements IObservab
         // class expression!
         return class extends ChromeDebugSession {
             constructor(debuggerLinesAndColumnsStartAt1?: boolean, isServer?: boolean) {
-                super(debuggerLinesAndColumnsStartAt1, isServer, opts);
+                super(!!debuggerLinesAndColumnsStartAt1, !!isServer, opts);
             }
         };
     }

--- a/src/chrome/client/chromeDebugAdapter/chromeDebugAdapterV2.ts
+++ b/src/chrome/client/chromeDebugAdapter/chromeDebugAdapterV2.ts
@@ -18,7 +18,7 @@ export class ChromeDebugAdapter implements IDebugAdapter, IObservableEvents<ISte
     private readonly _diContainer = createDIContainer(this, this._rawDebugSession, this._debugSessionOptions).bindAll();
 
     // TODO: Find a better way to initialize the component instead of using waitUntilInitialized
-    private waitUntilInitialized = Promise.resolve(<UninitializedCDA>null);
+    private waitUntilInitialized = Promise.resolve(<UninitializedCDA><unknown>null);
 
     private _state: IDebugAdapterState;
 

--- a/src/chrome/client/chromeDebugAdapter/connectingCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/connectingCDA.ts
@@ -24,7 +24,7 @@ export class ConnectingCDA extends BaseCDAState {
         super([], {});
     }
 
-    public async connect(telemetryPropertyCollector?: ITelemetryPropertyCollector): Promise<ConnectedCDA> {
+    public async connect(telemetryPropertyCollector: ITelemetryPropertyCollector): Promise<ConnectedCDA> {
         const result = await this._debuggeeLauncher.launch(this._configuration.args, telemetryPropertyCollector);
         await this._chromeConnection.attach(result.address, result.port, result.url, this._configuration.args.timeout, this._configuration.args.extraCRDPChannelPort);
         if (this._chromeConnection.api === undefined) {

--- a/src/chrome/client/chromeDebugAdapter/unconnectedCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/unconnectedCDA.ts
@@ -34,7 +34,7 @@ export class UnconnectedCDA implements IDebugAdapterState {
         @inject(TYPES.ConnectingCDAProvider) private readonly _connectingCDAProvider: ConnectingCDAProvider,
         @inject(TYPES.IClientCapabilities) private readonly _clientCapabilities: IClientCapabilities) { }
 
-    public processRequest(requestName: CommandText, args: unknown, telemetryPropertyCollector?: ITelemetryPropertyCollector): Promise<unknown> {
+    public processRequest(requestName: CommandText, args: unknown, telemetryPropertyCollector: ITelemetryPropertyCollector): Promise<unknown> {
         switch (requestName) {
             case 'launch':
                 return this.launch(<ILaunchRequestArgs>args, telemetryPropertyCollector);
@@ -45,11 +45,11 @@ export class UnconnectedCDA implements IDebugAdapterState {
         }
     }
 
-    public async launch(args: ILaunchRequestArgs, telemetryPropertyCollector?: ITelemetryPropertyCollector): Promise<IDebugAdapterState> {
+    public async launch(args: ILaunchRequestArgs, telemetryPropertyCollector: ITelemetryPropertyCollector): Promise<IDebugAdapterState> {
         return this.createConnection(ScenarioType.Launch, args, telemetryPropertyCollector);
     }
 
-    public async attach(args: IAttachRequestArgs, telemetryPropertyCollector?: ITelemetryPropertyCollector): Promise<IDebugAdapterState> {
+    public async attach(args: IAttachRequestArgs, telemetryPropertyCollector: ITelemetryPropertyCollector): Promise<IDebugAdapterState> {
         const updatedArgs = Object.assign({}, { port: 9229 }, args);
         return this.createConnection(ScenarioType.Attach, updatedArgs, telemetryPropertyCollector);
     }
@@ -57,10 +57,10 @@ export class UnconnectedCDA implements IDebugAdapterState {
     private parseLoggingConfiguration(args: ILaunchRequestArgs | IAttachRequestArgs): ILoggingConfiguration {
         const traceMapping: { [key: string]: Logger.LogLevel | undefined } = { true: Logger.LogLevel.Warn, verbose: Logger.LogLevel.Verbose };
         const traceValue = args.trace && traceMapping[args.trace.toString().toLowerCase()];
-        return { logLevel: traceValue, logFilePath: args.logFilePath, shouldLogTimestamps: args.logTimestamps };
+        return { logLevel: traceValue || undefined, logFilePath: args.logFilePath, shouldLogTimestamps: !!args.logTimestamps };
     }
 
-    private async createConnection(scenarioType: ScenarioType, args: ILaunchRequestArgs | IAttachRequestArgs, telemetryPropertyCollector?: ITelemetryPropertyCollector): Promise<IDebugAdapterState> {
+    private async createConnection(scenarioType: ScenarioType, args: ILaunchRequestArgs | IAttachRequestArgs, telemetryPropertyCollector: ITelemetryPropertyCollector): Promise<IDebugAdapterState> {
         if (this._clientCapabilities.pathFormat !== 'path') {
             throw errors.pathFormat();
         }

--- a/src/chrome/client/eventsToClientReporter.ts
+++ b/src/chrome/client/eventsToClientReporter.ts
@@ -4,7 +4,7 @@
 
 import { ILoadedSource } from '../internal/sources/loadedSource';
 import { ISession } from './session';
-import { LoadedSourceEvent, OutputEvent, BreakpointEvent } from 'vscode-debugadapter';
+import { LoadedSourceEvent, OutputEvent, BreakpointEvent, Source } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { LocationInLoadedSource } from '../internal/locations/location';
 import { IBPRecipeStatus } from '../internal/breakpoints/bpRecipeStatus';
@@ -42,7 +42,7 @@ export interface IBPStatusChangedParameters {
 export interface IExceptionThrownParameters {
     readonly exceptionStackTrace: IFormattedExceptionLineDescription[];
     readonly category: string;
-    readonly location?: LocationInLoadedSource;
+    readonly location: LocationInLoadedSource | undefined;
 }
 
 export interface IDebuggeeIsStoppedParameters {
@@ -91,7 +91,7 @@ export class EventsToClientReporter implements IEventsToClientReporter {
 
     public async sendSourceWasLoaded(params: ISourceWasLoadedParameters): Promise<void> {
         const clientSource = await this._sourceToClientConverter.toSource(params.source);
-        const event = new LoadedSourceEvent(params.reason, clientSource);
+        const event = new LoadedSourceEvent(params.reason, <Source>clientSource); // TODO: Update source to have an optional sourceReference so we don't need to do this cast
 
         this._session.sendEvent(event);
     }

--- a/src/chrome/client/sourceToClientConverter.ts
+++ b/src/chrome/client/sourceToClientConverter.ts
@@ -3,16 +3,17 @@ import * as utils from '../../utils';
 import { ILoadedSource } from '../internal/sources/loadedSource';
 import { Source } from 'vscode-debugadapter';
 import { HandlesRegistry } from './handlesRegistry';
+import { DebugProtocol } from 'vscode-debugprotocol';
 
 export class SourceToClientConverter {
     constructor(private readonly _handlesRegistry: HandlesRegistry) { }
 
-    public async toSource(loadedSource: ILoadedSource): Promise<Source> {
+    public async toSource(loadedSource: ILoadedSource): Promise<DebugProtocol.Source> {
         const exists = await utils.existsAsync(loadedSource.identifier.canonicalized);
 
         // if the path exists, do not send the sourceReference
         // new Source sends 0 for undefined
-        const source: Source = {
+        const source = {
             name: pathModule.basename(loadedSource.identifier.textRepresentation),
             path: loadedSource.identifier.textRepresentation,
             sourceReference: exists ? undefined : this._handlesRegistry.sources.getIdByObject(loadedSource),

--- a/src/chrome/collections/setUsingProjection.ts
+++ b/src/chrome/collections/setUsingProjection.ts
@@ -36,7 +36,7 @@ export class SetUsingProjection<T, P> implements Set<T> {
         }, thisArg);
     }
 
-    public tryGetting(referenceElement: T): T {
+    public tryGetting(referenceElement: T): T | undefined {
         const projectedValue = this._projection(referenceElement);
         const elementInSet = this._projectionToElement.tryGetting(projectedValue);
         return elementInSet !== undefined ? elementInSet : undefined;

--- a/src/chrome/collections/validatedMap.ts
+++ b/src/chrome/collections/validatedMap.ts
@@ -8,6 +8,7 @@ import { breakWhileDebugging } from '../../validation';
 export type ValueComparerFunction<V> = (left: V, right: V) => boolean;
 
 export interface IValidatedMap<K, V> extends Map<K, V> {
+    get(key: K): V;
     tryGetting(key: K): V | undefined;
     getOr(key: K, elementDoesntExistAction: () => V): V;
     getOrAdd(key: K, obtainValueToAdd: () => V): V;
@@ -19,10 +20,17 @@ export interface IValidatedMap<K, V> extends Map<K, V> {
 export class ValidatedMap<K, V> implements IValidatedMap<K, V> {
     private readonly _wrappedMap: Map<K, V>;
 
+    constructor(initialContents?: Map<K, V>);
+    constructor(iterable: Iterable<[K, V]>);
+    constructor(array: ReadonlyArray<[K, V]>);
     constructor(initialContents?: Map<K, V> | Iterable<[K, V]> | ReadonlyArray<[K, V]>) {
-        this._wrappedMap = initialContents instanceof Map
+        if (initialContents !== undefined) {
+            this._wrappedMap = initialContents instanceof Map
             ? new Map<K, V>(initialContents.entries())
             : new Map<K, V>(initialContents);
+        } else {
+            this._wrappedMap = new Map<K, V>();
+        }
     }
 
     public static with<K, V>(key: K, value: V): ValidatedMap<K, V> {

--- a/src/chrome/collections/validatedMultiMap.ts
+++ b/src/chrome/collections/validatedMultiMap.ts
@@ -19,12 +19,12 @@ export class ValidatedMultiMap<K, V> {
     }
 
     constructor(initialContents?: Map<K, Set<V>> | Iterable<[K, Set<V>]> | ReadonlyArray<[K, Set<V>]>) {
-        const elements = initialContents
-            ? Array.from(initialContents).map(element => <[K, IValidatedSet<V>]>[element[0], new ValidatedSet(element[1])])
-            : null;
-        this._wrappedMap = initialContents instanceof Map
-            ? new ValidatedMap<K, IValidatedSet<V>>(elements)
-            : new ValidatedMap<K, IValidatedSet<V>>(elements);
+        if (initialContents !== undefined) {
+            const elements = Array.from(initialContents).map(element => <[K, IValidatedSet<V>]>[element[0], new ValidatedSet(element[1])]);
+            this._wrappedMap = new ValidatedMap<K, IValidatedSet<V>>(elements);
+        } else {
+            this._wrappedMap = new ValidatedMap<K, IValidatedSet<V>>();
+        }
     }
 
     public clear(): void {
@@ -115,7 +115,7 @@ export class ValidatedMultiMap<K, V> {
         return this._wrappedMap.values();
     }
 
-    public tryGetting(key: K): Set<V> | null {
+    public tryGetting(key: K): Set<V> | undefined {
         return this._wrappedMap.tryGetting(key);
     }
 

--- a/src/chrome/collections/validatedSet.ts
+++ b/src/chrome/collections/validatedSet.ts
@@ -13,7 +13,9 @@ export class ValidatedSet<K> implements IValidatedSet<K> {
     public constructor(iterable: Iterable<K>);
     public constructor(values?: ReadonlyArray<K>);
     public constructor(valuesOrIterable?: ReadonlyArray<K> | undefined | Iterable<K>) {
-        this._wrappedSet = new Set(valuesOrIterable);
+        this._wrappedSet = valuesOrIterable
+            ? new Set(valuesOrIterable)
+            : new Set();
     }
 
     public get size(): number {

--- a/src/chrome/internal/breakpoints/features/breakpointsEventSystem.ts
+++ b/src/chrome/internal/breakpoints/features/breakpointsEventSystem.ts
@@ -36,7 +36,7 @@ export class BreakpointsEventSystem implements IBreakpointsEventsListener {
         this.bpRecipeStatusCalculator = bpRecipeStatusCalculator;
         this.bpRecipeAtLoadedSourceLogic = bpRecipeAtLoadedSourceLogic;
 
-        this._scheduledActions.forEach(action => action());
+        (this._scheduledActions || []).forEach(action => action());
         this._scheduledActions = null;
     }
 

--- a/src/chrome/internal/breakpoints/features/hitCountBreakpoints.ts
+++ b/src/chrome/internal/breakpoints/features/hitCountBreakpoints.ts
@@ -15,6 +15,7 @@ import { TYPES } from '../../../dependencyInjection.ts/types';
 import { PausedEvent } from '../../../cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider';
 import { ScriptOrSourceOrURLOrURLRegexp } from '../../locations/location';
 import { IDebuggeePausedHandler } from '../../features/debuggeePausedHandler';
+import { isNotUndefined } from '../../../../typeUtils';
 
 export interface IHitCountBreakpointsDependencies {
     registerAddBPRecipeHandler(handlerRequirements: (bpRecipe: BPRecipeInSource) => boolean,
@@ -78,8 +79,8 @@ export class HitCountBreakpoints {
     }
 
     public async onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
-        const hitCountBPData = paused.hitBreakpoints.map(hitBPRecipe =>
-            this.underlyingToBPRecipe.tryGetting(hitBPRecipe.unmappedBPRecipe)).filter(bpRecipe => bpRecipe !== undefined);
+        const hitCountBPData: HitCountBPData[] = <HitCountBPData[]>paused.hitBreakpoints.map(hitBPRecipe =>
+            this.underlyingToBPRecipe.tryGetting(hitBPRecipe.unmappedBPRecipe)).filter(bpRecipe => isNotUndefined(bpRecipe));
 
         const individualDecisions = hitCountBPData.map(data => data.notifyBPHit());
         return individualDecisions.some(v => !(v instanceof NoActionIsNeededForThisPause))

--- a/src/chrome/internal/breakpoints/features/hitCountConditionParser.ts
+++ b/src/chrome/internal/breakpoints/features/hitCountConditionParser.ts
@@ -6,16 +6,15 @@ export type HitCountConditionFunction = (numHits: number) => boolean;
 
 export class HitCountConditionParser {
     private readonly HIT_COUNT_CONDITION_PATTERN = /^(>|>=|=|<|<=|%)?\s*([0-9]+)$/;
-    private patternMatches: RegExpExecArray | undefined;
 
     constructor(private readonly _hitCountCondition: string) { }
 
     public parse(): HitCountConditionFunction {
-        this.patternMatches = this.HIT_COUNT_CONDITION_PATTERN.exec(this._hitCountCondition.trim());
-        if (this.patternMatches && this.patternMatches.length >= 3) {
+        const patternMatches = this.HIT_COUNT_CONDITION_PATTERN.exec(this._hitCountCondition.trim());
+        if (patternMatches && patternMatches.length >= 3) {
             // eval safe because of the regex, and this is only a string that the current user will type in
             /* tslint:disable:no-function-constructor-with-string-args */
-            const shouldPause: HitCountConditionFunction = <any>new Function('numHits', this.javaScriptCodeToEvaluateCondition());
+            const shouldPause: HitCountConditionFunction = <any>new Function('numHits', this.javaScriptCodeToEvaluateCondition(patternMatches));
             /* tslint:enable:no-function-constructor-with-string-args */
             return shouldPause;
         } else {
@@ -23,21 +22,21 @@ export class HitCountConditionParser {
         }
     }
 
-    private javaScriptCodeToEvaluateCondition() {
-        const operator = this.parseOperator();
-        const value = this.parseValue();
+    private javaScriptCodeToEvaluateCondition(patternMatches: RegExpExecArray) {
+        const operator = this.parseOperator(patternMatches);
+        const value = this.parseValue(patternMatches);
         const javaScriptCode = operator === '%'
             ? `return (numHits % ${value}) === 0;`
             : `return numHits ${operator} ${value};`;
         return javaScriptCode;
     }
 
-    private parseValue(): string {
-        return this.patternMatches[2];
+    private parseValue(patternMatches: RegExpExecArray): string {
+        return patternMatches[2];
     }
 
-    private parseOperator(): string {
-        let op = this.patternMatches[1] || '>=';
+    private parseOperator(patternMatches: RegExpExecArray): string {
+        let op = patternMatches[1] || '>=';
         if (op === '=')
             op = '==';
         return op;

--- a/src/chrome/internal/breakpoints/features/setBreakpointsRequestHandler.ts
+++ b/src/chrome/internal/breakpoints/features/setBreakpointsRequestHandler.ts
@@ -39,6 +39,10 @@ export class SetBreakpointsRequestHandler implements ICommandHandlerDeclarer {
     }
 
     private toBPRecipes(args: DebugProtocol.SetBreakpointsArguments): BPRecipesInSource {
+        if (args.breakpoints === undefined) {
+            throw new Error(`Expected the set breakpoints arguments to include a breakpoints list on the 'breakpoints' variable. The arguments are: ${JSON.stringify(args)}`);
+        }
+
         const source = this._clientSourceParser.toSource(args.source);
         const breakpoints = args.breakpoints.map(breakpoint => this.toBPRecipe(source, breakpoint));
         return new BPRecipesInSource(source, breakpoints);
@@ -74,7 +78,9 @@ export class SetBreakpointsRequestHandler implements ICommandHandlerDeclarer {
 
     private toLocation(location: { line: number; column?: number; }): Position {
         const lineNumber = createLineNumber(this._lineColTransformer.convertClientLineToDebugger(location.line));
-        const columnNumber = location.column !== undefined ? createColumnNumber(this._lineColTransformer.convertClientColumnToDebugger(location.column)) : undefined;
+        const columnNumber = location.column !== undefined
+            ? createColumnNumber(this._lineColTransformer.convertClientColumnToDebugger(location.column))
+            : createColumnNumber(0); // If no column number is specified, we default to assuming the column number is zero
         return new Position(lineNumber, columnNumber);
     }
 

--- a/src/chrome/internal/exceptions/pauseOnException.ts
+++ b/src/chrome/internal/exceptions/pauseOnException.ts
@@ -28,7 +28,7 @@ export interface IExceptionInformation {
     readonly exceptionId: string;
     readonly description?: string;
     readonly breakMode: ExceptionBreakMode;
-    readonly details?: IExceptionInformationDetails;
+    readonly details: IExceptionInformationDetails;
 }
 
 export class ExceptionWasThrown extends BaseNotifyClientOfPause {

--- a/src/chrome/internal/features/skipFiles.ts
+++ b/src/chrome/internal/features/skipFiles.ts
@@ -187,7 +187,7 @@ export class SkipFilesLogic implements IStackTracePresentationDetailsProvider {
                     isSkippedFile = parentIsSkipped;
                 }
 
-                this._skipFileStatuses.setAndReplaceIfExist(s.identifier, isSkippedFile);
+                this._skipFileStatuses.setAndReplaceIfExist(s.identifier, !!isSkippedFile);
 
                 if ((isSkippedFile && !inLibRange) || (!isSkippedFile && inLibRange)) {
                     const sourcesMapper = script.sourceMapper;

--- a/src/chrome/internal/features/smartStep.ts
+++ b/src/chrome/internal/features/smartStep.ts
@@ -4,7 +4,7 @@
 
 import { BasePathTransformer } from '../../../transformers/basePathTransformer';
 import { BaseSourceMapTransformer } from '../../../transformers/baseSourceMapTransformer';
-import { ScriptCallFrame } from '../stackTraces/callFrame';
+import { ScriptCallFrame, CallFrameWithState } from '../stackTraces/callFrame';
 import { PausedEvent } from '../../cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider';
 import { IActionToTakeWhenPaused, NoActionIsNeededForThisPause, BaseActionToTakeWhenPaused } from '../features/actionToTakeWhenPaused';
 import { logger } from 'vscode-debugadapter';
@@ -84,7 +84,7 @@ export class SmartStepLogic implements IStackTracePresentationDetailsProvider {
         throw new Error('Not implemented TODO DIEGO');
     }
 
-    public async shouldSkip(frame: ScriptCallFrame): Promise<boolean> {
+    public async shouldSkip(frame: ScriptCallFrame<CallFrameWithState>): Promise<boolean> {
         if (!this._isEnabled) return false;
 
         const clientPath = this._pathTransformer.getClientPathFromTargetPath(frame.location.script.runtimeSource.identifier)

--- a/src/chrome/internal/locations/location.ts
+++ b/src/chrome/internal/locations/location.ts
@@ -19,7 +19,7 @@ export class Position implements IEquivalenceComparable {
 
     constructor(
         public readonly lineNumber: LineNumber,
-        public readonly columnNumber?: ColumnNumber) {
+        public readonly columnNumber: ColumnNumber) {
         Validation.zeroOrPositive('Line number', lineNumber);
         if (columnNumber !== undefined) {
             Validation.zeroOrPositive('Column number', columnNumber);
@@ -27,11 +27,21 @@ export class Position implements IEquivalenceComparable {
     }
 
     public static appearingLastOf(...positions: Position[]): Position {
-        return _.reduce(positions, (left, right) => left.doesAppearBefore(right) ? right : left);
+        const lastPosition = _.reduce(positions, (left, right) => left.doesAppearBefore(right) ? right : left);
+        if (lastPosition !== undefined) {
+            return lastPosition;
+        } else {
+            throw new Error(`Couldn't find the position appearing last from the list: ${positions}. Is it possible the list was empty?`);
+        }
     }
 
     public static appearingFirstOf(...positions: Position[]): Position {
-        return _.reduce(positions, (left, right) => left.doesAppearBefore(right) ? left : right);
+        const firstPosition =  _.reduce(positions, (left, right) => left.doesAppearBefore(right) ? left : right);
+        if (firstPosition !== undefined) {
+            return firstPosition;
+        } else {
+            throw new Error(`Couldn't find the position appearing first from the list: ${positions}. Is it possible the list was empty?`);
+        }
     }
 
     public static isBetween(start: Position, maybeInBetween: Position, end: Position): boolean {

--- a/src/chrome/internal/locations/subtypes.ts
+++ b/src/chrome/internal/locations/subtypes.ts
@@ -14,8 +14,8 @@ export function createLineNumber(numberRepresentation: number): LineNumber {
 const columnIndexSymbol = Symbol();
 export type ColumnNumber = number & { [columnIndexSymbol]: true };
 
-export function createColumnNumber(numberRepresentation: number): ColumnNumber {
-    return <ColumnNumber>numberRepresentation;
+export function createColumnNumber<T extends number | undefined>(numberRepresentation: T): ColumnNumber & T {
+    return <ColumnNumber & T>numberRepresentation;
 }
 
 const URLRegexpSymbol = Symbol();

--- a/src/chrome/internal/requests.ts
+++ b/src/chrome/internal/requests.ts
@@ -2,11 +2,11 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { LoadedSourceCallFrame } from './stackTraces/callFrame';
+import { LoadedSourceCallFrame, CallFrameWithState } from './stackTraces/callFrame';
 
 export interface IEvaluateArguments {
     readonly expression: string;
-    readonly frame?: LoadedSourceCallFrame;
+    readonly frame?: LoadedSourceCallFrame<CallFrameWithState>;
     readonly context?: string;
     readonly format?: {
         /** Display the value in hex. */
@@ -15,7 +15,7 @@ export interface IEvaluateArguments {
 }
 
 export interface ICompletionsArguments {
-    readonly frame?: LoadedSourceCallFrame;
+    readonly frame?: LoadedSourceCallFrame<CallFrameWithState>;
     readonly text: string;
     readonly column: number;
     readonly line?: number;

--- a/src/chrome/internal/scripts/sourcesMapper.ts
+++ b/src/chrome/internal/scripts/sourcesMapper.ts
@@ -8,13 +8,14 @@ import { LocationInLoadedSource, LocationInScript, Position } from '../locations
 import { ILoadedSource } from '../sources/loadedSource';
 import { IResourceIdentifier, parseResourceIdentifier } from '../sources/resourceIdentifier';
 import { IScript } from './script';
+import { IValidatedMap } from '../../collections/validatedMap';
 
 export interface ISourceToScriptMapper {
     getPositionInScript(positionInSource: LocationInLoadedSource): LocationInScript | null;
 }
 
 export interface IScriptToSourceMapper {
-    getPositionInSource(positionInScript: LocationInScript): LocationInLoadedSource | null;
+    getPositionInSource(positionInScript: LocationInScript): LocationInLoadedSource;
 }
 
 export interface ISourceMapper extends ISourceToScriptMapper, IScriptToSourceMapper { }
@@ -25,13 +26,13 @@ export interface IMappedSourcesMapper extends ISourceMapper {
 
 /** This class maps locations from a script into the sources form which it was compiled, and back. */
 export class MappedSourcesMapper implements IMappedSourcesMapper {
-    private readonly _rangeInSources: Map<IResourceIdentifier, SourceRange>;
+    private readonly _rangeInSources: IValidatedMap<IResourceIdentifier, SourceRange>;
 
     constructor(private readonly _script: IScript, private readonly _sourceMap: SourceMap) {
         this._rangeInSources = this._sourceMap.rangesInSources();
     }
 
-    public getPositionInSource(positionInScript: LocationInScript): LocationInLoadedSource | null {
+    public getPositionInSource(positionInScript: LocationInScript): LocationInLoadedSource {
         const scriptPositionInResource = this._script.rangeInSource.start.position;
 
         // All the lines need to be adjusted by the relative position of the script in the resource (in an .html if the script starts in line 20, the first line is 20 rather than 0)
@@ -60,10 +61,6 @@ export class MappedSourcesMapper implements IMappedSourcesMapper {
 
         const mappedPositionRelativeToScript = this._sourceMap.generatedPositionFor(positionInSource.source.identifier.textRepresentation,
             positionInSource.position.lineNumber, positionInSource.position.columnNumber || 0);
-        const positionInSourceForMapping = this._sourceMap.authoredPositionFor(mappedPositionRelativeToScript.line, mappedPositionRelativeToScript.column);
-        if (positionInSourceForMapping.line !== positionInSource.position.lineNumber) {
-
-        }
 
         if (mappedPositionRelativeToScript && typeof mappedPositionRelativeToScript.line === 'number') {
 

--- a/src/chrome/internal/services/logging.ts
+++ b/src/chrome/internal/services/logging.ts
@@ -8,7 +8,7 @@ import { IExtensibilityPoints } from '../../extensibility/extensibilityPoints';
 export interface ILoggingConfiguration {
     logLevel?: Logger.LogLevel;
     shouldLogTimestamps: boolean;
-    logFilePath: string;
+    logFilePath?: string;
 }
 
 export class Logging {

--- a/src/chrome/internal/sources/features/dotScriptsCommand.ts
+++ b/src/chrome/internal/sources/features/dotScriptsCommand.ts
@@ -45,7 +45,7 @@ export class DotScriptCommand {
         }
 
         return outputStringP.then(scriptsStr => {
-            this._eventsToClientReporter.sendOutput({ output: scriptsStr, category: null });
+            this._eventsToClientReporter.sendOutput({ output: scriptsStr, category: 'stdout' });
         });
     }
 

--- a/src/chrome/internal/sources/identifiedLoadedSource.ts
+++ b/src/chrome/internal/sources/identifiedLoadedSource.ts
@@ -63,7 +63,7 @@ export class ScriptMapper implements IScriptMapper {
     constructor(public readonly relationships: ILoadedSourceToScriptRelationship[]) { }
 
     public mapToScripts(locationToMap: LocationInLoadedSource): LocationInScript[] {
-        return this.relationships.map(relationship => relationship.scriptAndSourceMapper.sourcesMapper.getPositionInScript(locationToMap))
+        return <LocationInScript[]>this.relationships.map(relationship => relationship.scriptAndSourceMapper.sourcesMapper.getPositionInScript(locationToMap))
             .filter(location => location !== null);
     }
 

--- a/src/chrome/internal/sources/sourceTextRetriever.ts
+++ b/src/chrome/internal/sources/sourceTextRetriever.ts
@@ -26,7 +26,7 @@ export class SourceTextRetriever {
     public async text(loadedSource: ILoadedSource): Promise<string> {
         let text = this._sourceToText.tryGetting(loadedSource);
 
-        if (text === null) {
+        if (text === undefined) {
             const scripts = loadedSource.scriptMapper().scripts;
             if (loadedSource.sourceScriptRelationship === SourceScriptRelationship.SourceIsSingleScript && scripts.length === 1) {
                 text = await this._scriptSources.getScriptSource(singleElementOfArray(scripts));

--- a/src/chrome/internal/stackTraces/callFrameDescription.ts
+++ b/src/chrome/internal/stackTraces/callFrameDescription.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------*/
 import * as path from 'path';
 import { DebugProtocol } from 'vscode-debugprotocol';
-import { ScriptCallFrame } from './callFrame';
+import { ScriptCallFrame, CallFrameWithState } from './callFrame';
 
 /** The clients can requests the stack traces frames descriptions in different formats.
  * We use this class to create the description for the call frame according to the parameters supplied by the client.
@@ -37,5 +37,5 @@ export class CustomCallFrameDescriptionFormatter implements ICallFrameDescriptio
         return formattedDescription;
     }
 
-    constructor(private readonly _callFrame: ScriptCallFrame, private readonly _formatArgs?: DebugProtocol.StackFrameFormat) { }
+    constructor(private readonly _callFrame: ScriptCallFrame<CallFrameWithState>, private readonly _formatArgs?: DebugProtocol.StackFrameFormat) { }
 }

--- a/src/chrome/internal/stackTraces/callFramePresentation.ts
+++ b/src/chrome/internal/stackTraces/callFramePresentation.ts
@@ -5,7 +5,7 @@
 import * as path from 'path';
 import { Location } from '../locations/location';
 import { ILoadedSource } from '../sources/loadedSource';
-import { CodeFlowFrame, ICallFrame, CallFrame } from './callFrame';
+import { CodeFlowFrame, ICallFrame, CallFrame, ICallFrameState } from './callFrame';
 import { CallFramePresentationHint, IStackTracePresentationRow } from './stackTracePresentationRow';
 import { DebugProtocol } from 'vscode-debugprotocol';
 
@@ -18,7 +18,7 @@ export interface ICallFramePresentationDetails {
 
 export class CallFramePresentation implements IStackTracePresentationRow {
     constructor(
-        public readonly callFrame: CallFrame<ILoadedSource>,
+        public readonly callFrame: CallFrame<ILoadedSource, ICallFrameState>,
         private readonly _descriptionFormatArgs?: DebugProtocol.StackFrameFormat,
         public readonly additionalPresentationDetails?: ICallFramePresentationDetails,
         public readonly presentationHint?: CallFramePresentationHint) {

--- a/src/chrome/internal/stackTraces/formatCallFrameDescription.ts
+++ b/src/chrome/internal/stackTraces/formatCallFrameDescription.ts
@@ -4,14 +4,14 @@
 
 import * as path from 'path';
 import { DebugProtocol } from 'vscode-debugprotocol';
-import { LoadedSourceCallFrame } from './callFrame';
+import { LoadedSourceCallFrame, CallFrameWithState } from './callFrame';
 import { functionDescription } from './callFramePresentation';
 
 /**
  * The clients can requests the stack traces frames descriptions in different formats.
  * We use this function to create the description for the call frame according to the parameters supplied by the client.
  */
-export function formatCallFrameDescription(callFrame: LoadedSourceCallFrame, formatArgs?: DebugProtocol.StackFrameFormat): string {
+export function formatCallFrameDescription(callFrame: LoadedSourceCallFrame<CallFrameWithState>, formatArgs?: DebugProtocol.StackFrameFormat): string {
     const location = callFrame.location;
 
     let formattedDescription = functionDescription(callFrame.codeFlow.functionName, location.source);

--- a/src/chrome/internal/stackTraces/scopes.ts
+++ b/src/chrome/internal/stackTraces/scopes.ts
@@ -4,12 +4,13 @@
 
  import { LocationInScript } from '../locations/location';
 import { Protocol as CDTP } from 'devtools-protocol';
+import { CDTPNonPrimitiveRemoteObject } from '../../cdtpDebuggee/cdtpPrimitives';
 
 /** This class represents a variable's scope (Globals, locals, block variables, etc...) */
 export class Scope {
     constructor(
         public readonly type: ('global' | 'local' | 'with' | 'closure' | 'catch' | 'block' | 'script' | 'eval' | 'module'),
-        public readonly object: CDTP.Runtime.RemoteObject,
+        public readonly object: CDTPNonPrimitiveRemoteObject,
         public readonly name?: string,
         public readonly startLocation?: LocationInScript,
         public readonly endLocation?: LocationInScript) { }

--- a/src/chrome/internal/stackTraces/stackTraceRequestHandler.ts
+++ b/src/chrome/internal/stackTraces/stackTraceRequestHandler.ts
@@ -10,7 +10,7 @@ import { IStackTraceResponseBody } from '../../../debugAdapterInterfaces';
 import { CallFramePresentation } from '../stackTraces/callFramePresentation';
 import { IStackTracePresentationRow, StackTraceLabel } from '../stackTraces/stackTracePresentationRow';
 import { HandlesRegistry } from '../../client/handlesRegistry';
-import { StackTracePresenter } from './stackTracePresenter';
+import { StackTracePresenter, StackTraceDefaultFormat, StackTraceCustomFormat } from './stackTracePresenter';
 import { asyncMap } from '../../collections/async';
 import { RemoveProperty } from '../../../typeUtils';
 import { LocationInSourceToClientConverter } from '../../client/locationInSourceToClientConverter';
@@ -37,10 +37,14 @@ export class StackTraceRequestHandler implements ICommandHandlerDeclarer {
     }
 
     public async stackTrace(args: DebugProtocol.StackTraceArguments): Promise<IStackTraceResponseBody> {
+        const format = args.format
+            ? new StackTraceCustomFormat(args.format)
+            : new StackTraceDefaultFormat();
+
         const firstFrameIndex = typeof args.startFrame === 'number' ? args.startFrame : 0;
         const framesCountOrNull = typeof args.levels === 'number' ? args.levels : null;
 
-        const stackTracePresentation = await this._stackTraceLogic.stackTrace(args.format, firstFrameIndex, framesCountOrNull);
+        const stackTracePresentation = await this._stackTraceLogic.stackTrace(format, firstFrameIndex, framesCountOrNull);
         const clientStackTracePresentation = {
             stackFrames: await this.toStackFrames(stackTracePresentation.stackFrames),
             totalFrames: stackTracePresentation.totalFrames

--- a/src/chrome/internal/stepping/features/syncStepping.ts
+++ b/src/chrome/internal/stepping/features/syncStepping.ts
@@ -2,7 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { ScriptCallFrame } from '../../stackTraces/callFrame';
+import { ScriptCallFrame, CallFrameWithState } from '../../stackTraces/callFrame';
 import { IActionToTakeWhenPaused, NoActionIsNeededForThisPause } from '../../features/actionToTakeWhenPaused';
 import { injectable, inject } from 'inversify';
 import { IDebuggeeExecutionController } from '../../../cdtpDebuggee/features/cdtpDebugeeExecutionController';
@@ -60,7 +60,7 @@ export class SyncStepping {
         return new NoActionIsNeededForThisPause(this);
     }
 
-    public async restartFrame(callFrame: ScriptCallFrame): Promise<void> {
+    public async restartFrame(callFrame: ScriptCallFrame<CallFrameWithState>): Promise<void> {
         this._status = this._status.startStepping();
         await this._debugeeStepping.restartFrame(callFrame);
         await this._debugeeStepping.stepInto({ breakOnAsyncCall: true });

--- a/src/chrome/internal/stepping/steppingRequestsHandler.ts
+++ b/src/chrome/internal/stepping/steppingRequestsHandler.ts
@@ -21,7 +21,7 @@ export class SteppingRequestsHandler implements ICommandHandlerDeclarer {
 
     public async restartFrame(args: DebugProtocol.RestartFrameRequest): Promise<void> {
         const callFrame = this._handlesRegistry.frames.getObjectById(args.arguments.frameId);
-        if (callFrame instanceof CallFramePresentation) {
+        if (callFrame instanceof CallFramePresentation && callFrame.callFrame.hasState()) {
             return this._syncStepping.restartFrame(callFrame.callFrame.unmappedCallFrame);
         } else {
             throw new Error(`Cannot restart to a frame that doesn't have state information`);

--- a/src/chrome/internal/variables/scopesRequestHandler.ts
+++ b/src/chrome/internal/variables/scopesRequestHandler.ts
@@ -22,10 +22,10 @@ export class ScopesRequestHandler implements ICommandHandlerDeclarer {
 
     public scopes(args: DebugProtocol.ScopesArguments): IScopesResponseBody {
         const frame = this.getCallFrameById(args.frameId);
-        if (frame instanceof CallFramePresentation) {
+        if (frame instanceof CallFramePresentation && frame.callFrame.hasState()) {
             return this._chromeDebugAdapter.scopes(frame.callFrame);
         } else {
-            throw new Error(`Can't get scopes for the frame because a label frame is only a description of the different sections of the call stack`);
+            throw new Error(`Can't get scopes for a frame that has no associated state`);
         }
     }
 

--- a/src/chrome/internalSourceBreakpoint.ts
+++ b/src/chrome/internalSourceBreakpoint.ts
@@ -32,7 +32,7 @@ export class InternalSourceBreakpoint {
 }
 
 function isLogpointStack(stackTrace: CodeFlowStackTrace | null): boolean {
-    return stackTrace && stackTrace.codeFlowFrames.length > 0
+    return !!stackTrace && stackTrace.codeFlowFrames.length > 0
     && stackTrace.codeFlowFrames[0].script.runtimeSource.identifier.isEquivalentTo(parseResourceIdentifier(createCDTPScriptUrl(InternalSourceBreakpoint.LOGPOINT_URL)));
 }
 

--- a/src/chrome/logging/printObjectDescription.ts
+++ b/src/chrome/logging/printObjectDescription.ts
@@ -14,16 +14,23 @@ export function printObjectDescription(objectToPrint: unknown, fallbackPrintDesc
             // This is a noice-json-rpc proxy
             printed = 'CDTP Proxy';
         } else {
-            const toString = objectToPrint.toString();
-            if (toString !== '[object Object]') {
-                printed = toString;
-            } else if (isJSONObject(objectToPrint)) {
-                printed = JSON.stringify(objectToPrint);
-            } else if (objectToPrint.constructor === Object) {
-                printed = fallbackPrintDescription(objectToPrint);
+            // This if is actually unnecesary, the previous if (!objectToPrint) { does the same thing. For some reason the typescript compiler cannot infer the type from that if
+            // so we just write this code to leave the compiler happy
+            // TODO: Sync with the typescript team and figure out how to remove this
+            if (!objectToPrint) {
+                printed = `${objectToPrint}`;
             } else {
-                printed = `${objectToPrint}(${objectToPrint.constructor.name})`;
-            }
+                const toString = objectToPrint.toString();
+                if (toString !== '[object Object]') {
+                    printed = toString;
+                } else if (isJSONObject(objectToPrint)) {
+                    printed = JSON.stringify(objectToPrint);
+                } else if (objectToPrint.constructor === Object) {
+                    printed = fallbackPrintDescription(objectToPrint);
+                } else {
+                    printed = `${objectToPrint}(${objectToPrint.constructor.name})`;
+                }
+                }
         }
     } else if (typeof objectToPrint === 'function') {
         if (objectToPrint.name) {

--- a/src/chrome/utils/version.ts
+++ b/src/chrome/utils/version.ts
@@ -3,12 +3,18 @@
  *--------------------------------------------------------*/
 
 import * as semver from 'semver';
+import { version } from 'punycode';
 
 export class Version {
     constructor(private readonly _semverVersion: semver.SemVer) { }
 
     public static coerce(versionString: string): Version {
-        return new Version(semver.coerce(versionString));
+        const semVerOrNull = semver.coerce(versionString);
+        if (semVerOrNull !== null) {
+            return new Version(semVerOrNull);
+        } else {
+            throw new Error(`Couldn't parse a version number from ${versionString}`);
+        }
     }
 
     public static unknownVersion(): Version {

--- a/src/sourceMaps/sourceMap.ts
+++ b/src/sourceMaps/sourceMap.ts
@@ -13,6 +13,7 @@ import { Position } from '../chrome/internal/locations/location';
 import { createLineNumber, createColumnNumber } from '../chrome/internal/locations/subtypes';
 import { newResourceIdentifierMap, IResourceIdentifier, parseResourceIdentifier } from '../chrome/internal/sources/resourceIdentifier';
 import * as _ from 'lodash';
+import { IValidatedMap } from '../chrome/collections/validatedMap';
 
 export type MappedPosition = MappedPosition;
 
@@ -248,7 +249,7 @@ export class SourceMap {
         return (<any>this._smc).sourceContentFor(authoredSourcePath, /*returnNullOnMissing=*/true);
     }
 
-    public rangesInSources(): Map<IResourceIdentifier, SourceRange> {
+    public rangesInSources(): IValidatedMap<IResourceIdentifier, SourceRange> {
         const sourceToRange = newResourceIdentifierMap<SourceRange>();
         const memoizedParseResourceIdentifier = _.memoize(parseResourceIdentifier);
         this._smc.eachMapping(mapping => {

--- a/src/sourceMaps/sourceMapUtils.ts
+++ b/src/sourceMaps/sourceMapUtils.ts
@@ -128,7 +128,7 @@ export function applySourceMapPathOverrides(sourcePath: string, sourceMapPathOve
     return sourcePath;
 }
 
-export function resolveMapPath(pathToGenerated: string, mapPath: string, pathMapping: IPathMapping): string {
+export function resolveMapPath(pathToGenerated: string, mapPath: string, pathMapping: IPathMapping | undefined): string | null {
     if (!utils.isURL(mapPath)) {
         if (utils.isURL(pathToGenerated)) {
             const scriptUrl = url.parse(pathToGenerated);

--- a/src/sourceMaps/sourceMaps.ts
+++ b/src/sourceMaps/sourceMaps.ts
@@ -17,59 +17,34 @@ export class SourceMaps {
         this._sourceMapFactory = new SourceMapFactory(pathMapping, sourceMapPathOverrides, enableSourceMapCaching);
     }
 
-    /**
-     * Returns the generated script path for an authored source path
-     * @param pathToSource - The absolute path to the authored file
-     */
-    public getGeneratedPathFromAuthoredPath(authoredPath: string): string {
-        authoredPath = authoredPath.toLowerCase();
-        return this._authoredPathToSourceMap.has(authoredPath) ?
-            this._authoredPathToSourceMap.get(authoredPath).generatedPath() :
-            null;
-    }
-
-    public mapToGenerated(authoredPath: string, line: number, column: number): MappedPosition {
-        authoredPath = authoredPath.toLowerCase();
-        return this._authoredPathToSourceMap.has(authoredPath) ?
-            this._authoredPathToSourceMap.get(authoredPath)
-                .generatedPositionFor(authoredPath, line, column) :
-            null;
-    }
-
-    public mapToAuthored(pathToGenerated: string, line: number, column: number): MappedPosition {
+    public mapToAuthored(pathToGenerated: string, line: number, column: number): MappedPosition | null {
         pathToGenerated = pathToGenerated.toLowerCase();
-        return this._generatedPathToSourceMap.has(pathToGenerated) ?
-            this._generatedPathToSourceMap.get(pathToGenerated)
-                .authoredPositionFor(line, column) :
+        const sourceMap = this._generatedPathToSourceMap.get(pathToGenerated);
+        return sourceMap !== undefined ?
+            sourceMap.authoredPositionFor(line, column) :
             null;
     }
 
-    public allMappedSources(pathToGenerated: string): string[] {
+    public allMappedSources(pathToGenerated: string): string[] | null {
         pathToGenerated = pathToGenerated.toLowerCase();
-        return this._generatedPathToSourceMap.has(pathToGenerated) ?
-            this._generatedPathToSourceMap.get(pathToGenerated).authoredSources :
+        const sourceMap = this._generatedPathToSourceMap.get(pathToGenerated);
+        return sourceMap !== undefined ?
+            sourceMap.authoredSources :
             null;
     }
 
-    public allSourcePathDetails(pathToGenerated: string): ISourcePathDetails[] {
+    public allSourcePathDetails(pathToGenerated: string): ISourcePathDetails[] | null {
         pathToGenerated = pathToGenerated.toLowerCase();
-        return this._generatedPathToSourceMap.has(pathToGenerated) ?
-            this._generatedPathToSourceMap.get(pathToGenerated).allSourcePathDetails :
-            null;
-    }
-
-    public sourceContentFor(authoredPath: string): string {
-        authoredPath = authoredPath.toLowerCase();
-        return this._authoredPathToSourceMap.has(authoredPath) ?
-            this._authoredPathToSourceMap.get(authoredPath)
-                .sourceContentFor(authoredPath) :
+        const sourceMap = this._generatedPathToSourceMap.get(pathToGenerated);
+        return sourceMap !== undefined ?
+            sourceMap.allSourcePathDetails :
             null;
     }
 
     /**
      * Given a new path to a new script file, finds and loads the sourcemap for that file
      */
-    public async processNewSourceMap(pathToGenerated: string, sourceMapURL: string, isVSClient = false): Promise<SourceMap> {
+    public async processNewSourceMap(pathToGenerated: string, sourceMapURL: string, isVSClient = false): Promise<SourceMap | null> {
         const sourceMap = await this._sourceMapFactory.getMapForGeneratedPath(pathToGenerated, sourceMapURL, isVSClient);
         if (sourceMap) {
             this._generatedPathToSourceMap.set(pathToGenerated.toLowerCase(), sourceMap);

--- a/src/transformers/basePathTransformer.ts
+++ b/src/transformers/basePathTransformer.ts
@@ -35,7 +35,7 @@ export class BasePathTransformer {
         return clientPath;
     }
 
-    public getClientPathFromTargetPath(targetPath: IResourceIdentifier): IResourceIdentifier {
+    public getClientPathFromTargetPath(targetPath: IResourceIdentifier): IResourceIdentifier | undefined {
         return targetPath;
     }
 }

--- a/src/transformers/configurationBasedPathTransformer.ts
+++ b/src/transformers/configurationBasedPathTransformer.ts
@@ -46,7 +46,7 @@ export class ConfigurationBasedPathTransformer extends BasePathTransformer {
         return this._pathTransformer.getTargetPathFromClientPath(clientPath);
     }
 
-    public getClientPathFromTargetPath(targetPath: IResourceIdentifier): IResourceIdentifier {
+    public getClientPathFromTargetPath(targetPath: IResourceIdentifier): IResourceIdentifier | undefined {
         return this._pathTransformer.getClientPathFromTargetPath(targetPath);
     }
 }

--- a/src/transformers/eagerSourceMapTransformer.ts
+++ b/src/transformers/eagerSourceMapTransformer.ts
@@ -66,7 +66,7 @@ export class EagerSourceMapTransformer extends BaseSourceMapTransformer {
      * Try to find the 'sourceMappingURL' in content or the file with the given path.
      * Returns null if no source map url is found or if an error occured.
      */
-    private findSourceMapUrlInFile(pathToGenerated: string, content?: string): Promise<string> {
+    private findSourceMapUrlInFile(pathToGenerated: string, content?: string): Promise<string | null> {
         if (content) {
             return Promise.resolve(this.findSourceMapUrl(content));
         }
@@ -80,7 +80,7 @@ export class EagerSourceMapTransformer extends BaseSourceMapTransformer {
      * Relative file paths are converted into absolute paths.
      * Returns null if no source map url is found.
      */
-    private findSourceMapUrl(contents: string): string {
+    private findSourceMapUrl(contents: string): string | null {
         const lines = contents.split('\n');
         for (let l = lines.length - 1; l >= Math.max(lines.length - 10, 0); l--) {    // only search for url in the last 10 lines
             const line = lines[l].trim();

--- a/src/transformers/urlPathTransformer.ts
+++ b/src/transformers/urlPathTransformer.ts
@@ -19,7 +19,7 @@ import { IConnectedCDAConfiguration } from '../chrome/client/chromeDebugAdapter/
  */
 @injectable()
 export class UrlPathTransformer extends BasePathTransformer {
-    private _pathMapping: IPathMapping;
+    private _pathMapping: IPathMapping | undefined;
     private _clientPathToTargetUrl = newResourceIdentifierMap<IResourceIdentifier>();
     private _targetUrlToClientPath = newResourceIdentifierMap<IResourceIdentifier>();
 
@@ -62,7 +62,7 @@ export class UrlPathTransformer extends BasePathTransformer {
             clientPath;
     }
 
-    public getClientPathFromTargetPath(targetPath: IResourceIdentifier): IResourceIdentifier {
+    public getClientPathFromTargetPath(targetPath: IResourceIdentifier): IResourceIdentifier | undefined {
         return this._targetUrlToClientPath.tryGetting(targetPath);
     }
 

--- a/src/typeUtils.ts
+++ b/src/typeUtils.ts
@@ -7,3 +7,11 @@
  */
 export type MakePropertyRequired<T, K extends keyof T> = T & { [P in K]-?: T[K] };
 export type RemoveProperty<T, K> = Pick<T, Exclude<keyof T, K>>;
+
+export function isNotUndefined<T>(object: T | undefined): object is T {
+    return object !== undefined;
+}
+
+export interface Array<T> {
+    filter<U extends T>(predicate: (element: T) => element is U): U[];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
         "noImplicitReturns": true,
         "strictFunctionTypes": true,
         "noImplicitAny": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictPropertyInitialization": false,
 
 


### PR DESCRIPTION
Enabled strict null checking for Typescript.
Modified all the code necessary to make the project compile with that option.
Also deleted some code from the transformers that wasn't being used any more.