### PR TITLE
- Several bug fixes to make the int test pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "ws": "^6.0.0"
   },
   "devDependencies": {
-    "@types/source-map": "^0.5.7",
     "@types/color": "^3.0.0",
     "@types/glob": "^5.0.35",
     "@types/lodash": "^4.14.123",
@@ -37,6 +36,7 @@
     "@types/mockery": "^1.4.29",
     "@types/node": "^8.0.58",
     "@types/semver": "^5.5.0",
+    "@types/source-map": "^0.5.7",
     "@types/ws": "^6.0.0",
     "del": "^2.2.2",
     "event-stream": "^3.3.4",

--- a/src/chrome/client/sourceToClientConverter.ts
+++ b/src/chrome/client/sourceToClientConverter.ts
@@ -3,6 +3,7 @@ import * as utils from '../../utils';
 import { ILoadedSource } from '../internal/sources/loadedSource';
 import { HandlesRegistry } from './handlesRegistry';
 import { DebugProtocol } from 'vscode-debugprotocol';
+import { LocalFileURL } from '../internal/sources/resourceIdentifier';
 
 export class SourceToClientConverter {
     constructor(private readonly _handlesRegistry: HandlesRegistry) { }
@@ -10,11 +11,16 @@ export class SourceToClientConverter {
     public async toSource(loadedSource: ILoadedSource): Promise<DebugProtocol.Source> {
         const exists = await utils.existsAsync(loadedSource.identifier.canonicalized);
 
+        const sourceIdentifier = loadedSource.identifier;
+        const sourceTextRepresentation = sourceIdentifier instanceof LocalFileURL
+            ? sourceIdentifier.filePathRepresentation
+            : sourceIdentifier.textRepresentation;
+
         // if the path exists, do not send the sourceReference
         // new Source sends 0 for undefined
         const source = {
-            name: pathModule.basename(loadedSource.identifier.textRepresentation),
-            path: loadedSource.identifier.textRepresentation,
+            name: pathModule.basename(sourceTextRepresentation),
+            path: sourceTextRepresentation,
             sourceReference: exists ? undefined : this._handlesRegistry.sources.getIdByObject(loadedSource),
         };
 

--- a/src/chrome/collections/bidirectionalMap.ts
+++ b/src/chrome/collections/bidirectionalMap.ts
@@ -12,6 +12,12 @@ export class BidirectionalMap<Left, Right> {
     private readonly _leftToRight = new ValidatedMap<Left, Right>();
     private readonly _rightToLeft = new ValidatedMap<Right, Left>();
 
+    constructor(initialContents?: Iterable<[Left, Right]> | ReadonlyArray<[Left, Right]>) {
+        this._leftToRight = initialContents ? new ValidatedMap<Left, Right>(initialContents) :  new ValidatedMap<Left, Right>();
+        const reversed = Array.from(this._leftToRight.entries()).map(e => <[Right, Left]>[e[1], e[0]]);
+        this._rightToLeft = new ValidatedMap<Right, Left>(reversed);
+    }
+
     public clear(): void {
         this._leftToRight.clear();
         this._rightToLeft.clear();

--- a/src/chrome/collections/validatedSet.ts
+++ b/src/chrome/collections/validatedSet.ts
@@ -3,6 +3,8 @@ import { breakWhileDebugging } from '../../validation';
 
 export interface IValidatedSet<K> extends Set<K> {
     addOrReplaceIfExists(key: K): this;
+    deleteIfExists(key: K): boolean;
+    toArray(): K[];
 }
 
 /** A set that throws exceptions instead of returning error codes. */
@@ -37,6 +39,10 @@ export class ValidatedSet<K> implements IValidatedSet<K> {
         }
 
         return true;
+    }
+
+    public deleteIfExists(key: K): boolean {
+        return this._wrappedSet.delete(key);
     }
 
     public forEach(callbackfn: (key: K, sameKeyAgain: K, set: Set<K>) => void, thisArg?: any): void {
@@ -79,5 +85,9 @@ export class ValidatedSet<K> implements IValidatedSet<K> {
 
     public toString(): string {
         return printSet('ValidatedSet', this);
+    }
+
+    public toArray(): K[] {
+        return Array.from(this);
     }
 }

--- a/src/chrome/internal/breakpoints/features/existingBPsForJustParsedScriptSetter.ts
+++ b/src/chrome/internal/breakpoints/features/existingBPsForJustParsedScriptSetter.ts
@@ -96,7 +96,8 @@ export class ExistingBPsForJustParsedScriptSetter {
         const bpRecepieResolved = bpRecipe.resolvedWithLoadedSource(sourceWhichMayHaveBPs);
         const runtimeLocationsWhichAlreadyHaveThisBPR = debuggeeBPRecipes.map(recipe => recipe.runtimeSourceLocation);
 
-        const bprInScripts = (await this._sourceToScriptMapper.mapBPRecipe(bpRecepieResolved)).filter(b => b.location.script === justParsedScript);
+        const manyBPRecipesInScripts = await this._sourceToScriptMapper.mapBPRecipe(bpRecepieResolved);
+        const bprInScripts = manyBPRecipesInScripts.filter(b => b.location.script === justParsedScript);
         await this.withLogging.setBPRsInScriptIfNeeded(bprInScripts, runtimeLocationsWhichAlreadyHaveThisBPR);
     }
 

--- a/src/chrome/internal/breakpoints/features/pauseScriptLoadsToSetBPs.ts
+++ b/src/chrome/internal/breakpoints/features/pauseScriptLoadsToSetBPs.ts
@@ -35,6 +35,11 @@ export class PausedWhileLoadingScriptToResolveBreakpoints extends BasePauseShoul
     }
 }
 
+export enum WhenWasEnabled {
+    JustEnabled,
+    AlreadyEnabled
+}
+
 /// TODO: Move this to a browser-shared package
 /**
  * Pause the scripts after they are parsed, so we have time to set all the breakpoint recipes for that script before resuming the execution,
@@ -61,9 +66,12 @@ export class PauseScriptLoadsToSetBPs implements IInstallableComponent {
         this._debuggeePausedHandler.registerActionProvider(paused => this.withLogging.onProvideActionForWhenPaused(paused));
     }
 
-    public async enableIfNeccesary(): Promise<void> {
+    public async enableIfNeccesary(): Promise<WhenWasEnabled> {
         if (this._isInstrumentationEnabled === false) {
             await this.startPausingOnScriptFirstStatement();
+            return WhenWasEnabled.JustEnabled;
+        } else {
+            return WhenWasEnabled.AlreadyEnabled;
         }
     }
 

--- a/src/chrome/internal/features/pauseActionsPriorities.ts
+++ b/src/chrome/internal/features/pauseActionsPriorities.ts
@@ -8,6 +8,7 @@ import { HitBreakpoint, NoRecognizedBreakpoints } from '../breakpoints/features/
 import { HitStillPendingBreakpoint, PausedWhileLoadingScriptToResolveBreakpoints } from '../breakpoints/features/pauseScriptLoadsToSetBPs';
 import { ExceptionWasThrown, PromiseWasRejected } from '../exceptions/pauseOnException';
 import { HitAndSatisfiedHitCountBreakpoint, HitCountBreakpointWhenConditionWasNotSatisfied } from '../breakpoints/features/hitCountBreakpointsSetter';
+import { FinishedStepping } from '../stepping/features/syncStepping';
 
 export type ActionToTakeWhenPausedClass = { new(...args: any[]): IActionToTakeWhenPaused };
 
@@ -19,6 +20,8 @@ const actionsFromHighestToLowestPriority: ActionToTakeWhenPausedClass[] = [
     HitStillPendingBreakpoint,
     ExceptionWasThrown,
     PromiseWasRejected,
+
+    FinishedStepping,
 
     PausedWhileLoadingScriptToResolveBreakpoints,
 

--- a/src/chrome/internal/features/skipFiles.ts
+++ b/src/chrome/internal/features/skipFiles.ts
@@ -116,7 +116,7 @@ export class SkipFilesLogic implements IStackTracePresentationDetailsProvider {
 
             const newStatus = !this.shouldSkipSource(resolvedSource);
             logger.log(`Setting the skip file status for: ${resolvedSource} to ${newStatus}`);
-            this._skipFileStatuses.set(resolvedSource.identifier, newStatus);
+            this._skipFileStatuses.setAndReplaceIfExist(resolvedSource.identifier, newStatus);
 
             if (newStatus) {
                 // TODO: Verify that using targetPath works here. We need targetPath to be this.getScriptByUrl(targetPath).url

--- a/src/chrome/internal/locations/mappedTokensInScript.ts
+++ b/src/chrome/internal/locations/mappedTokensInScript.ts
@@ -26,6 +26,10 @@ export class MappedTokensInScript implements IMappedTokensInScript {
         return new MappedTokensInScript(characterLocation.script, [Range.at(characterLocation.position)]);
     }
 
+    public static untilNextLine(characterLocation: LocationInScript): IMappedTokensInScript {
+        return new MappedTokensInScript(characterLocation.script, [Range.untilNextLine(characterLocation.position)]);
+    }
+
     public get enclosingRange(): RangeInScript {
         return new RangeInResource(this.script, Range.enclosingAll(this._ranges));
     }

--- a/src/chrome/internal/locations/rangeInScript.ts
+++ b/src/chrome/internal/locations/rangeInScript.ts
@@ -4,7 +4,7 @@
 
 import { Position, Location, ScriptOrSourceOrURLOrURLRegexp, createLocation, LocationInScript } from './location';
 import { IScript } from '../scripts/script';
-import { createColumnNumber } from './subtypes';
+import { createColumnNumber, createLineNumber, LineNumber } from './subtypes';
 
 export class Range {
     public constructor(
@@ -18,6 +18,10 @@ export class Range {
 
     public static at(position: Position): Range {
         return new Range(position, new Position(position.lineNumber, createColumnNumber(position.columnNumber + 1)));
+    }
+
+    public static untilNextLine(position: Position): Range {
+        return new Range(position, new Position(createLineNumber(position.lineNumber + 1), createColumnNumber(0)));
     }
 
     public static enclosingAll(manyRanges: Range[]) {
@@ -51,6 +55,15 @@ export class RangeInResource<TResource extends ScriptOrSourceOrURLOrURLRegexp> {
 
     public static characterAt(characterLocation: LocationInScript): RangeInResource<IScript> {
         return RangeInResource.fromPositions(characterLocation.script, characterLocation.position, characterLocation.position);
+    }
+
+    public static wholeLine(script: IScript, lineNumber: LineNumber): RangeInResource<IScript> {
+        const zeroColumnNumber = createColumnNumber(0);
+        const nextLineNumber = createLineNumber(lineNumber + 1);
+
+        return RangeInResource.fromPositions(script,
+            new Position(lineNumber, zeroColumnNumber),
+            new Position(nextLineNumber, zeroColumnNumber));
     }
 
     public get start(): Location<TResource> {

--- a/src/chrome/internal/sources/resourceIdentifier.ts
+++ b/src/chrome/internal/sources/resourceIdentifier.ts
@@ -96,6 +96,11 @@ export class LocalFileURL<TString extends string = string> extends IsEquivalentC
         return `file://${encodeURIComponent(this._localResourcePath.textRepresentation)}` as TString;
     }
 
+    public get filePathRepresentation(): string {
+        // TODO: Migrate to url.fileURLToPath after VS Code migrates to node v10.12
+        return this._localResourcePath.textRepresentation;
+    }
+
     public get canonicalized(): string {
         return this._localResourcePath.canonicalized;
     }
@@ -162,13 +167,21 @@ export class UnixLocalFilePath<TString extends string = string> extends LocalFil
 // A windows local file path
 // e.g.: C:\proj\myfile.js
 export class WindowLocalFilePath<TString extends string = string> extends LocalFilePathCommonLogic<TString> implements ILocalFilePath<TString> {
+    public constructor(textRepresentation: TString) {
+        super(WindowLocalFilePath.normalize(textRepresentation));
+    }
+
     public static isValid(path: string) {
         return path.match(/^[A-Za-z]:/);
     }
 
+    private static normalize<TString extends string>(textRepresentation: TString): TString {
+        const normalized = path.normalize(textRepresentation); // Remove ../s
+        return <TString>normalized.replace(/[\\\/]+/, '\\');
+    }
+
     protected generateCanonicalized(): string {
-        const normalized = path.normalize(this.textRepresentation); // Remove ../s
-        return normalized.toLowerCase().replace(/[\\\/]+/, '\\');
+        return this.textRepresentation.toLowerCase();
     }
 }
 

--- a/src/chrome/internal/stepping/features/syncStepping.ts
+++ b/src/chrome/internal/stepping/features/syncStepping.ts
@@ -3,30 +3,70 @@
  *--------------------------------------------------------*/
 
 import { ScriptCallFrame, CallFrameWithState } from '../../stackTraces/callFrame';
-import { IActionToTakeWhenPaused, NoActionIsNeededForThisPause } from '../../features/actionToTakeWhenPaused';
+import { IActionToTakeWhenPaused, NoActionIsNeededForThisPause, BaseNotifyClientOfPause } from '../../features/actionToTakeWhenPaused';
 import { injectable, inject } from 'inversify';
 import { IDebuggeeExecutionController } from '../../../cdtpDebuggee/features/cdtpDebugeeExecutionController';
 import { TYPES } from '../../../dependencyInjection.ts/types';
 import { PausedEvent } from '../../../cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider';
 import { IDebuggeeSteppingController } from '../../../cdtpDebuggee/features/cdtpDebugeeSteppingController';
 import { IDebuggeePausedHandler } from '../../features/debuggeePausedHandler';
+import { printClassDescription } from '../../../utils/printing';
+import { IEventsToClientReporter } from '../../../client/eventsToClientReporter';
 
 type SteppingAction = () => Promise<void>;
 
 interface SyncSteppingStatus {
-    startStepping(): SyncSteppingStatus;
+    startStepping(): void;
+
+    onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused>;
+}
+
+@printClassDescription
+export class FinishedStepping extends BaseNotifyClientOfPause {
+    protected readonly reason = 'step';
+
+    public constructor(
+        private readonly _changeStatus: (newStatus: SyncSteppingStatus) => void,
+        protected readonly _eventsToClientReporter: IEventsToClientReporter,
+    ) {
+        super();
+    }
+
+    public async execute(): Promise<void> {
+        this._changeStatus(new CurrentlyIdle(this._changeStatus, this._eventsToClientReporter));
+        await super.execute();
+    }
 }
 
 class CurrentlyStepping implements SyncSteppingStatus {
+    public constructor(
+        private readonly _changeStatus: (newStatus: SyncSteppingStatus) => void,
+        private readonly _eventsToClientReporter: IEventsToClientReporter) { }
+
     public startStepping(): SyncSteppingStatus {
         throw new Error('Cannot start stepping again while the program is already stepping');
     }
 
+    public async onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
+        if (paused.reason === 'other') {
+            return new FinishedStepping(this._changeStatus, this._eventsToClientReporter);
+        } else {
+            return new NoActionIsNeededForThisPause(this);
+        }
+    }
 }
 
 class CurrentlyIdle implements SyncSteppingStatus {
-    public startStepping(): SyncSteppingStatus {
-        return new CurrentlyStepping();
+    public constructor(
+        private readonly _changeStatus: (newStatus: SyncSteppingStatus) => void,
+        private readonly _eventsToClientReporter: IEventsToClientReporter) { }
+
+    public startStepping(): void {
+        this._changeStatus(new CurrentlyStepping(this._changeStatus, this._eventsToClientReporter));
+    }
+
+    public async onProvideActionForWhenPaused(_paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
+        return new NoActionIsNeededForThisPause(this);
     }
 }
 
@@ -35,17 +75,22 @@ class CurrentlyIdle implements SyncSteppingStatus {
  */
 @injectable()
 export class SyncStepping {
-    private _status: SyncSteppingStatus = new CurrentlyIdle();
+    private _status: SyncSteppingStatus = new CurrentlyIdle(this.changeStatus(), this._eventsToClientReporter);
 
     public stepOver = this.createSteppingMethod(() => this._debugeeStepping.stepOver());
     public stepInto = this.createSteppingMethod(() => this._debugeeStepping.stepInto({ breakOnAsyncCall: true }));
     public stepOut = this.createSteppingMethod(() => this._debugeeStepping.stepOut());
 
     constructor(
+        @inject(TYPES.IEventsToClientReporter) private readonly _eventsToClientReporter: IEventsToClientReporter,
         @inject(TYPES.IDebuggeeSteppingController) private readonly _debugeeStepping: IDebuggeeSteppingController,
         @inject(TYPES.IDebuggeePausedHandler) private readonly _debuggeePausedHandler: IDebuggeePausedHandler,
         @inject(TYPES.IDebuggeeExecutionController) private readonly _debugeeExecutionControl: IDebuggeeExecutionController) {
         this._debuggeePausedHandler.registerActionProvider(paused => this.onProvideActionForWhenPaused(paused));
+    }
+
+    private changeStatus(): (newStatus: SyncSteppingStatus) => void {
+        return (newStatus: SyncSteppingStatus) => this._status = newStatus;
     }
 
     public continue(): Promise<void> {
@@ -56,21 +101,20 @@ export class SyncStepping {
         return this._debugeeExecutionControl.pause();
     }
 
-    private async onProvideActionForWhenPaused(_paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
-        return new NoActionIsNeededForThisPause(this);
+    private async onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
+        return this._status.onProvideActionForWhenPaused(paused);
     }
 
     public async restartFrame(callFrame: ScriptCallFrame<CallFrameWithState>): Promise<void> {
-        this._status = this._status.startStepping();
+        this._status.startStepping();
         await this._debugeeStepping.restartFrame(callFrame);
         await this._debugeeStepping.stepInto({ breakOnAsyncCall: true });
     }
 
     private createSteppingMethod(steppingAction: SteppingAction): (() => Promise<void>) {
         return async () => {
-            this._status = this._status.startStepping();
+            this._status.startStepping();
             await steppingAction();
-            this._status = new CurrentlyIdle();
         };
     }
 }

--- a/src/typeUtils.ts
+++ b/src/typeUtils.ts
@@ -7,6 +7,7 @@
  */
 export type MakePropertyRequired<T, K extends keyof T> = T & { [P in K]-?: T[K] };
 export type RemoveProperty<T, K> = Pick<T, Exclude<keyof T, K>>;
+export type SpecializeProperty<T, K extends keyof T, S extends T[K]> = T & { [P in K]: S };
 
 export function isNotUndefined<T>(object: T | undefined): object is T {
     return object !== undefined;
@@ -15,3 +16,7 @@ export function isNotUndefined<T>(object: T | undefined): object is T {
 export interface Array<T> {
     filter<U extends T>(predicate: (element: T) => element is U): U[];
 }
+
+export type Replace<T, R extends keyof T, N> = {
+    [K in keyof T]: K extends R ? N : T[K];
+};


### PR DESCRIPTION
- Merge changes from core-v2 from v1
- Several fixes to make the int tests work:
1. chromeDebugSession.ts: Removed AvailableCommands to make illegal requests respond a failure
2. sourceToClientConverter.ts: Updated logic so stack traces would return file paths as file paths instead of file:/// urls
3. sourceToScriptMapper.ts: setting a breakpoint on the semi-colon on "x++;" was failing. This searches for a break point in the whole line to make that work
4. syncStepping.ts: After stepping-in the stopped reason was: "debugger_statement" instead of "step". This fixes it.
5. sourceMap.ts: Some of our tests had source mappings where the lines and source were null, and that was crashing that method
6. singleBreakpointSetter.ts: Fixed a race condition while enabling instrumentation for scripts