### PR TITLE
Refactor getPositionInScript and getPositionInSource to make the code and the names easier to understand

### DIFF
--- a/src/chrome/extensibility/extensibilityPoints.ts
+++ b/src/chrome/extensibility/extensibilityPoints.ts
@@ -5,7 +5,6 @@
 import { Protocol as CDTP } from 'devtools-protocol';
 import { ChromeConnection, ITargetFilter } from '../chromeConnection';
 import { BasePathTransformer } from '../../transformers/basePathTransformer';
-import { BaseSourceMapTransformer } from '../../transformers/baseSourceMapTransformer';
 import { LineColTransformer } from '../../transformers/lineNumberTransformer';
 import { ILaunchRequestArgs, IAttachRequestArgs } from '../../debugAdapterInterfaces';
 import { interfaces } from 'inversify';
@@ -28,7 +27,6 @@ export interface IExtensibilityPoints {
 
     chromeConnection: typeof ChromeConnection;
     pathTransformer?: { new(configuration: IConnectedCDAConfiguration): BasePathTransformer };
-    sourceMapTransformer?: { new(configuration: IConnectedCDAConfiguration): BaseSourceMapTransformer };
     lineColTransformer?: { new(configuration: IConnectedCDAConfiguration): LineColTransformer };
 
     bindAdditionalComponents(diContainer: DependencyInjection): void;
@@ -44,7 +42,6 @@ export class OnlyProvideCustomLauncherExtensibilityPoints implements IExtensibil
     targetFilter?: ITargetFilter;
     chromeConnection: typeof ChromeConnection = ChromeConnection;
     pathTransformer?: new (configuration: IConnectedCDAConfiguration) => BasePathTransformer;
-    sourceMapTransformer?: new (configuration: IConnectedCDAConfiguration) => BaseSourceMapTransformer;
     lineColTransformer?: new (configuration: IConnectedCDAConfiguration) => LineColTransformer;
 
     constructor(

--- a/src/chrome/internal/locations/rangeInScript.ts
+++ b/src/chrome/internal/locations/rangeInScript.ts
@@ -4,7 +4,7 @@
 
 import { Position, Location, ScriptOrSourceOrURLOrURLRegexp, createLocation, LocationInScript } from './location';
 import { IScript } from '../scripts/script';
-import { createColumnNumber, createLineNumber, LineNumber } from './subtypes';
+import { createColumnNumber, createLineNumber, LineNumber, ColumnNumber } from './subtypes';
 
 export class Range {
     public constructor(
@@ -22,6 +22,14 @@ export class Range {
 
     public static untilNextLine(position: Position): Range {
         return new Range(position, new Position(createLineNumber(position.lineNumber + 1), createColumnNumber(0)));
+    }
+
+    public static acrossSingleLine(lineNumber: LineNumber, startingColumnNumber: ColumnNumber, endingExclusiveColumnNumber: ColumnNumber): Range {
+        const exclusiveEnd = endingExclusiveColumnNumber === Infinity
+            // If the column end is infinity, we assume that means that the range includes the whole line, so the exclusive end is the start of the next line
+            ? new Position(createLineNumber(lineNumber + 1), createColumnNumber(0))
+            : new Position(lineNumber, endingExclusiveColumnNumber);
+        return new Range(new Position(lineNumber, startingColumnNumber), exclusiveEnd);
     }
 
     public static enclosingAll(manyRanges: Range[]) {

--- a/src/chrome/internal/scripts/executionContext.ts
+++ b/src/chrome/internal/scripts/executionContext.ts
@@ -1,8 +1,8 @@
-import { FrameId } from '../../cdtpDebuggee/cdtpPrimitives';
-
 /*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
+
+import { FrameId } from '../../cdtpDebuggee/cdtpPrimitives';
 
 /**
  * This interface represents the execution context in CDTP where a script is executed. A new context is created when a page is refreshed, etc...

--- a/src/chrome/internal/scripts/htmlToScriptPositionTranslator.ts
+++ b/src/chrome/internal/scripts/htmlToScriptPositionTranslator.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { createLineNumber, createColumnNumber } from '../locations/subtypes';
+import { Position, LocationInScript } from '../locations/location';
+
+export class HtmlToScriptPositionTranslator {
+    public toPositionRelativeToScript(positionOfScriptTagInHtml: Position, positionRelativeToHtml: LocationInScript): LocationInScript {
+        // All the lines need to be adjusted by the relative position of the script in the resource (in an .html if the script starts in line 20, the first line is 20 rather than 0)
+        const lineRelativeToScript = positionRelativeToHtml.position.lineNumber - positionOfScriptTagInHtml.lineNumber;
+
+        // The columns on the first line need to be adjusted. Columns on all other lines don't need any adjustment.
+        const columnRelativeToScript = (lineRelativeToScript === 0 ? positionOfScriptTagInHtml.columnNumber : 0)
+            + positionRelativeToHtml.position.columnNumber;
+
+        return new LocationInScript(positionRelativeToHtml.script,
+            new Position(createLineNumber(lineRelativeToScript), createColumnNumber(columnRelativeToScript)));
+    }
+}

--- a/src/chrome/internal/scripts/scriptToHtmlPositionTranslator.ts
+++ b/src/chrome/internal/scripts/scriptToHtmlPositionTranslator.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Position } from '../locations/location';
+import { createLineNumber, createColumnNumber } from '../locations/subtypes';
+import { Range } from '../locations/rangeInScript';
+
+export class ScriptToHtmlPositionTranslator {
+    public toPositionRelativeToHtml(positionOfScriptTagInHtml: Position, positionRelativeToScript: Position): Position {
+        // All the lines need to be adjusted by the relative position of the script in the resource (in an .Html if the script starts in line 20, the first line is 20 rather than 0)
+        const lineRelativeToHtml = createLineNumber(positionRelativeToScript.lineNumber + positionOfScriptTagInHtml.lineNumber);
+
+        // The columns on the first line relative to the script need to be adjusted. Columns on all other lines don't need any adjustment.
+        const columnRelativeToHtml = createColumnNumber(
+            (positionRelativeToScript.lineNumber === 0 ? positionOfScriptTagInHtml.columnNumber : 0)
+            + positionRelativeToScript.columnNumber);
+
+        return new Position(lineRelativeToHtml, columnRelativeToHtml);
+    }
+
+    public toRangeRelativeToHtml(positionOfScriptInHtml: Position, rangeRelativeToScript: Range): Range {
+        return new Range(
+            this.toPositionRelativeToHtml(positionOfScriptInHtml, rangeRelativeToScript.start),
+            this.toPositionRelativeToHtml(positionOfScriptInHtml, rangeRelativeToScript.exclusiveEnd));
+    }
+
+    public toManyRangesRelativeToHtml(positionOfScriptInHtml: Position, manyRangesRelativeToScript: Range[]): Range[] {
+        return manyRangesRelativeToScript.map(positionInScript => this.toRangeRelativeToHtml(positionOfScriptInHtml, positionInScript));
+    }
+}

--- a/src/transformers/eagerSourceMapTransformer.ts
+++ b/src/transformers/eagerSourceMapTransformer.ts
@@ -9,7 +9,10 @@ import { BaseSourceMapTransformer } from './baseSourceMapTransformer';
 import { ILaunchRequestArgs, IAttachRequestArgs } from '../debugAdapterInterfaces';
 import * as utils from '../utils';
 import { logger } from 'vscode-debugadapter';
-import { injectable } from 'inversify';
+import { injectable, inject } from 'inversify';
+import { IConnectedCDAConfiguration } from '../chrome/client/chromeDebugAdapter/cdaConfiguration';
+import { CDTPScriptsRegistry } from '../chrome/cdtpDebuggee/registries/cdtpScriptsRegistry';
+import { TYPES } from '../chrome/dependencyInjection.ts/types';
 
 /**
  * Load SourceMaps on launch. Requires reading the file and parsing out the sourceMappingURL, because
@@ -18,6 +21,12 @@ import { injectable } from 'inversify';
 @injectable()
 export class EagerSourceMapTransformer extends BaseSourceMapTransformer {
     private static SOURCE_MAPPING_MATCHER = new RegExp('^//[#@] ?sourceMappingURL=(.+)$');
+
+    constructor(
+        @inject(TYPES.ConnectedCDAConfiguration) configuration: IConnectedCDAConfiguration,
+        scriptsRegistry: CDTPScriptsRegistry) {
+        super(configuration, scriptsRegistry);
+    }
 
     protected init(args: ILaunchRequestArgs | IAttachRequestArgs): void {
         super.init(args);


### PR DESCRIPTION
Refactor getPositionInScript and getPositionInSource to make the code and the names easier to understand as suggested by previous feedback.

htmlToScriptPositionTranslator.ts & scriptToHtmlPositionTranslator.ts: Utilities to translate locations in script relative to the script tags (which is what source map uses), or relative to the html file with the script tags (which is what CDTP uses).

sourceMap.ts: Started using the new models to help simplify the code in sourcesMapper.ts

sourceMaps.ts, baseSourceMapTransformer.ts & eagerSourceMapTransformer.ts: Had to update to be coherent with the changes in sourceMap.ts

extensibilityPoints.ts: sourceMapTransformer is not currently being used, and the signature was failing to compile after this change, so I removed it.