### PR TITLE
Fix stacktrace line number formatting

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -2019,12 +2019,10 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
                 frame.source.path = undefined;
                 frame.source.name = this.displayNameForSourceReference(frame.source.sourceReference);
             }
-
-            // Format stackframe name
-            frame.name = this.formatStackFrameName(frame, args.format);
         }));
 
         this._lineColTransformer.stackTraceResponse(stackTraceResponse);
+        stackTraceResponse.stackFrames.forEach(frame => frame.name = this.formatStackFrameName(frame, args.format));
 
         return stackTraceResponse;
     }


### PR DESCRIPTION
Fixing a formatting bug introduced in 2e1ce915c907c0e7f7ed2f7129ebf6cab1177981

Formatting the stack frame name needs to happen after the line numbers are adjusted, otherwise the line numbers in the name will be off by one. This doesn't impact vscode since it doesn't use line number in its format, however VS does use it.

This is being totally refactored in V2, so will need to be checked again...