### PR TITLE
Fixes associated with chrome launch tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1167,18 +1167,6 @@
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        }
       }
     },
     "css": {
@@ -3927,9 +3915,9 @@
       "dev": true
     },
     "is": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
-      "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
       "dev": true
     },
     "is-absolute": {
@@ -7014,15 +7002,16 @@
       "integrity": "sha512-qCfdzcH+0LgQnBpZA53bA32kzp9rpq/f66Som577ObeuDlFIrtbEJ+A/+CCxjIh4G8dpJYNCKIsxpRAHIfsbNw=="
     },
     "vscode-nls-dev": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/vscode-nls-dev/-/vscode-nls-dev-3.2.2.tgz",
-      "integrity": "sha512-6XyESZOyNowLza/fV6Kfmwx0+0iNwa4OkTsBRepwP+eaR7JYnf/ohPaFDX7Egqe4330swtRDCbqr+7i3Q9/TvA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vscode-nls-dev/-/vscode-nls-dev-3.2.6.tgz",
+      "integrity": "sha512-PsL6k363fp5vHZEVJX0ywT7Uem1WvqnFG/eRGxsjOIPYAXQQl8bhJSxm+kNofM8nchZOAnScbtFRz70z9evkqw==",
       "dev": true,
       "requires": {
+        "ansi-colors": "^3.2.3",
         "clone": "^2.1.1",
         "event-stream": "^3.3.4",
+        "fancy-log": "^1.3.3",
         "glob": "^7.1.2",
-        "gulp-util": "^3.0.8",
         "iconv-lite": "^0.4.19",
         "is": "^3.2.1",
         "source-map": "^0.6.1",
@@ -7032,6 +7021,12 @@
         "yargs": "^10.1.1"
       },
       "dependencies": {
+        "ansi-colors": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+          "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+          "dev": true
+        },
         "clone": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -7043,6 +7038,18 @@
           "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
           "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
           "dev": true
+        },
+        "fancy-log": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
+          "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
+          "dev": true,
+          "requires": {
+            "ansi-gray": "^0.1.1",
+            "color-support": "^1.1.3",
+            "parse-node-version": "^1.0.0",
+            "time-stamp": "^1.0.0"
+          }
         },
         "replace-ext": {
           "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -718,7 +718,7 @@
     },
     "brace-expansion": {
       "version": "1.1.8",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
         "balanced-match": "^1.0.0",
@@ -1126,7 +1126,7 @@
     },
     "convert-source-map": {
       "version": "1.5.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
       "dev": true
     },
@@ -2001,7 +2001,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2022,12 +2023,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2042,17 +2045,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2169,7 +2175,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2181,6 +2188,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2195,6 +2203,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2202,12 +2211,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2226,6 +2237,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2306,7 +2318,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2318,6 +2331,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2403,7 +2417,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2439,6 +2454,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2458,6 +2474,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2501,12 +2518,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3966,7 +3985,7 @@
     },
     "is-buffer": {
       "version": "1.1.5",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
       "dev": true
     },
@@ -4103,7 +4122,7 @@
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
@@ -4903,7 +4922,7 @@
     },
     "normalize-path": {
       "version": "2.1.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
@@ -5047,7 +5066,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
@@ -5607,7 +5626,7 @@
     },
     "remove-trailing-separator": {
       "version": "1.0.2",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
       "dev": true
     },
@@ -5704,7 +5723,7 @@
     },
     "resolve": {
       "version": "1.3.3",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
       "dev": true,
       "requires": {
@@ -6227,7 +6246,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -6249,7 +6268,7 @@
         },
         "readable-stream": {
           "version": "2.3.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
@@ -6264,7 +6283,7 @@
         },
         "string_decoder": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
@@ -7115,7 +7134,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "tslint-microsoft-contrib": "^6.1.1",
     "typemoq": "^2.1.0",
     "typescript": "^3.4.5",
-    "vscode-nls-dev": "^3.2.2"
+    "vscode-nls-dev": "^3.2.6"
   },
   "scripts": {
     "build": "gulp build",

--- a/src/chrome/client/chromeDebugAdapter/cdaConfiguration.ts
+++ b/src/chrome/client/chromeDebugAdapter/cdaConfiguration.ts
@@ -18,6 +18,7 @@ export interface IConnectedCDAConfiguration {
     session: ISession;
     clientCapabilities: IClientCapabilities;
     scenarioType: ScenarioType;
+    userRequestedUrl: string;
 }
 
 @injectable()
@@ -41,4 +42,26 @@ export class ConnectedCDAConfiguration implements IConnectedCDAConfiguration {
             }
         }
     }
+
+    /**
+     * Get the url the user requested for launch/attach
+     */
+    public get userRequestedUrl() {
+        let launchUrl: string | null = null;
+        if (this.isLaunchArgs(this.args) && this.args.file) {
+            launchUrl = utils.pathToFileURL(this.args.file);
+        } else if (this.args.url) {
+            launchUrl = this.args.url;
+        } else {
+            throw new Error(`You must specify either file or url to launch Chrome against a local file or a url. None were specified. `
+                + `The specified parameterse are: ${JSON.stringify(this.args)}`);
+        }
+        return launchUrl;
+    }
+
+    /** Type guard for args */
+    private isLaunchArgs(_args: ILaunchRequestArgs | IAttachRequestArgs): _args is ILaunchRequestArgs {
+        return this.scenarioType === ScenarioType.Launch;
+    }
+
 }

