### PR TITLE
Fix skip files

### DIFF
--- a/src/chrome/internal/features/skipFiles.ts
+++ b/src/chrome/internal/features/skipFiles.ts
@@ -119,11 +119,11 @@ export class SkipFilesLogic implements IStackTracePresentationDetailsProvider {
                 await this.resolveSkipFiles(script, script.developmentSource, script.mappedSources, /*toggling=*/true);
             }
 
-            if (newStatus && scripts.length === 1) {
+            if (newStatus) {
                 // TODO: Verify that using targetPath works here. We need targetPath to be this.getScriptByUrl(targetPath).url
-                this.makeRegexesSkip(scripts[0].url);
+                this.makeRegexesSkip(resolvedSource.url);
             } else {
-                this.makeRegexesNotSkip(scripts[0].url);
+                this.makeRegexesNotSkip(resolvedSource.url);
             }
 
             // Reprocess the latest pause event to adjust for any changes in our configuration


### PR DESCRIPTION
2 of the tests pass after thix fis.

1. We were first creating the blackbox ranges in resolveSkipFiles, and afterwards setting the new skip file status for the files, so it was ignoring the new skip file.

2. makeRegexesSkip: We were trying to create a regexp with a typescript file, instead of a javascript file
