### PR TITLE
Make small optimization that happens to be a workaround for the failing reload test

### DIFF
--- a/src/chrome/internal/breakpoints/features/existingBPsForJustParsedScriptSetter.ts
+++ b/src/chrome/internal/breakpoints/features/existingBPsForJustParsedScriptSetter.ts
@@ -96,9 +96,8 @@ export class ExistingBPsForJustParsedScriptSetter {
         const bpRecepieResolved = bpRecipe.resolvedWithLoadedSource(sourceWhichMayHaveBPs);
         const runtimeLocationsWhichAlreadyHaveThisBPR = debuggeeBPRecipes.map(recipe => recipe.runtimeSourceLocation);
 
-        const manyBPRecipesInScripts = await this._sourceToScriptMapper.mapBPRecipe(bpRecepieResolved);
-        const bprInScripts = manyBPRecipesInScripts.filter(b => b.location.script === justParsedScript);
-        await this.withLogging.setBPRsInScriptIfNeeded(bprInScripts, runtimeLocationsWhichAlreadyHaveThisBPR);
+        const manyBPRecipesInScripts = await this._sourceToScriptMapper.mapBPRecipe(bpRecepieResolved, script => script === justParsedScript);
+        await this.withLogging.setBPRsInScriptIfNeeded(manyBPRecipesInScripts, runtimeLocationsWhichAlreadyHaveThisBPR);
     }
 
     private async setBPRsInScriptIfNeeded(bprInScripts: BPRecipeInScript[], runtimeLocationsWhichAlreadyHaveThisBPR: LocationInLoadedSource[]) {

--- a/src/chrome/internal/breakpoints/features/existingBPsForJustParsedScriptSetter.ts
+++ b/src/chrome/internal/breakpoints/features/existingBPsForJustParsedScriptSetter.ts
@@ -93,10 +93,10 @@ export class ExistingBPsForJustParsedScriptSetter {
 
     private async setBPFromSourceIntoScriptIfNeeded(bpRecipe: BPRecipeInSource<IBPActionWhenHit>, justParsedScript: IScript, sourceWhichMayHaveBPs: ILoadedSource<string>) {
         const debuggeeBPRecipes = this._debuggeeBPRsSetForClientBPRFinder.findDebuggeeBPRsSet(bpRecipe);
-        const bpRecepieResolved = bpRecipe.resolvedWithLoadedSource(sourceWhichMayHaveBPs);
+        const bpRecipeResolved = bpRecipe.resolvedWithLoadedSource(sourceWhichMayHaveBPs);
         const runtimeLocationsWhichAlreadyHaveThisBPR = debuggeeBPRecipes.map(recipe => recipe.runtimeSourceLocation);
 
-        const manyBPRecipesInScripts = await this._sourceToScriptMapper.mapBPRecipe(bpRecepieResolved, script => script === justParsedScript);
+        const manyBPRecipesInScripts = await this._sourceToScriptMapper.mapBPRecipe(bpRecipeResolved, script => script === justParsedScript);
         await this.withLogging.setBPRsInScriptIfNeeded(manyBPRecipesInScripts, runtimeLocationsWhichAlreadyHaveThisBPR);
     }
 

--- a/src/chrome/internal/services/sourceToScriptMapper.ts
+++ b/src/chrome/internal/services/sourceToScriptMapper.ts
@@ -10,6 +10,7 @@ import { IDebuggeeBreakpointsSetter } from '../../cdtpDebuggee/features/cdtpDebu
 import { printArray } from '../../collections/printing';
 import { asyncMap } from '../../collections/async';
 import { TYPES } from '../../dependencyInjection.ts/types';
+import { IScript } from '../scripts/script';
 
 @injectable()
 export class SourceToScriptMapper {
@@ -21,8 +22,8 @@ export class SourceToScriptMapper {
         this.doesTargetSupportColumnBreakpointsCached = this._breakpointFeaturesSupport.supportsColumnBreakpoints;
     }
 
-    public async mapBPRecipe(bpRecipe: BPRecipeInLoadedSource<ConditionalPause | AlwaysPause>): Promise<BPRecipeInScript[]> {
-        const tokensInManyScripts = bpRecipe.location.tokensWhenMappedToScript();
+    public async mapBPRecipe(bpRecipe: BPRecipeInLoadedSource<ConditionalPause | AlwaysPause>, onlyKeepIfScript: (script: IScript) => boolean = () => true): Promise<BPRecipeInScript[]> {
+        const tokensInManyScripts = bpRecipe.location.tokensWhenMappedToScript().filter(tokens => onlyKeepIfScript(tokens.script));
         return asyncMap(tokensInManyScripts, async manyTokensInScript => {
             const bestLocation = this.doesTargetSupportColumnBreakpointsCached
                 ? await this.findBestLocationForBP(manyTokensInScript.enclosingRange)


### PR DESCRIPTION
Make small optimization that happens to be a workaround for the failing reload test.

Changing the position of the filter will avoid some unnecessary calls to GetPossibleBreakpoints