--- a/src/chrome/client/chromeDebugAdapter/connectingCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/connectingCDA.ts
@@ -5,41 +5,24 @@
 import { inject, injectable } from 'inversify';
 import { TYPES } from '../../dependencyInjection.ts/types';
 import { BaseCDAState } from './baseCDAState';
-import { IDebuggeeLauncher } from '../../debugeeStartup/debugeeLauncher';
 import { ChromeConnection } from '../../chromeConnection';
 import { ConnectedCDA, ConnectedCDAProvider } from './connectedCDA';
 import { ConnectedCDAConfiguration } from './cdaConfiguration';
 import { ITelemetryPropertyCollector } from '../../../telemetry';
-import { ScenarioType } from './unconnectedCDA';
-import { IAttachRequestArgs } from '../../../debugAdapterInterfaces';
-import { logger } from 'vscode-debugadapter';
 
 export type ConnectingCDAProvider = (configuration: ConnectedCDAConfiguration) => ConnectingCDA;
 
 @injectable()
 export class ConnectingCDA extends BaseCDAState {
     constructor(
-        @inject(TYPES.IDebuggeeLauncher) private readonly _debuggeeLauncher: IDebuggeeLauncher,
         @inject(TYPES.ConnectedCDAProvider) private readonly _connectedCDAProvider: ConnectedCDAProvider,
         @inject(TYPES.ChromeConnection) private readonly _chromeConnection: ChromeConnection,
-        @inject(TYPES.ConnectedCDAConfiguration) private readonly _configuration: ConnectedCDAConfiguration,
     ) {
         super([], {});
     }
 
     public async connect(telemetryPropertyCollector: ITelemetryPropertyCollector): Promise<ConnectedCDA> {
-
-        if (this._configuration.scenarioType === ScenarioType.Launch) {
-            logger.verbose('[ConnectingCDA]: Launching debugee...');
-            const result = await this._debuggeeLauncher.launch(this._configuration.args, telemetryPropertyCollector);
-            await this._chromeConnection.attach(result.address, result.port, result.url, this._configuration.args.timeout, this._configuration.args.extraCRDPChannelPort);
-        }
-        else if (this._configuration.scenarioType === ScenarioType.Attach) {
-            logger.verbose('[ConnectingCDA]: Attaching to an existing instance of debugee...');
-            const attachArgs = <IAttachRequestArgs>this._configuration.args;
-            await this._chromeConnection.attach(attachArgs.address, attachArgs.port, attachArgs.url, attachArgs.timeout, attachArgs.extraCRDPChannelPort);
-        }
-
+        await this._chromeConnection.open(telemetryPropertyCollector);
         const newState = this._connectedCDAProvider(this._chromeConnection.api);
         await newState.install();
         return newState;

--- a/src/chrome/client/chromeDebugAdapter/connectingCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/connectingCDA.ts
@@ -40,7 +40,6 @@ export class ConnectingCDA extends BaseCDAState {
             await this._chromeConnection.attach(attachArgs.address, attachArgs.port, attachArgs.url, attachArgs.timeout, attachArgs.extraCRDPChannelPort);
         }
 
-
         const newState = this._connectedCDAProvider(this._chromeConnection.api);
         await newState.install();
         return newState;

--- a/src/chrome/client/chromeDebugAdapter/terminatingCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/terminatingCDA.ts
@@ -14,6 +14,7 @@ import { IRestartRequestArgs, ILaunchRequestArgs } from '../../../debugAdapterIn
 import { ConnectedCDAConfiguration } from './cdaConfiguration';
 import { DisconnectedCDA } from './disconnectedCDA';
 import { IDebuggeeRunner, IDebuggeeLauncher } from '../../debugeeStartup/debugeeLauncher';
+import { ScenarioType } from './unconnectedCDA';
 
 export enum TerminatingReason {
     DisconnectedFromWebsocket,
@@ -47,7 +48,11 @@ export class TerminatingCDA extends BaseCDAState {
         // TODO: Wait until we don't have any more requests in flight.
         // TODO: Figure out if we need to do the stops before or after the shutdown and terminateSession
         await this._debuggeeRunner.stop();
-        await this._debuggeeLauncher.stop();
+
+        // don't call stop on the launcher if we attached
+        if (this._configuration.scenarioType === ScenarioType.Launch) {
+            await this._debuggeeLauncher.stop();
+        }
 
         this.shutdown();
         await this.terminateSession(this._reason === TerminatingReason.DisconnectedFromWebsocket ? 'Got disconnect request' : 'Disconnected from websocket');

--- a/src/chrome/client/chromeDebugAdapter/terminatingCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/terminatingCDA.ts
@@ -86,7 +86,7 @@ export class TerminatingCDA extends BaseCDAState {
         }
 
         if (this._chromeConnection.isAttached) {
-            this._chromeConnection.close();
+            await this._chromeConnection.close();
         }
     }
 }

--- a/src/debugAdapterInterfaces.d.ts
+++ b/src/debugAdapterInterfaces.d.ts
@@ -53,6 +53,7 @@ export interface ICommonRequestArgs {
 
     _suppressConsoleOutput?: boolean;
 
+    url?: string;
     port?: number;
 }
 
@@ -68,6 +69,7 @@ export interface IRestartRequestArgs {
  * Properties needed by -core, just a subset of the properties needed for launch in general
  */
 export interface ILaunchRequestArgs extends DebugProtocol.LaunchRequestArguments, ICommonRequestArgs {
+    file?: string;
     __restart?: IRestartRequestArgs;
 }
 


### PR DESCRIPTION
Added code to handle attach requests in ConnectingCDA, and updated vscode-nls-dev to fix windows path separator bug (this was breaking localization and causing the "messages not found" error).