### PR TITLE
Fix issues to make int tests pass

### DIFF
--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpOnScriptParsedEventProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpOnScriptParsedEventProvider.ts
@@ -171,7 +171,7 @@ abstract class ScriptCreator {
     protected abstract registerRuntimeAndDevelopmentSourcesRelationships(script: IScript): Promise<void>;
 
     private mappedSources(sourceMapper: IMappedSourcesMapper): IdentifiedLoadedSource[] {
-        return sourceMapper.sources.map((path: string) => this.obtainLoadedSource(parseResourceIdentifier(path), SourceScriptRelationship.Unknown));
+        return sourceMapper.sources.map(path => this.obtainLoadedSource(path, SourceScriptRelationship.Unknown));
     }
 
     private sourceMapper(script: IScript, sourceMap: SourceMap | null): IMappedSourcesMapper {

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -53,7 +53,6 @@ import { ConnectedCDAConfiguration } from './client/chromeDebugAdapter/cdaConfig
 import { CDTPScriptsRegistry } from './cdtpDebuggee/registries/cdtpScriptsRegistry';
 import { EventsToClientReporter } from './client/eventsToClientReporter';
 import { validateNonPrimitiveRemoteObject, CDTPNonPrimitiveRemoteObject, CDTPRemoteObjectOfTypeObject, validateCDTPRemoteObjectOfTypeObject } from './cdtpDebuggee/cdtpPrimitives';
-import { waitForEnd } from './utils/promises';
 
 let localize = nls.loadMessageBundle();
 
@@ -688,7 +687,7 @@ export class ChromeDebugLogic {
 
     private async waitThenDoEvaluate(expression: string, frame?: LoadedSourceCallFrame<CallFrameWithState>, extraArgs?: Partial<CDTP.Runtime.EvaluateRequest>): Promise<CDTP.Debugger.EvaluateOnCallFrameResponse | CDTP.Runtime.EvaluateResponse> {
         const waitThenEval = this._waitAfterStep.then(() => this.doEvaluate(expression, frame, extraArgs));
-        this._waitAfterStep = waitForEnd(waitThenEval);
+        this._waitAfterStep = waitThenEval.then(() => { }, () => { }); // to Promise<void> and handle failed evals
         return waitThenEval;
     }
 

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -53,6 +53,7 @@ import { ConnectedCDAConfiguration } from './client/chromeDebugAdapter/cdaConfig
 import { CDTPScriptsRegistry } from './cdtpDebuggee/registries/cdtpScriptsRegistry';
 import { EventsToClientReporter } from './client/eventsToClientReporter';
 import { validateNonPrimitiveRemoteObject, CDTPNonPrimitiveRemoteObject, CDTPRemoteObjectOfTypeObject, validateCDTPRemoteObjectOfTypeObject } from './cdtpDebuggee/cdtpPrimitives';
+import { waitForEnd } from './utils/promises';
 
 let localize = nls.loadMessageBundle();
 
@@ -687,7 +688,7 @@ export class ChromeDebugLogic {
 
     private async waitThenDoEvaluate(expression: string, frame?: LoadedSourceCallFrame<CallFrameWithState>, extraArgs?: Partial<CDTP.Runtime.EvaluateRequest>): Promise<CDTP.Debugger.EvaluateOnCallFrameResponse | CDTP.Runtime.EvaluateResponse> {
         const waitThenEval = this._waitAfterStep.then(() => this.doEvaluate(expression, frame, extraArgs));
-        this._waitAfterStep = waitThenEval.then(() => { }, () => { }); // to Promise<void> and handle failed evals
+        this._waitAfterStep = waitForEnd(waitThenEval);
         return waitThenEval;
     }
 

--- a/src/chrome/client/chromeDebugAdapter/chromeDebugAdapterV2.ts
+++ b/src/chrome/client/chromeDebugAdapter/chromeDebugAdapterV2.ts
@@ -10,7 +10,7 @@ import { CommandText } from '../requests';
 import { createDIContainer } from './cdaDIContainerCreator';
 import { TYPES } from '../../dependencyInjection.ts/types';
 import { TerminatingCDA } from './terminatingCDA';
-import { logger } from '../../..';
+import { logger } from 'vscode-debugadapter';
 
 export class ChromeDebugAdapter implements IDebugAdapter, IObservableEvents<IStepStartedEventsEmitter & IFinishedStartingUpEventsEmitter>{
     public readonly events = new StepProgressEventsEmitter();

--- a/src/chrome/collections/mapUsingProjection.ts
+++ b/src/chrome/collections/mapUsingProjection.ts
@@ -8,6 +8,10 @@ import { printMap } from './printing';
 
 class KeyAndValue<K, V> {
     constructor(public readonly key: K, public readonly value: V) { }
+
+    public toString(): string {
+        return `${this.key}: ${this.value}`;
+    }
 }
 
 /** A map which uses a projection of the key to compare it's elements (This is equivalent to define a custom comparison criteria in other languages) */

--- a/src/chrome/internal/breakpoints/features/hitCountBreakpointsSetter.ts
+++ b/src/chrome/internal/breakpoints/features/hitCountBreakpointsSetter.ts
@@ -20,6 +20,7 @@ import { Listeners } from '../../../communication/listeners';
 import { OnPausedForBreakpointCallback } from './bpRecipeAtLoadedSourceLogic';
 import { BPRecipeStatusChanged } from '../registries/bpRecipeStatusCalculator';
 import { LocationInLoadedSource } from '../../locations/location';
+import { logger } from 'vscode-debugadapter';
 
 @printClassDescription
 export class HitAndSatisfiedHitCountBreakpoint extends BaseNotifyClientOfPause {
@@ -49,11 +50,14 @@ class HitCountBreakpointData {
     }
 
     public shouldPauseForBreakpoint(): boolean {
-        return this._shouldPauseCondition(++this._currentHitCount);
+        ++this._currentHitCount;
+        const shouldPause = this._shouldPauseCondition(this._currentHitCount);
+        logger.log(`Evaluating hit count breakpoint: ${this.hitCountBPRecipe}. Hit count: ${this._currentHitCount}. Should pause: ${shouldPause}`);
+        return shouldPause;
     }
 
     public toString(): string {
-        return `Pause when: ${this._shouldPauseCondition}, current: hits ${this._currentHitCount}`;
+        return `Pause when: ${this.hitCountBPRecipe.bpActionWhenHit.pauseOnHitCondition}, current: hits ${this._currentHitCount}`;
     }
 }
 

--- a/src/chrome/internal/breakpoints/features/setBreakpointsRequestHandler.ts
+++ b/src/chrome/internal/breakpoints/features/setBreakpointsRequestHandler.ts
@@ -19,11 +19,10 @@ import { SourceResolver } from '../../sources/sourceResolver';
 import { logger } from 'vscode-debugadapter';
 import { IEventsToClientReporter } from '../../../client/eventsToClientReporter';
 import { BPRecipeStatusChanged } from '../registries/bpRecipeStatusCalculator';
-import { waitForEnd } from '../../../utils/promises';
 
 @injectable()
 export class SetBreakpointsRequestHandler implements ICommandHandlerDeclarer {
-    private _onFlightRequests = Promise.resolve();
+    private _onFlightRequests = Promise.resolve<unknown>(null);
 
     private readonly _clientSourceParser = new ClientSourceParser(this._handlesRegistry, this._sourcesResolver);
     private readonly _bpRecipieStatusToClientConverter = new BPRecipieStatusToClientConverter(this._handlesRegistry, this._lineColTransformer);
@@ -103,13 +102,14 @@ export class SetBreakpointsRequestHandler implements ICommandHandlerDeclarer {
         return CommandHandlerDeclaration.fromLiteralObject({
             setBreakpoints: args => {
                 const response = this.setBreakpoints(args);
+                const waitForResponseIgnoringFailures = response.then(() => {}, () => {});
                 /**
                  * The breakpoints gets assigned at the end of the setBreakpoints request
                  * We need to prevent BPStatusChanged from being sent while we are processing a setBreakpoints request event, because they might
                  * try to reference a breakpoint for which the client doesn't yet have an id
                  */
-                this._onFlightRequests = waitForEnd(this._onFlightRequests, response);
-                return response;
+                this._onFlightRequests = Promise.all([this._onFlightRequests, waitForResponseIgnoringFailures]); // onFlightRequests ignores failures on requests
+                return response; // The setBreakpoints failures will ve handled by our caller
             }
         });
     }
@@ -121,7 +121,9 @@ export class SetBreakpointsRequestHandler implements ICommandHandlerDeclarer {
          * try to reference a breakpoint for which the client doesn't yet have an id
          */
         logger.log(`Waiting for set breakpoints on flight requests`);
-        // tslint:disable-next-line: no-floating-promises
-        this._onFlightRequests.then(() => this._eventsToClientReporter.sendBPStatusChanged({ reason: 'changed', bpRecipeStatus: statusChanged.status }));
+
+        this._onFlightRequests.then(() => this._eventsToClientReporter.sendBPStatusChanged({ reason: 'changed', bpRecipeStatus: statusChanged.status }), rejection => {
+            logger.error(`Failed to send a breakpoint status update: ${rejection}`);
+        });
     }
 }

--- a/src/chrome/internal/breakpoints/features/setBreakpointsRequestHandler.ts
+++ b/src/chrome/internal/breakpoints/features/setBreakpointsRequestHandler.ts
@@ -16,9 +16,15 @@ import { HandlesRegistry } from '../../../client/handlesRegistry';
 import { LineColTransformer } from '../../../../transformers/lineNumberTransformer';
 import { createLineNumber, createColumnNumber } from '../../locations/subtypes';
 import { SourceResolver } from '../../sources/sourceResolver';
+import { logger } from 'vscode-debugadapter';
+import { IEventsToClientReporter } from '../../../client/eventsToClientReporter';
+import { BPRecipeStatusChanged } from '../registries/bpRecipeStatusCalculator';
+import { waitForEnd } from '../../../utils/promises';
 
 @injectable()
 export class SetBreakpointsRequestHandler implements ICommandHandlerDeclarer {
+    private _onFlightRequests = Promise.resolve();
+
     private readonly _clientSourceParser = new ClientSourceParser(this._handlesRegistry, this._sourcesResolver);
     private readonly _bpRecipieStatusToClientConverter = new BPRecipieStatusToClientConverter(this._handlesRegistry, this._lineColTransformer);
 
@@ -26,7 +32,10 @@ export class SetBreakpointsRequestHandler implements ICommandHandlerDeclarer {
         @inject(TYPES.IBreakpointsUpdater) protected readonly _breakpointsLogic: BreakpointsUpdater,
         private readonly _handlesRegistry: HandlesRegistry,
         @inject(TYPES.LineColTransformer) private readonly _lineColTransformer: LineColTransformer,
-        private readonly _sourcesResolver: SourceResolver) { }
+        @inject(TYPES.IEventsToClientReporter) private readonly _eventsToClientReporter: IEventsToClientReporter,
+        private readonly _sourcesResolver: SourceResolver) {
+        this._breakpointsLogic.bpRecipeStatusChangedListeners.add(status => this.onBPRecipeStatusChanged(status));
+    }
 
     public async setBreakpoints(args: DebugProtocol.SetBreakpointsArguments, telemetryPropertyCollector?: ITelemetryPropertyCollector): Promise<ISetBreakpointsResponseBody> {
         if (args.breakpoints) {
@@ -92,7 +101,27 @@ export class SetBreakpointsRequestHandler implements ICommandHandlerDeclarer {
     public async getCommandHandlerDeclarations(): Promise<ICommandHandlerDeclaration[]> {
         await this._breakpointsLogic.install();
         return CommandHandlerDeclaration.fromLiteralObject({
-            setBreakpoints: args => this.setBreakpoints(args)
+            setBreakpoints: args => {
+                const response = this.setBreakpoints(args);
+                /**
+                 * The breakpoints gets assigned at the end of the setBreakpoints request
+                 * We need to prevent BPStatusChanged from being sent while we are processing a setBreakpoints request event, because they might
+                 * try to reference a breakpoint for which the client doesn't yet have an id
+                 */
+                this._onFlightRequests = waitForEnd(this._onFlightRequests, response);
+                return response;
+            }
         });
+    }
+
+    protected async onBPRecipeStatusChanged(statusChanged: BPRecipeStatusChanged): Promise<void> {
+        /**
+         * The breakpoints gets assigned at the end of the setBreakpoints request
+         * We need to prevent BPStatusChanged from being sent while we are processing a setBreakpoints request event, because they might
+         * try to reference a breakpoint for which the client doesn't yet have an id
+         */
+        logger.log(`Waiting for set breakpoints on flight requests`);
+        // tslint:disable-next-line: no-floating-promises
+        this._onFlightRequests.then(() => this._eventsToClientReporter.sendBPStatusChanged({ reason: 'changed', bpRecipeStatus: statusChanged.status }));
     }
 }

--- a/src/chrome/internal/features/pauseActionsPriorities.ts
+++ b/src/chrome/internal/features/pauseActionsPriorities.ts
@@ -8,12 +8,14 @@ import { HitBreakpoint, NoRecognizedBreakpoints } from '../breakpoints/features/
 import { HitStillPendingBreakpoint, PausedWhileLoadingScriptToResolveBreakpoints } from '../breakpoints/features/pauseScriptLoadsToSetBPs';
 import { ExceptionWasThrown, PromiseWasRejected } from '../exceptions/pauseOnException';
 import { HitAndSatisfiedHitCountBreakpoint, HitCountBreakpointWhenConditionWasNotSatisfied } from '../breakpoints/features/hitCountBreakpointsSetter';
-import { FinishedStepping } from '../stepping/features/syncStepping';
+import { FinishedStepping, UserPaused } from '../stepping/features/syncStepping';
 
 export type ActionToTakeWhenPausedClass = { new(...args: any[]): IActionToTakeWhenPaused };
 
 const actionsFromHighestToLowestPriority: ActionToTakeWhenPausedClass[] = [
-    ShouldStepInToAvoidSkippedSource, // Stepping in to avoid a skipper source takes preference over hitting breakpoints, etc...
+    ShouldStepInToAvoidSkippedSource, // Stepping in to avoid a skipped source takes preference over hitting breakpoints, even user pausing, etc...
+
+    UserPaused, // The user requesting to pause takes preferences over everything else
 
     HitAndSatisfiedHitCountBreakpoint,
     HitBreakpoint,

--- a/src/chrome/internal/locations/mappedTokensInScript.ts
+++ b/src/chrome/internal/locations/mappedTokensInScript.ts
@@ -1,7 +1,7 @@
 import { RangeInScript, RangeInResource, Range } from './rangeInScript';
-import { IScript } from '../../..';
 import { LocationInScript } from './location';
 import { printArray } from '../../collections/printing';
+import { IScript } from '../scripts/script';
 
 export interface IMappedTokensInScript {
     readonly script: IScript;

--- a/src/chrome/internal/scripts/sourcesMapper.ts
+++ b/src/chrome/internal/scripts/sourcesMapper.ts
@@ -6,7 +6,7 @@ import { createColumnNumber, createLineNumber } from '../locations/subtypes';
 import { SourceMap } from '../../../sourceMaps/sourceMap';
 import { LocationInLoadedSource, LocationInScript, Position } from '../locations/location';
 import { ILoadedSource } from '../sources/loadedSource';
-import { IResourceIdentifier, parseResourceIdentifier } from '../sources/resourceIdentifier';
+import { IResourceIdentifier } from '../sources/resourceIdentifier';
 import { IScript } from './script';
 import { IValidatedMap } from '../../collections/validatedMap';
 import { logger } from 'vscode-debugadapter';
@@ -24,7 +24,7 @@ export interface IScriptToSourceMapper {
 export interface ISourceMapper extends ISourceToScriptMapper, IScriptToSourceMapper { }
 
 export interface IMappedSourcesMapper extends ISourceMapper {
-    readonly sources: string[];
+    readonly sources: IResourceIdentifier[];
 }
 
 /** This class maps locations from a script into the sources form which it was compiled, and back. */
@@ -44,19 +44,19 @@ export class MappedSourcesMapper implements IMappedSourcesMapper {
         // The columns on the first line need to be adjusted. Columns on all other lines don't need any adjustment.
         const columnNumberRelativeToScript = (lineNumberRelativeToScript === 0 ? scriptPositionInResource.columnNumber : 0) + (positionInScript.position.columnNumber || 0);
 
-        const mappedPosition = this._sourceMap.authoredPositionFor(lineNumberRelativeToScript, columnNumberRelativeToScript);
-
-        if (mappedPosition && mappedPosition.source && mappedPosition.line !== null && mappedPosition.column !== null) {
-            const position = new Position(createLineNumber(mappedPosition.line), createColumnNumber(mappedPosition.column));
-            const mappedResult = new LocationInLoadedSource(positionInScript.script.getSource(parseResourceIdentifier(mappedPosition.source)), position);
-            logger.log(`SourceMapper: ${positionInScript} mapped to source: ${mappedResult}`);
-            return mappedResult;
-        } else {
-            // If we couldn't map it, return the location in the development source
-            const mappedResult = new LocationInLoadedSource(positionInScript.script.developmentSource, positionInScript.position);
-            logger.log(`SourceMapper: ${positionInScript} couldn't be mapped to source so we'll return the development location: ${mappedResult}`);
-            return mappedResult;
-        }
+        return this._sourceMap.authoredPosition(lineNumberRelativeToScript, columnNumberRelativeToScript,
+            mappedPosition => {
+                const position = new Position(createLineNumber(mappedPosition.line), createColumnNumber(mappedPosition.column));
+                const mappedResult = new LocationInLoadedSource(positionInScript.script.getSource(mappedPosition.source), position);
+                logger.log(`SourceMapper: ${positionInScript} mapped to source: ${mappedResult}`);
+                return mappedResult;
+            },
+            () => {
+                // If we couldn't map it, return the location in the development source
+                const mappedResult = new LocationInLoadedSource(positionInScript.script.developmentSource, positionInScript.position);
+                logger.log(`SourceMapper: ${positionInScript} couldn't be mapped to source so we'll return the development location: ${mappedResult}`);
+                return mappedResult;
+            });
     }
 
     public getPositionInScript(positionInSource: LocationInLoadedSource): IMappedTokensInScript {
@@ -69,8 +69,9 @@ export class MappedSourcesMapper implements IMappedSourcesMapper {
             return new NoMappedTokensInScript(this._script);
         }
 
-        const manyMappedPositionRelativeToScript = this._sourceMap.allGeneratedPositionFor(positionInSource.source.identifier.textRepresentation,
+        const manyMappedPositionRelativeToScript = this._sourceMap.allGeneratedPositionFor(positionInSource.source.identifier,
             positionInSource.position.lineNumber, positionInSource.position.columnNumber);
+        logger.log(`SourceMapperDebugger: For ${positionInSource} we got: ${JSON.stringify(manyMappedPositionRelativeToScript)}`);
 
         const results = manyMappedPositionRelativeToScript.map(mappedPositionRelativeToScript => {
             const scriptPositionInResource = this._script.rangeInSource.start.position;
@@ -121,8 +122,8 @@ export class MappedSourcesMapper implements IMappedSourcesMapper {
         return new MappedTokensInScript(this._script, results);
     }
 
-    public get sources(): string[] {
-        return this._sourceMap.authoredSources || [];
+    public get sources(): IResourceIdentifier[] {
+        return this._sourceMap.mappedSources;
     }
 
     public toString(): string {
@@ -147,7 +148,7 @@ export class NoMappedSourcesMapper implements IMappedSourcesMapper {
         }
     }
 
-    public get sources(): string[] {
+    public get sources(): IResourceIdentifier[] {
         return [];
     }
 

--- a/src/chrome/internal/sources/resourceIdentifier.ts
+++ b/src/chrome/internal/sources/resourceIdentifier.ts
@@ -7,6 +7,7 @@ import { IValidatedMap } from '../../collections/validatedMap';
 import { MapUsingProjection } from '../../collections/mapUsingProjection';
 import { IEquivalenceComparable } from '../../utils/equivalence';
 import * as utils from '../../../utils';
+import { SetUsingProjection } from '../../collections/setUsingProjection';
 
 /**
  * Hierarchy:
@@ -249,4 +250,9 @@ export function newResourceIdentifierMap<V, TString extends string = string>(
     initialContents: Map<IResourceIdentifier<TString>, V> | Iterable<[IResourceIdentifier<TString>, V]>
         | ReadonlyArray<[IResourceIdentifier<TString>, V]> = []): IValidatedMap<IResourceIdentifier<TString>, V> {
     return new MapUsingProjection<IResourceIdentifier<TString>, V, string>(path => path.canonicalized, initialContents);
+}
+
+export function newResourceIdentifierSet<TString extends string = string>(
+    initialContents: IResourceIdentifier<TString>[] = []): SetUsingProjection<IResourceIdentifier<TString>, string> {
+    return new SetUsingProjection<IResourceIdentifier<TString>, string>(path => path.canonicalized, initialContents);
 }

--- a/src/chrome/utils/promises.ts
+++ b/src/chrome/utils/promises.ts
@@ -1,5 +1,22 @@
+import { asyncMap } from '../collections/async';
+
 /*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
 export type PromiseOrNot<T> = Promise<T> | T;
+
+/**
+ * Wait until the promise gets either resolved or rejected. If the promise gets rejected, waitForEnd will ignore that rejection and succeed anyways.
+ */
+export async function waitForEnd(...manyPromisesToWaitFor: Promise<unknown>[]): Promise<void> {
+    await asyncMap(manyPromisesToWaitFor, waitForSinglePromiseToEnd);
+}
+
+async function waitForSinglePromiseToEnd(promiseToWaitFor: Promise<unknown>): Promise<void> {
+    try {
+        await promiseToWaitFor;
+    } catch {
+        // Ignore failures
+    }
+}

--- a/src/chrome/utils/promises.ts
+++ b/src/chrome/utils/promises.ts
@@ -1,22 +1,5 @@
-import { asyncMap } from '../collections/async';
-
 /*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
 export type PromiseOrNot<T> = Promise<T> | T;
-
-/**
- * Wait until the promise gets either resolved or rejected. If the promise gets rejected, waitForEnd will ignore that rejection and succeed anyways.
- */
-export async function waitForEnd(...manyPromisesToWaitFor: Promise<unknown>[]): Promise<void> {
-    await asyncMap(manyPromisesToWaitFor, waitForSinglePromiseToEnd);
-}
-
-async function waitForSinglePromiseToEnd(promiseToWaitFor: Promise<unknown>): Promise<void> {
-    try {
-        await promiseToWaitFor;
-    } catch {
-        // Ignore failures
-    }
-}

--- a/src/sourceMaps/sourceMapFactory.ts
+++ b/src/sourceMaps/sourceMapFactory.ts
@@ -48,7 +48,7 @@ export class SourceMapFactory {
             if (contents) {
                 try {
                     // Throws for invalid JSON
-                    return await new SourceMap(pathToGenerated, contents, this._pathMapping, this._sourceMapPathOverrides, isVSClient).init();
+                    return await SourceMap.create(pathToGenerated, contents, this._pathMapping, this._sourceMapPathOverrides, isVSClient);
                 } catch (e) {
                     logger.error(`SourceMaps.getMapForGeneratedPath: exception while processing path: ${pathToGenerated}, sourcemap: ${mapPath}\n${e.stack}`);
                     return null;

--- a/src/sourceMaps/sourceMapUtils.ts
+++ b/src/sourceMaps/sourceMapUtils.ts
@@ -9,6 +9,8 @@ import { logger } from 'vscode-debugadapter';
 import * as chromeUtils from '../chrome/chromeUtils';
 import * as utils from '../utils';
 import { ISourceMapPathOverrides, IPathMapping } from '../debugAdapterInterfaces';
+import { IResourceIdentifier } from '..';
+import { parseResourceIdentifier } from '../chrome/internal/sources/resourceIdentifier';
 
 /**
  * Resolves a relative path in terms of another file
@@ -20,7 +22,7 @@ export function resolveRelativeToFile(absPath: string, relPath: string): string 
 /**
  * Determine an absolute path for the sourceRoot.
  */
-export function getComputedSourceRoot(sourceRoot: string, generatedPath: string, pathMapping: IPathMapping = {}): string {
+export function getComputedSourceRoot(sourceRoot: string | undefined, generatedPath: string, pathMapping: IPathMapping = {}): string {
     let absSourceRoot: string;
     if (sourceRoot) {
         if (sourceRoot.startsWith('file:///')) {
@@ -155,14 +157,14 @@ export function resolveMapPath(pathToGenerated: string, mapPath: string, pathMap
     return mapPath;
 }
 
-export function getFullSourceEntry(sourceRoot: string | undefined, sourcePath: string): string {
+export function getFullSourceEntry(sourceRoot: string | undefined, sourcePath: string): IResourceIdentifier {
     if (!sourceRoot) {
-        return sourcePath;
+        return parseResourceIdentifier(sourcePath);
     }
 
     if (!sourceRoot.endsWith('/')) {
         sourceRoot += '/';
     }
 
-    return sourceRoot + sourcePath;
+    return parseResourceIdentifier(sourceRoot + sourcePath);
 }

--- a/src/transformers/baseSourceMapTransformer.ts
+++ b/src/transformers/baseSourceMapTransformer.ts
@@ -5,7 +5,7 @@
 import { DebugProtocol } from 'vscode-debugprotocol';
 
 import { ILaunchRequestArgs, IAttachRequestArgs, IScopesResponseBody } from '../debugAdapterInterfaces';
-import { ISourcePathDetails, SourceMap } from '../sourceMaps/sourceMap';
+import { ISourcePathDetails, SourceMap, IAuthoredPosition } from '../sourceMaps/sourceMap';
 import { SourceMaps } from '../sourceMaps/sourceMaps';
 import { logger } from 'vscode-debugadapter';
 
@@ -13,7 +13,7 @@ import { ILoadedSource } from '../chrome/internal/sources/loadedSource';
 import { TYPES } from '../chrome/dependencyInjection.ts/types';
 import { inject, injectable } from 'inversify';
 import { IConnectedCDAConfiguration } from '../chrome/client/chromeDebugAdapter/cdaConfiguration';
-import { NullableMappedPosition } from 'source-map';
+import { IResourceIdentifier } from '..';
 
 export interface ISourceLocation {
     source: ILoadedSource;
@@ -126,14 +126,14 @@ export class BaseSourceMapTransformer {
         }
     }
 
-    public async mapToAuthored(pathToGenerated: string, line: number, column: number): Promise<NullableMappedPosition | null> {
+    public async mapToAuthored(pathToGenerated: string, line: number, column: number): Promise<IAuthoredPosition | null> {
         if (!this._sourceMaps) return null;
 
         await this.wait();
         return this._sourceMaps.mapToAuthored(pathToGenerated, line, column);
     }
 
-    public async allSources(pathToGenerated: string): Promise<string[]> {
+    public async allSources(pathToGenerated: string): Promise<IResourceIdentifier[]> {
         if (!this._sourceMaps) return [];
 
         await this.wait();


### PR DESCRIPTION
- breakpointsUpdater.ts: Move the breakpoint update logic to setBreakpointsRequestHandler.ts to synchronize the updates with the setBreakpoints request, and prevent a race condition (We shouldn't attempt to send a breakpoint update for a breakpoint before that breakpoint appears on the response of setBreakpoints, and the client knows the id).

- hitCountBreakpointsSetter.ts: Added more logging

- setBreakpointsRequestHandler.ts: Synchronize the breakpoints update, so they'll wait for the setBreakpoints requests that are on flight to finish before sending the update. If we don't do this, we can try to send an update for a breakpoint that hasn't been assigned an id yet, and the this._eventsToClientReporter.sendBPStatusChanged method will fail.

- singleBreakpointSetter.ts: Instead of enabling the DOM Instrumentation for Scripts when we get the first breakpoint, we enable it always at the start, to address race conditions that can happen if we are processing a ScriptParsed event while we enable the DOM Instrumentation for Scripts.

- sourcesMapper.ts: Added more logging, and updated in response to the changes in sourceMap.ts to use Position and IResourceIdentifier instead of strings.

- syncStepping.ts: Created UserPaused and CurrentlyPausing to force the debugger to pause after we send the Pause request, even if the message is a DOM Instrumentation pause (Without this change we would auto-resume if we got a DOM Instrumentation pause after reciving a pause request from the user).

- sourceMap.ts:
	1. Moved the ISourcePathDetails logic into it's own class: SourcePathMappingCalculator.
	2. Updated the class to use ResourceIdentifiers, and to always normalize the sources strings with .canonicalized (The tests were failing because the string we looked up was normalized differently than the one we stored on the map).
	3. Updated authoredPosition, generatedPositionFor, and allGeneratedPositionsForBothDirections to provide a more strict error checking, and to look for mappings in both directions if needed
