### PR TITLE
Change stacktrace label whitespace to match V1

### DIFF
--- a/src/chrome/internal/stackTraces/stackTraceRequestHandler.ts
+++ b/src/chrome/internal/stackTraces/stackTraceRequestHandler.ts
@@ -73,7 +73,7 @@ export class StackTraceRequestHandler implements ICommandHandlerDeclarer {
         } else if (stackFrame instanceof StackTraceLabel) {
             return {
                 id: this.getFrameId(stackFrame),
-                name: `[${stackFrame.description}]`,
+                name: `[ ${stackFrame.description} ]`,
                 presentationHint: 'label'
             } as DebugProtocol.StackFrame;
         } else {


### PR DESCRIPTION
Needed to make Microsoft/vscode-chrome-debug#830 pass