### PR TITLE
Improve logic to set breakpoints and fix stackTrace line number issue

### DIFF
--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpOnScriptParsedEventProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpOnScriptParsedEventProvider.ts
@@ -184,7 +184,7 @@ abstract class ScriptCreator {
     protected scriptRange(runtimeSource: ILoadedSource<CDTPScriptUrl>) {
         const startPosition = new Position(createLineNumber(this._scriptParsedEvent.startLine), createColumnNumber(this._scriptParsedEvent.startColumn));
         const endPosition = new Position(createLineNumber(this._scriptParsedEvent.endLine), createColumnNumber(this._scriptParsedEvent.endColumn));
-        const scriptRange = new RangeInResource(runtimeSource, startPosition, endPosition);
+        const scriptRange = RangeInResource.fromPositions(runtimeSource, startPosition, endPosition);
         return scriptRange;
     }
 

--- a/src/chrome/internal/breakpoints/baseMappedBPRecipe.ts
+++ b/src/chrome/internal/breakpoints/baseMappedBPRecipe.ts
@@ -8,6 +8,7 @@ import { createURLRegexp, URLRegexp } from '../locations/subtypes';
 import { IURL } from '../sources/resourceIdentifier';
 import { CDTPScriptUrl } from '../sources/resourceIdentifierSubtypes';
 import * as utils from '../../../utils';
+import { IMappedTokensInScript } from '../locations/mappedTokensInScript';
 
 export interface IMappedBPRecipe<TResource extends ScriptOrSourceOrURLOrURLRegexp, TBPActionWhenHit extends IBPActionWhenHit>
     extends IBPRecipe<TResource, TBPActionWhenHit> {
@@ -42,8 +43,8 @@ abstract class BaseMappedBPRecipe<TResource extends ScriptOrSourceOrURLOrURLRege
 }
 
 export class BPRecipeInLoadedSource<TBPActionWhenHit extends IBPActionWhenHit> extends BaseMappedBPRecipe<ILoadedSource, TBPActionWhenHit>  {
-    public mappedToScript(): BPRecipeInScript[] {
-        return this.location.mappedToScript().map(location => new BPRecipeInScript(this.unmappedBPRecipe, location));
+    public tokensWhenMappedToScript(): IMappedTokensInScript[] {
+        return this.location.tokensWhenMappedToScript();
     }
 
     public withAlwaysPause(): BPRecipeInLoadedSource<AlwaysPause> {

--- a/src/chrome/internal/breakpoints/diBindings.ts
+++ b/src/chrome/internal/breakpoints/diBindings.ts
@@ -18,6 +18,7 @@ import { BPRsDeltaCalculatorFromStoredBPRs } from './registries/bprsDeltaCalcula
 import { BreakpointsSetForScriptFinder } from './registries/breakpointsSetForScriptFinder';
 import { PauseScriptLoadsToSetBPs } from './features/pauseScriptLoadsToSetBPs';
 import { BPRecipesForSourceRetriever } from './registries/bpRecipesForSourceRetriever';
+import { SourceToScriptMapper } from '../services/sourceToScriptMapper';
 
 const exportedIdentifierToClasses = new ValidatedMap<interfaces.ServiceIdentifier<any>, interfaces.Newable<any>>([
     [TYPES.IBreakpointsUpdater, BreakpointsUpdater],
@@ -33,6 +34,7 @@ const privatedentifierToClasses: IdentifierToClassPairs = [
     [PrivateTypes.HitCountBreakpointsSetter, HitCountBreakpointsSetter],
     [PrivateTypes.BreakpointsSetForScriptFinder, BreakpointsSetForScriptFinder],
     [PrivateTypes.BPRecipesForSourceRetriever, BPRecipesForSourceRetriever],
+    [PrivateTypes.SourceToScriptMapper, SourceToScriptMapper],
     [PrivateTypes.PauseScriptLoadsToSetBPs, PauseScriptLoadsToSetBPs],
     [PrivateTypes.CurrentBPRecipesForSourceRegistry, BPRsDeltaCalculatorFromStoredBPRs],
     [PrivateTypes.ExistingBPsForJustParsedScriptSetter, ExistingBPsForJustParsedScriptSetter],

--- a/src/chrome/internal/breakpoints/diTypes.ts
+++ b/src/chrome/internal/breakpoints/diTypes.ts
@@ -12,5 +12,6 @@ export const PrivateTypes = {
     ExistingBPsForJustParsedScriptSetter: Symbol.for('ExistingBPsForJustParsedScriptSetter'),
     BreakpointsSetForScriptFinder: Symbol.for('BreakpointsSetForScriptFinder'),
     BPRecipesForSourceRetriever: Symbol.for('BPRecipesForSourceRetriever'),
+    SourceToScriptMapper: Symbol.for('SourceToScriptMapper'),
     DebuggeeBPRsSetForClientBPRFinder: Symbol.for('DebuggeeBPRsSetForClientBPRFinder'),
 };

--- a/src/chrome/internal/features/skipFiles.ts
+++ b/src/chrome/internal/features/skipFiles.ts
@@ -198,7 +198,7 @@ export class SkipFilesLogic implements IStackTracePresentationDetailsProvider {
                         throw new Error(`Source '${s}' start not found in script.`);
                     }
 
-                    libPositions.push(pos);
+                    libPositions.push(pos.enclosingRange.start);
                     inLibRange = !inLibRange;
                 }
             }

--- a/src/chrome/internal/locations/location.ts
+++ b/src/chrome/internal/locations/location.ts
@@ -11,6 +11,7 @@ import { CDTPScriptUrl } from '../sources/resourceIdentifierSubtypes';
 import { IResourceIdentifier, IURL, isResourceIdentifier } from '../sources/resourceIdentifier';
 import { IEquivalenceComparable } from '../../utils/equivalence';
 import * as _ from 'lodash';
+import { IMappedTokensInScript } from './mappedTokensInScript';
 
 export type integer = number;
 
@@ -177,7 +178,7 @@ export class LocationInLoadedSource extends BaseLocation<ILoadedSource> {
         return this.resource;
     }
 
-    public mappedToScript(): LocationInScript[] {
+    public tokensWhenMappedToScript(): IMappedTokensInScript[] {
         return this.source.scriptMapper().mapToScripts(this);
     }
 }

--- a/src/chrome/internal/locations/mappedTokensInScript.ts
+++ b/src/chrome/internal/locations/mappedTokensInScript.ts
@@ -1,29 +1,28 @@
-import { RangeInScript, RangeInResource } from './rangeInScript';
+import { RangeInScript, RangeInResource, Range } from './rangeInScript';
 import { IScript } from '../../..';
 import { LocationInScript } from './location';
 import { printArray } from '../../collections/printing';
 
 export interface IMappedTokensInScript {
     readonly script: IScript;
-    readonly ranges: RangeInScript[];
     readonly enclosingRange: RangeInScript;
 
     isEmpty(): boolean;
 }
 
 export class MappedTokensInScript implements IMappedTokensInScript {
-    public constructor(public readonly script: IScript, public readonly ranges: RangeInScript[]) {
-        if (this.ranges.length === 0) {
+    public constructor(public readonly script: IScript, private readonly _ranges: Range[]) {
+        if (this._ranges.length === 0) {
             throw new Error(`Expected the mapped tokens to have a non empty list of ranges where the tokens are located`);
         }
     }
 
     public static characterAt(characterLocation: LocationInScript): IMappedTokensInScript {
-        return new MappedTokensInScript(characterLocation.script, [RangeInResource.characterAt(characterLocation)]);
+        return new MappedTokensInScript(characterLocation.script, [Range.at(characterLocation.position)]);
     }
 
     public get enclosingRange(): RangeInScript {
-        return RangeInResource.enclosingAll(this.ranges);
+        return new RangeInResource(this.script, Range.enclosingAll(this._ranges));
     }
 
     public isEmpty(): boolean {
@@ -31,7 +30,7 @@ export class MappedTokensInScript implements IMappedTokensInScript {
     }
 
     public toString(): string {
-        return printArray('Mapped to script tokens at:', this.ranges);
+        return printArray('Mapped to script tokens at:', this._ranges);
     }
 }
 

--- a/src/chrome/internal/locations/mappedTokensInScript.ts
+++ b/src/chrome/internal/locations/mappedTokensInScript.ts
@@ -1,0 +1,56 @@
+import { RangeInScript, RangeInResource } from './rangeInScript';
+import { IScript } from '../../..';
+import { LocationInScript } from './location';
+import { printArray } from '../../collections/printing';
+
+export interface IMappedTokensInScript {
+    readonly script: IScript;
+    readonly ranges: RangeInScript[];
+    readonly enclosingRange: RangeInScript;
+
+    isEmpty(): boolean;
+}
+
+export class MappedTokensInScript implements IMappedTokensInScript {
+    public constructor(public readonly script: IScript, public readonly ranges: RangeInScript[]) {
+        if (this.ranges.length === 0) {
+            throw new Error(`Expected the mapped tokens to have a non empty list of ranges where the tokens are located`);
+        }
+    }
+
+    public static characterAt(characterLocation: LocationInScript): IMappedTokensInScript {
+        return new MappedTokensInScript(characterLocation.script, [RangeInResource.characterAt(characterLocation)]);
+    }
+
+    public get enclosingRange(): RangeInScript {
+        return RangeInResource.enclosingAll(this.ranges);
+    }
+
+    public isEmpty(): boolean {
+        return false;
+    }
+
+    public toString(): string {
+        return printArray('Mapped to script tokens at:', this.ranges);
+    }
+}
+
+export class NoMappedTokensInScript implements IMappedTokensInScript {
+    public constructor(public readonly script: IScript) { }
+
+    public get ranges(): never {
+        throw new Error(`Can't get the ranges when the source mapped to no tokens on the script`);
+    }
+
+    public get enclosingRange(): never {
+        throw new Error(`Can't get the enclosing range when the source mapped to no tokens on the script`);
+    }
+
+    public isEmpty(): boolean {
+        return true;
+    }
+
+    public toString(): string {
+        return `Didn't map to any script tokens`;
+    }
+}

--- a/src/chrome/internal/locations/rangeInScript.ts
+++ b/src/chrome/internal/locations/rangeInScript.ts
@@ -4,46 +4,56 @@
 
 import { Position, Location, ScriptOrSourceOrURLOrURLRegexp, createLocation, LocationInScript } from './location';
 import { IScript } from '../scripts/script';
-import { printArray } from '../../collections/printing';
+
+export class Range {
+    public constructor(
+        readonly start: Position,
+        readonly end: Position) {
+        if (start.lineNumber > end.lineNumber
+            || (start.lineNumber === end.lineNumber && start.columnNumber > end.columnNumber)) {
+            throw new Error(`Can't create a range in where the end position (${end}) happens before the start position ${start}`);
+        }
+    }
+
+    public static at(position: Position): Range {
+        return new Range(position, position);
+    }
+
+    public static enclosingAll(manyRanges: Range[]) {
+        if (manyRanges.length === 0) {
+            throw new Error(`Can't find the enclosing range of an empty list of ranges`);
+        } else {
+            const firstPosition = Position.appearingFirstOf(...manyRanges.map(range => range.start));
+            const lastPosition = Position.appearingLastOf(...manyRanges.map(range => range.end));
+            return new Range(firstPosition, lastPosition);
+        }
+    }
+
+    public toString(): string {
+        return `[${this.start} to ${this.end}]`;
+    }
+}
 
 /** Used by CDTP getPossibleBreakpoints API to inquire the valid set of positions for a breakpoint in a particular range of the script */
 export class RangeInResource<TResource extends ScriptOrSourceOrURLOrURLRegexp> {
     constructor(
         public readonly resource: TResource,
-        private readonly _start: Position,
-        private readonly _end: Position) {
-        if (_start.lineNumber > _end.lineNumber
-            || (_start.lineNumber === _end.lineNumber && _start.columnNumber > _end.columnNumber)) {
-            throw new Error(`Can't create a range in a resource ${resource} where the end position (${_end}) happens before the start position ${_start}`);
-        }
+        public readonly range: Range) { }
+
+    public static fromPositions<TResource extends ScriptOrSourceOrURLOrURLRegexp>(resource: TResource, start: Position, end: Position): RangeInResource<TResource> {
+        return new RangeInResource<TResource>(resource, new Range(start, end));
     }
 
     public static characterAt(characterLocation: LocationInScript): RangeInResource<IScript> {
-        return new RangeInResource<IScript>(characterLocation.script, characterLocation.position, characterLocation.position);
+        return RangeInResource.fromPositions(characterLocation.script, characterLocation.position, characterLocation.position);
     }
 
     public get start(): Location<TResource> {
-        return createLocation(this.resource, this._start);
+        return createLocation(this.resource, this.range.start);
     }
 
     public get end(): Location<TResource> {
-        return createLocation(this.resource, this._end);
-    }
-
-    public static enclosingAll(manyRanges: RangeInResource<IScript>[]) {
-        if (manyRanges.length === 0) {
-            throw new Error(`Can't find the enclosing range of an empty list of ranges`);
-        } else {
-            const script = manyRanges[0].resource;
-            const rangesWithDifferentScript = manyRanges.filter(range => range.resource !== script);
-            if (rangesWithDifferentScript.length >= 1) {
-                throw new Error(`Expected all the ranges to refer to the same resource yet the first range refered to: ${script} while some ranges refered to ${printArray('other resources', rangesWithDifferentScript)}`);
-            }
-
-            const firstPosition = Position.appearingFirstOf(...manyRanges.map(range => range.start.position));
-            const lastPosition = Position.appearingLastOf(...manyRanges.map(range => range.end.position));
-            return new RangeInResource(manyRanges[0].resource, firstPosition, lastPosition);
-        }
+        return createLocation(this.resource, this.range.end);
     }
 
     public toString(): string {

--- a/src/chrome/internal/locations/rangeInScript.ts
+++ b/src/chrome/internal/locations/rangeInScript.ts
@@ -2,8 +2,9 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { Position, Location, ScriptOrSourceOrURLOrURLRegexp, createLocation } from './location';
+import { Position, Location, ScriptOrSourceOrURLOrURLRegexp, createLocation, LocationInScript } from './location';
 import { IScript } from '../scripts/script';
+import { printArray } from '../../collections/printing';
 
 /** Used by CDTP getPossibleBreakpoints API to inquire the valid set of positions for a breakpoint in a particular range of the script */
 export class RangeInResource<TResource extends ScriptOrSourceOrURLOrURLRegexp> {
@@ -17,12 +18,36 @@ export class RangeInResource<TResource extends ScriptOrSourceOrURLOrURLRegexp> {
         }
     }
 
+    public static characterAt(characterLocation: LocationInScript): RangeInResource<IScript> {
+        return new RangeInResource<IScript>(characterLocation.script, characterLocation.position, characterLocation.position);
+    }
+
     public get start(): Location<TResource> {
         return createLocation(this.resource, this._start);
     }
 
     public get end(): Location<TResource> {
         return createLocation(this.resource, this._end);
+    }
+
+    public static enclosingAll(manyRanges: RangeInResource<IScript>[]) {
+        if (manyRanges.length === 0) {
+            throw new Error(`Can't find the enclosing range of an empty list of ranges`);
+        } else {
+            const script = manyRanges[0].resource;
+            const rangesWithDifferentScript = manyRanges.filter(range => range.resource !== script);
+            if (rangesWithDifferentScript.length >= 1) {
+                throw new Error(`Expected all the ranges to refer to the same resource yet the first range refered to: ${script} while some ranges refered to ${printArray('other resources', rangesWithDifferentScript)}`);
+            }
+
+            const firstPosition = Position.appearingFirstOf(...manyRanges.map(range => range.start.position));
+            const lastPosition = Position.appearingLastOf(...manyRanges.map(range => range.end.position));
+            return new RangeInResource(manyRanges[0].resource, firstPosition, lastPosition);
+        }
+    }
+
+    public toString(): string {
+        return `${this.resource} @ [${this.start.position} to ${this.end.position}]`;
     }
 }
 

--- a/src/chrome/internal/services/sourceToScriptMapper.ts
+++ b/src/chrome/internal/services/sourceToScriptMapper.ts
@@ -1,0 +1,51 @@
+import { BPRecipeInLoadedSource, BPRecipeInScript } from '../breakpoints/baseMappedBPRecipe';
+import { ConditionalPause, AlwaysPause } from '../breakpoints/bpActionWhenHit';
+import { injectable, inject } from 'inversify';
+import { IBreakpointFeaturesSupport } from '../../cdtpDebuggee/features/cdtpBreakpointFeaturesSupport';
+import { LocationInScript } from '../locations/location';
+import { RangeInScript } from '../locations/rangeInScript';
+import { logger } from 'vscode-debugadapter/lib/logger';
+import { IDebuggeeBreakpointsSetter } from '../../cdtpDebuggee/features/cdtpDebuggeeBreakpointsSetter';
+import { printArray } from '../../collections/printing';
+import { asyncMap } from '../../collections/async';
+import { TYPES } from '../../dependencyInjection.ts/types';
+
+@injectable()
+export class SourceToScriptMapper {
+    private readonly doesTargetSupportColumnBreakpointsCached: Promise<boolean>;
+
+    constructor(
+        @inject(TYPES.IBreakpointFeaturesSupport) private readonly _breakpointFeaturesSupport: IBreakpointFeaturesSupport,
+        @inject(TYPES.IDebuggeeBreakpointsSetter) private readonly _targetBreakpoints: IDebuggeeBreakpointsSetter) {
+        this.doesTargetSupportColumnBreakpointsCached = this._breakpointFeaturesSupport.supportsColumnBreakpoints;
+    }
+
+    public async mapBPRecipe(bpRecipe: BPRecipeInLoadedSource<ConditionalPause | AlwaysPause>): Promise<BPRecipeInScript[]> {
+        const tokensInManyScripts = bpRecipe.location.tokensWhenMappedToScript();
+        return asyncMap(tokensInManyScripts, async manyTokensInScript => {
+            const bestLocation = this.doesTargetSupportColumnBreakpointsCached
+                ? await this.findBestLocationForBP(manyTokensInScript.enclosingRange)
+                : manyTokensInScript.enclosingRange.start; // If we don't support column breakpoints we set the breakpoint at the start of the range
+            const bpRecipeAtBestLocation = new BPRecipeInScript(bpRecipe.unmappedBPRecipe, bestLocation);
+            return bpRecipeAtBestLocation;
+        });
+    }
+
+    private async findBestLocationForBP(range: RangeInScript): Promise<LocationInScript> {
+        const possibleLocations = await this._targetBreakpoints.getPossibleBreakpoints(range);
+
+        if (possibleLocations.length > 0) {
+            // I'm assuming that the first location will always be the earliest/leftmost location. If that is not the case we'll need to fix this code
+            const choosenLocation = possibleLocations[0];
+            if (possibleLocations.length === 1) {
+                logger.verbose(`Breakpoint at ${range} mapped to the only option: ${choosenLocation}`);
+            } else {
+                logger.verbose(`Breakpoint at ${range} can be mapped to ${printArray('many options:', possibleLocations)}. Chose the first one: ${choosenLocation}`);
+            }
+
+            return choosenLocation;
+        } else {
+            throw new Error(`Couldn't find a suitable position to set a breakpoin in: ${range}`);
+        }
+    }
+}

--- a/src/chrome/internal/sources/identifiedLoadedSource.ts
+++ b/src/chrome/internal/sources/identifiedLoadedSource.ts
@@ -5,7 +5,8 @@ import { ILoadedSource, IScriptMapper, ICurrentScriptRelationshipsProvider as IS
 import { ILoadedSourceToScriptRelationship } from './loadedSourceToScriptRelationship';
 import * as _ from 'lodash';
 import { printArray } from '../../collections/printing';
-import { LocationInScript, LocationInLoadedSource } from '../locations/location';
+import { LocationInLoadedSource } from '../locations/location';
+import { IMappedTokensInScript } from '../locations/mappedTokensInScript';
 
 /**
  * Loaded Source classification:
@@ -62,9 +63,9 @@ export class IdentifiedLoadedSource<TString extends string = string> implements 
 export class ScriptMapper implements IScriptMapper {
     constructor(public readonly relationships: ILoadedSourceToScriptRelationship[]) { }
 
-    public mapToScripts(locationToMap: LocationInLoadedSource): LocationInScript[] {
-        return <LocationInScript[]>this.relationships.map(relationship => relationship.scriptAndSourceMapper.sourcesMapper.getPositionInScript(locationToMap))
-            .filter(location => location !== null);
+    public mapToScripts(locationToMap: LocationInLoadedSource): IMappedTokensInScript[] {
+        return this.relationships.map(relationship => relationship.scriptAndSourceMapper.sourcesMapper.getPositionInScript(locationToMap))
+            .filter(mappedTokensInScript => !mappedTokensInScript.isEmpty());
     }
 
     public get scripts(): IScript[] {

--- a/src/chrome/internal/sources/loadedSource.ts
+++ b/src/chrome/internal/sources/loadedSource.ts
@@ -8,7 +8,8 @@ import { determineOrderingOfStrings } from '../../collections/utilities';
 import { IEquivalenceComparable } from '../../utils/equivalence';
 import { IdentifiedLoadedSource } from './identifiedLoadedSource';
 import { ISourceMapper } from '../scripts/sourcesMapper';
-import { LocationInScript, LocationInLoadedSource } from '../locations/location';
+import { LocationInLoadedSource } from '../locations/location';
+import { IMappedTokensInScript } from '../locations/mappedTokensInScript';
 
 /**
  * This interface represents a source or text that is related to a script that the debuggee is executing. The text can be the contents of the script itself,
@@ -50,7 +51,7 @@ export class ScriptAndSourceMapper {
 
 export interface IScriptMapper {
     readonly scripts: IScript[];
-    mapToScripts(position: LocationInLoadedSource): LocationInScript[];
+    mapToScripts(position: LocationInLoadedSource): IMappedTokensInScript[];
 }
 
 export enum SourceScriptRelationship {

--- a/src/chrome/internal/sources/unidentifiedLoadedSource.ts
+++ b/src/chrome/internal/sources/unidentifiedLoadedSource.ts
@@ -5,6 +5,7 @@ import { ILoadedSource, IScriptMapper, SourceScriptRelationship, ImplementsLoade
 import { ILoadedSourceToScriptRelationship, DevelopmentSourceOf, RuntimeSourceOf } from './loadedSourceToScriptRelationship';
 import { UnmappedSourceMapper } from '../scripts/sourcesMapper';
 import { LocationInLoadedSource, LocationInScript } from '../locations/location';
+import { IMappedTokensInScript, MappedTokensInScript } from '../locations/mappedTokensInScript';
 
 export class UnidentifiedLoadedSource implements ILoadedSource<CDTPScriptUrl> {
     // TODO DIEGO: Move these two properties to the client layer
@@ -52,8 +53,8 @@ export class UnidentifiedLoadedSource implements ILoadedSource<CDTPScriptUrl> {
 export class CurrentUnidentifiedSourceScriptRelationships implements IScriptMapper {
     constructor(private readonly _source: UnidentifiedLoadedSource, private readonly _script: IScript) { }
 
-    public mapToScripts(position: LocationInLoadedSource): LocationInScript[] {
-        return [new LocationInScript(this._script, position.position)];
+    public mapToScripts(position: LocationInLoadedSource): IMappedTokensInScript[] {
+        return [MappedTokensInScript.characterAt(new LocationInScript(this._script, position.position))];
     }
 
     public get relationships(): ILoadedSourceToScriptRelationship[] {

--- a/src/chrome/internal/stackTraces/callFramePresentation.ts
+++ b/src/chrome/internal/stackTraces/callFramePresentation.ts
@@ -62,7 +62,10 @@ export class CallFramePresentation implements IStackTracePresentationRow {
             }
 
             if (this._descriptionFormatArgs.formatOptions.line) {
-                formattedDescription += ` Line ${location.position.lineNumber}`;
+                // The description property intended for the user, so we don't care if the client uses 0-index or 1-index line number. We send this as 1-index line number always
+                const oneBasedLineNumber = location.position.lineNumber + 1;
+
+                formattedDescription += ` Line ${oneBasedLineNumber}`;
             }
         }
 

--- a/src/sourceMaps/sourceMap.ts
+++ b/src/sourceMaps/sourceMap.ts
@@ -14,6 +14,7 @@ import { createLineNumber, createColumnNumber } from '../chrome/internal/locatio
 import { newResourceIdentifierMap, IResourceIdentifier, parseResourceIdentifier } from '../chrome/internal/sources/resourceIdentifier';
 import * as _ from 'lodash';
 import { IValidatedMap } from '../chrome/collections/validatedMap';
+import { Range } from '../chrome/internal/locations/rangeInScript';
 
 export type MappedPosition = MappedPosition;
 
@@ -26,14 +27,10 @@ export interface ISourcePathDetails {
     startPosition: MappedPosition;
 }
 
-export class SourceRange {
-    public constructor(
-        readonly start: Position,
-        readonly end: Position) { }
-
-    public toString(): string {
-        return `[${this.start} to ${this.end}]`;
-    }
+export interface NonNullablePosition extends NullablePosition {
+    line: number;
+    column: number;
+    lastColumn: number | null;
 }
 
 export class SourceMap {
@@ -150,6 +147,7 @@ export class SourceMap {
 
         this._init = new SourceMapConsumer(sm).then(sourceMapConsumer => {
             this._smc = sourceMapConsumer;
+            this._smc.computeColumnSpans(); // So allGeneratedPositionsFor will return the last column info
         });
     }
 
@@ -256,7 +254,11 @@ export class SourceMap {
         }
     }
 
-    public allGeneratedPositionFor(source: string, line: number, column: number): NullablePosition[] {
+    private isNonNullablePosition(position: NullablePosition): position is NonNullablePosition {
+        return position.line !== null && position.column != null;
+    }
+
+    public allGeneratedPositionFor(source: string, line: number, column: number): NonNullablePosition[] {
         // source-map lib uses 1-indexed lines.
         line++;
 
@@ -272,9 +274,14 @@ export class SourceMap {
         };
 
         let positions = this._smc!.allGeneratedPositionsFor(lookupArgs);
+        const validPositions = <NonNullablePosition[]>positions.filter(p => this.isNonNullablePosition(p));
+        if (validPositions.length < positions.length) {
+            const invalidPositions = _.difference(positions, validPositions);
+            logger.log(`WARNING: Some source map positions for: ${JSON.stringify(lookupArgs)} were discarded because they weren't valid: ${JSON.stringify(invalidPositions)}`);
+        }
 
-        return positions.map(position => ({
-            line: position.line !== null ? position.line - 1 : null, // Back to 0-indexed lines
+        return validPositions.map(position => ({
+            line: position.line - 1, // Back to 0-indexed lines
             column: position.column,
             lastColumn: position.lastColumn
         }));
@@ -285,19 +292,19 @@ export class SourceMap {
         return (<any>this._smc).sourceContentFor(authoredSourcePath, /*returnNullOnMissing=*/true);
     }
 
-    public rangesInSources(): IValidatedMap<IResourceIdentifier, SourceRange> {
-        const sourceToRange = newResourceIdentifierMap<SourceRange>();
+    public rangesInSources(): IValidatedMap<IResourceIdentifier, Range> {
+        const sourceToRange = newResourceIdentifierMap<Range>();
         const memoizedParseResourceIdentifier = _.memoize(parseResourceIdentifier);
         this._smc!.eachMapping(mapping => {
             const positionInSource = new Position(createLineNumber(mapping.originalLine), createColumnNumber(mapping.originalColumn));
             if (mapping.source) { // In source-map 0.5.7 this is null sometimes
                 const sourceIdentifier = memoizedParseResourceIdentifier(mapping.source);
-                const range = sourceToRange.getOr(sourceIdentifier, () => new SourceRange(positionInSource, positionInSource));
-                const expandedRange = new SourceRange(
+                const range = sourceToRange.getOr(sourceIdentifier, () => new Range(positionInSource, positionInSource));
+                const expandedRange = new Range(
                     Position.appearingFirstOf(range.start, positionInSource),
                     Position.appearingLastOf(range.end, positionInSource));
                 sourceToRange.setAndReplaceIfExist(sourceIdentifier, expandedRange);
-                }
+            }
         });
 
         return sourceToRange;


### PR DESCRIPTION
Now instead of getting a single mapping from the source maps, we get all the mappings associated with a position, we find the range of the section enclosing all of them, and we set the breakpoint on the first breakable position inside that region.

We also fixed a bug with the line number of stack traces.
