### PR TITLE
Fixing disconnect issue

### DIFF
--- a/src/chrome/chromeDebugSession.ts
+++ b/src/chrome/chromeDebugSession.ts
@@ -132,8 +132,15 @@ export class ChromeDebugSession extends LoggingDebugSession implements IObservab
             try {
                 logger.verbose(`From client: ${request.command}(${JSON.stringify(request.arguments) })`);
                 telemetryPropertyCollector.addTelemetryProperty('requestType', request.type);
+                // Disconnect request is a special case--the response needs to be sent before
+                // we do our "shutdown" processing.
+                if (request.command === 'disconnect') {
+                    this.sendResponse(response);
+                }
                 response.body = await this._debugAdapter.processRequest(<CommandText>request.command, request.arguments, telemetryPropertyCollector);
-                this.sendResponse(response);
+                if (request.command !== 'disconnect') {
+                    this.sendResponse(response);
+                }
             } catch (e) {
                 if (!this.isEvaluateRequest(request.command, e)) {
                     reportFailure(e);


### PR DESCRIPTION
Previously, the debug adapter would wait for disconnect to be processed and then send the response. This was problematic because part of the disconnect process was to shut down the connection to the client. This would leave the client waiting for the disconnect response which would never come.