### PR TITLE
Fix stack frame formatting when no source is in the frame (fix for previous fix in PR #426)

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -2082,7 +2082,8 @@ export abstract class ChromeDebugAdapter implements IDebugAdapter {
 
     private formatStackFrameName(frame: DebugProtocol.StackFrame, formatArgs?: DebugProtocol.StackFrameFormat): string {
         let formattedName = frame.name;
-        if (formatArgs) {
+
+        if (frame.source && formatArgs) {
             if (formatArgs.module) {
                 formattedName += ` [${frame.source.name}]`;
             }


### PR DESCRIPTION
When there is no source in the stack frame, (e.g. when the presentationHint is 'label') formatting was broken. This bug was introduced in #426 

This time I wrote some integration tests to make sure this doesn't regress again, see Microsoft/vscode-chrome-debug#822