### PR TITLE
TSLint - strict boolean expressions - 1

### DIFF
--- a/src/chrome/cdtpDebuggee/cdtpPrimitives.ts
+++ b/src/chrome/cdtpDebuggee/cdtpPrimitives.ts
@@ -11,6 +11,7 @@ import { IResourceIdentifier } from '../internal/sources/resourceIdentifier';
 import { IBPRecipeForRuntimeSource } from '../internal/breakpoints/baseMappedBPRecipe';
 import { MappableBreakpoint } from '../internal/breakpoints/breakpoint';
 import { MakePropertyRequired } from '../../typeUtils';
+import { isNotEmpty, isDefined } from '../utils/typedOperators';
 
 export type integer = number;
 // The IResourceIdentifier<CDTPScriptUrl> is used with the URL that is associated with each Script in CDTP. This should be a URL, but it could also be a string that is not a valid URL
@@ -25,7 +26,7 @@ export type FrameId = string & { [ImplementsFrameId]: 'FrameId' };
 export type CDTPNonPrimitiveRemoteObject = MakePropertyRequired<CDTP.Runtime.RemoteObject, 'objectId'>; // objectId won't be null for non primitive values. See https://chromedevtools.github.io/devtools-protocol/tot/Runtime#type-RemoteObject
 export type CDTPRemoteObjectOfTypeObject = MakePropertyRequired<CDTPNonPrimitiveRemoteObject, 'preview'>; // preview is only specified for remote objects of type === 'object'
 export function validateNonPrimitiveRemoteObject(remoteObject: CDTP.Runtime.RemoteObject): remoteObject is CDTPNonPrimitiveRemoteObject {
-    if (remoteObject.objectId) {
+    if (isNotEmpty(remoteObject.objectId)) {
         return true;
     } else {
         throw new Error(`Expected a non-primitive value to have an object id, yet it doesn't: ${JSON.stringify(remoteObject)}`);
@@ -33,7 +34,7 @@ export function validateNonPrimitiveRemoteObject(remoteObject: CDTP.Runtime.Remo
 }
 
 export function validateCDTPRemoteObjectOfTypeObject(remoteObject: CDTP.Runtime.RemoteObject): remoteObject is CDTPRemoteObjectOfTypeObject {
-    if (remoteObject.type === 'object' && remoteObject.objectId && remoteObject.preview) {
+    if (remoteObject.type === 'object' && isNotEmpty(remoteObject.objectId) && isDefined(remoteObject.preview)) {
         return true;
     } else {
         throw new Error(`Expected remote object to be of type == 'object' and to have an object id and a preview, yet it doesn't: ${JSON.stringify(remoteObject)}`);

--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpConsoleEventsProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpConsoleEventsProvider.ts
@@ -10,7 +10,7 @@ import { CodeFlowStackTrace } from '../../internal/stackTraces/codeFlowStackTrac
 import { TYPES } from '../../dependencyInjection.ts/types';
 import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
 import { CDTPDomainsEnabler } from '../infrastructure/cdtpDomainsEnabler';
-import { ifDefinedDo } from '../../utils/typedOperators';
+import { isDefined } from '../../utils/typedOperators';
 
 export type ConsoleAPIEventType = 'log' | 'debug' | 'info' | 'error' | 'warning' | 'dir' | 'dirxml' | 'table' | 'trace' | 'clear' | 'startGroup' | 'startGroupCollapsed' | 'endGroup' | 'assert' | 'profile' | 'profileEnd' | 'count' | 'timeEnd';
 
@@ -54,7 +54,7 @@ class CDTPConsoleEventsFromRuntimeProvider extends CDTPEventsEmitterDiagnosticsM
             executionContextId: params.executionContextId,
             timestamp: params.timestamp,
             type: params.type,
-            stackTrace: await ifDefinedDo(params.stackTrace, stackTrace => this._stackTraceParser.toStackTraceCodeFlow(stackTrace))
+            stackTrace: isDefined(params.stackTrace) ? await this._stackTraceParser.toStackTraceCodeFlow(params.stackTrace) : undefined
         }));
 
     constructor(

--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpConsoleEventsProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpConsoleEventsProvider.ts
@@ -10,6 +10,7 @@ import { CodeFlowStackTrace } from '../../internal/stackTraces/codeFlowStackTrac
 import { TYPES } from '../../dependencyInjection.ts/types';
 import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
 import { CDTPDomainsEnabler } from '../infrastructure/cdtpDomainsEnabler';
+import { ifDefinedDo } from '../../utils/typedOperators';
 
 export type ConsoleAPIEventType = 'log' | 'debug' | 'info' | 'error' | 'warning' | 'dir' | 'dirxml' | 'table' | 'trace' | 'clear' | 'startGroup' | 'startGroupCollapsed' | 'endGroup' | 'assert' | 'profile' | 'profileEnd' | 'count' | 'timeEnd';
 
@@ -53,7 +54,7 @@ class CDTPConsoleEventsFromRuntimeProvider extends CDTPEventsEmitterDiagnosticsM
             executionContextId: params.executionContextId,
             timestamp: params.timestamp,
             type: params.type,
-            stackTrace: params.stackTrace && await this._stackTraceParser.toStackTraceCodeFlow(params.stackTrace)
+            stackTrace: await ifDefinedDo(params.stackTrace, stackTrace => this._stackTraceParser.toStackTraceCodeFlow(stackTrace))
         }));
 
     constructor(

--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider.ts
@@ -19,7 +19,7 @@ import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
 import { CDTPCallFrameRegistry } from '../registries/cdtpCallFrameRegistry';
 import { CDTPDomainsEnabler } from '../infrastructure/cdtpDomainsEnabler';
 import { CDTPBPRecipe, validateNonPrimitiveRemoteObject } from '../cdtpPrimitives';
-import _ = require('lodash');
+import * as _ from 'lodash';
 import { ifDefinedDo } from '../../utils/typedOperators';
 
 export type PauseEventReason = 'XHR' | 'DOM' | 'EventListener' | 'exception' | 'assert' | 'debugCommand' | 'promiseRejection' | 'OOM' | 'other' | 'ambiguous';

--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpExceptionThrownEventsProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpExceptionThrownEventsProvider.ts
@@ -13,6 +13,7 @@ import { integer } from '../cdtpPrimitives';
 import { IScript } from '../../internal/scripts/script';
 import { CodeFlowStackTrace } from '../../internal/stackTraces/codeFlowStackTrace';
 import { CDTPDomainsEnabler } from '../infrastructure/cdtpDomainsEnabler';
+import { ifDefinedDo } from '../../utils/typedOperators';
 
 export interface IExceptionThrownEvent {
     readonly timestamp: CDTP.Runtime.Timestamp;
@@ -61,9 +62,9 @@ export class CDTPExceptionThrownEventsProvider extends CDTPEventsEmitterDiagnost
             text: exceptionDetails.text,
             lineNumber: exceptionDetails.lineNumber,
             columnNumber: exceptionDetails.columnNumber,
-            script: exceptionDetails.scriptId ? await this._scriptsRegistry.getScriptByCdtpId(exceptionDetails.scriptId) : undefined,
+            script: await ifDefinedDo(exceptionDetails.scriptId, scriptId => this._scriptsRegistry.getScriptByCdtpId(scriptId)),
             url: exceptionDetails.url,
-            stackTrace: exceptionDetails.stackTrace && await this._stackTraceParser.toStackTraceCodeFlow(exceptionDetails.stackTrace),
+            stackTrace: await ifDefinedDo(exceptionDetails.stackTrace, stackTrace => this._stackTraceParser.toStackTraceCodeFlow(stackTrace)),
             exception: exceptionDetails.exception,
             executionContextId: exceptionDetails.executionContextId,
         };

--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpExceptionThrownEventsProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpExceptionThrownEventsProvider.ts
@@ -13,7 +13,7 @@ import { integer } from '../cdtpPrimitives';
 import { IScript } from '../../internal/scripts/script';
 import { CodeFlowStackTrace } from '../../internal/stackTraces/codeFlowStackTrace';
 import { CDTPDomainsEnabler } from '../infrastructure/cdtpDomainsEnabler';
-import { ifDefinedDo } from '../../utils/typedOperators';
+import { isDefined, isNotEmpty } from '../../utils/typedOperators';
 
 export interface IExceptionThrownEvent {
     readonly timestamp: CDTP.Runtime.Timestamp;
@@ -62,9 +62,9 @@ export class CDTPExceptionThrownEventsProvider extends CDTPEventsEmitterDiagnost
             text: exceptionDetails.text,
             lineNumber: exceptionDetails.lineNumber,
             columnNumber: exceptionDetails.columnNumber,
-            script: await ifDefinedDo(exceptionDetails.scriptId, scriptId => this._scriptsRegistry.getScriptByCdtpId(scriptId)),
+            script: isNotEmpty(exceptionDetails.scriptId) ? await this._scriptsRegistry.getScriptByCdtpId(exceptionDetails.scriptId) : undefined,
             url: exceptionDetails.url,
-            stackTrace: await ifDefinedDo(exceptionDetails.stackTrace, stackTrace => this._stackTraceParser.toStackTraceCodeFlow(stackTrace)),
+            stackTrace: isDefined(exceptionDetails.stackTrace) ? await this._stackTraceParser.toStackTraceCodeFlow(exceptionDetails.stackTrace) : undefined,
             exception: exceptionDetails.exception,
             executionContextId: exceptionDetails.executionContextId,
         };

--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpLogEventsProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpLogEventsProvider.ts
@@ -12,6 +12,7 @@ import { TYPES } from '../../dependencyInjection.ts/types';
 import { inject } from 'inversify';
 import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
 import { CDTPDomainsEnabler } from '../infrastructure/cdtpDomainsEnabler';
+import { ifDefinedDo } from '../../utils/typedOperators';
 
 export type LogEntrySource = 'xml' | 'javascript' | 'network' | 'storage' | 'appcache' | 'rendering' | 'security' | 'deprecation' | 'worker' | 'violation' | 'intervention' | 'recommendation' | 'other';
 export type LogLevel = 'verbose' | 'info' | 'warning' | 'error';
@@ -59,7 +60,7 @@ export class CDTPLogEventsProvider extends CDTPEventsEmitterDiagnosticsModule<CD
             networkRequestId: entry.networkRequestId,
             workerId: entry.workerId,
             args: entry.args,
-            stackTrace: entry.stackTrace && await this._stackTraceParser.toStackTraceCodeFlow(entry.stackTrace),
+            stackTrace: await ifDefinedDo(entry.stackTrace, stackTrace => this._stackTraceParser.toStackTraceCodeFlow(stackTrace)),
         };
     }
 }

--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpLogEventsProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpLogEventsProvider.ts
@@ -12,7 +12,7 @@ import { TYPES } from '../../dependencyInjection.ts/types';
 import { inject } from 'inversify';
 import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
 import { CDTPDomainsEnabler } from '../infrastructure/cdtpDomainsEnabler';
-import { ifDefinedDo } from '../../utils/typedOperators';
+import { isDefined } from '../../utils/typedOperators';
 
 export type LogEntrySource = 'xml' | 'javascript' | 'network' | 'storage' | 'appcache' | 'rendering' | 'security' | 'deprecation' | 'worker' | 'violation' | 'intervention' | 'recommendation' | 'other';
 export type LogLevel = 'verbose' | 'info' | 'warning' | 'error';
@@ -60,7 +60,7 @@ export class CDTPLogEventsProvider extends CDTPEventsEmitterDiagnosticsModule<CD
             networkRequestId: entry.networkRequestId,
             workerId: entry.workerId,
             args: entry.args,
-            stackTrace: await ifDefinedDo(entry.stackTrace, stackTrace => this._stackTraceParser.toStackTraceCodeFlow(stackTrace)),
+            stackTrace: isDefined(entry.stackTrace) ? await this._stackTraceParser.toStackTraceCodeFlow(entry.stackTrace) : undefined,
         };
     }
 }

--- a/src/chrome/cdtpDebuggee/protocolParsers/cdtpLocationParser.ts
+++ b/src/chrome/cdtpDebuggee/protocolParsers/cdtpLocationParser.ts
@@ -6,7 +6,7 @@ import { Position, LocationInScript } from '../../internal/locations/location';
 import { createColumnNumber, createLineNumber } from '../../internal/locations/subtypes';
 import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
 import { Protocol as CDTP } from 'devtools-protocol';
-import _ = require('lodash');
+import * as _ from 'lodash';
 
 interface IHasCoordinates {
     lineNumber: number;

--- a/src/chrome/cdtpDebuggee/protocolParsers/cdtpLocationParser.ts
+++ b/src/chrome/cdtpDebuggee/protocolParsers/cdtpLocationParser.ts
@@ -6,6 +6,7 @@ import { Position, LocationInScript } from '../../internal/locations/location';
 import { createColumnNumber, createLineNumber } from '../../internal/locations/subtypes';
 import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
 import { Protocol as CDTP } from 'devtools-protocol';
+import _ = require('lodash');
 
 interface IHasCoordinates {
     lineNumber: number;
@@ -28,6 +29,6 @@ export class CDTPLocationParser {
 
     private getCoordinates(crdpObjectWithCoordinates: IHasCoordinates): Position {
         // If the colum number is not specified, we assume it's referring to column 0
-        return new Position(createLineNumber(crdpObjectWithCoordinates.lineNumber), createColumnNumber(crdpObjectWithCoordinates.columnNumber || 0));
+        return new Position(createLineNumber(crdpObjectWithCoordinates.lineNumber), createColumnNumber(_.defaultTo(crdpObjectWithCoordinates.columnNumber, 0)));
     }
 }

--- a/src/chrome/cdtpDebuggee/protocolParsers/cdtpStackTraceParser.ts
+++ b/src/chrome/cdtpDebuggee/protocolParsers/cdtpStackTraceParser.ts
@@ -10,6 +10,7 @@ import { CodeFlowFrame } from '../../internal/stackTraces/callFrame';
 import { CDTPLocationParser, IHasScriptLocation } from './cdtpLocationParser';
 import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
 import { asyncMap } from '../../collections/async';
+import { ifDefinedDo } from '../../utils/typedOperators';
 
 export class CDTPStackTraceParser {
     private readonly _cdtpLocationParser = new CDTPLocationParser(this._scriptsRegistry);
@@ -20,7 +21,7 @@ export class CDTPStackTraceParser {
         return {
             codeFlowFrames: await asyncMap(stackTrace.callFrames, (callFrame, index) => this.runtimeCallFrameToCodeFlowFrame(index, callFrame)),
             description: stackTrace.description,
-            parent: stackTrace.parent && await this.toStackTraceCodeFlow(stackTrace.parent)
+            parent: await ifDefinedDo(stackTrace.parent, parent => this.toStackTraceCodeFlow(parent))
         };
     }
 

--- a/src/chrome/cdtpDebuggee/protocolParsers/cdtpStackTraceParser.ts
+++ b/src/chrome/cdtpDebuggee/protocolParsers/cdtpStackTraceParser.ts
@@ -10,7 +10,7 @@ import { CodeFlowFrame } from '../../internal/stackTraces/callFrame';
 import { CDTPLocationParser, IHasScriptLocation } from './cdtpLocationParser';
 import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
 import { asyncMap } from '../../collections/async';
-import { ifDefinedDo } from '../../utils/typedOperators';
+import { isDefined } from '../../utils/typedOperators';
 
 export class CDTPStackTraceParser {
     private readonly _cdtpLocationParser = new CDTPLocationParser(this._scriptsRegistry);
@@ -21,7 +21,7 @@ export class CDTPStackTraceParser {
         return {
             codeFlowFrames: await asyncMap(stackTrace.callFrames, (callFrame, index) => this.runtimeCallFrameToCodeFlowFrame(index, callFrame)),
             description: stackTrace.description,
-            parent: await ifDefinedDo(stackTrace.parent, parent => this.toStackTraceCodeFlow(parent))
+            parent: isDefined(stackTrace.parent) ? await this.toStackTraceCodeFlow(stackTrace.parent) : undefined
         };
     }
 

--- a/src/chrome/cdtpDebuggee/registries/cdtpScriptsRegistry.ts
+++ b/src/chrome/cdtpDebuggee/registries/cdtpScriptsRegistry.ts
@@ -9,7 +9,7 @@ import { ExecutionContext, IExecutionContext } from '../../internal/scripts/exec
 import { injectable } from 'inversify';
 import { IResourceIdentifier, newResourceIdentifierMap } from '../../internal/sources/resourceIdentifier';
 import { FrameId } from '../cdtpPrimitives';
-import _ = require('lodash');
+import * as _ from 'lodash';
 
 /**
  * TODO: The CDTPScriptsRegistry is still a work in progress. We need to understand exactly how the ExecutionContexts, the Scripts, and the script "generations" work to figure out the best way to implement this

--- a/src/chrome/cdtpDebuggee/registries/cdtpScriptsRegistry.ts
+++ b/src/chrome/cdtpDebuggee/registries/cdtpScriptsRegistry.ts
@@ -9,6 +9,7 @@ import { ExecutionContext, IExecutionContext } from '../../internal/scripts/exec
 import { injectable } from 'inversify';
 import { IResourceIdentifier, newResourceIdentifierMap } from '../../internal/sources/resourceIdentifier';
 import { FrameId } from '../cdtpPrimitives';
+import _ = require('lodash');
 
 /**
  * TODO: The CDTPScriptsRegistry is still a work in progress. We need to understand exactly how the ExecutionContexts, the Scripts, and the script "generations" work to figure out the best way to implement this
@@ -100,6 +101,6 @@ class CDTPCurrentGeneration {
 
     public getScriptByPath(path: IResourceIdentifier): IScript[] {
         const runtimeScript = this._scriptByPath.tryGetting(path);
-        return runtimeScript || [];
+        return _.defaultTo(runtimeScript, []);
     }
 }

--- a/src/chrome/client/chromeDebugAdapter/cdaConfiguration.ts
+++ b/src/chrome/client/chromeDebugAdapter/cdaConfiguration.ts
@@ -9,6 +9,7 @@ import { ScenarioType } from './unconnectedCDA';
 import { injectable } from 'inversify';
 import { ISession } from '../session';
 import * as utils from '../../../utils';
+import { isDefined } from '../../utils/typedOperators';
 
 export interface IConnectedCDAConfiguration {
     args: ILaunchRequestArgs | IAttachRequestArgs;
@@ -36,7 +37,7 @@ export class ConnectedCDAConfiguration implements IConnectedCDAConfiguration {
         private readonly originalArgs: ILaunchRequestArgs | IAttachRequestArgs) {
         this.args = this.extensibilityPoints.updateArguments(this.scenarioType, this.originalArgs);
 
-        if (this.args.pathMapping) {
+        if (isDefined(this.args.pathMapping)) {
             for (const urlToMap in this.args.pathMapping) {
                 this.args.pathMapping[urlToMap] = utils.canonicalizeUrl(this.args.pathMapping[urlToMap]);
             }

--- a/src/chrome/client/chromeDebugAdapter/cdaDIContainerCreator.ts
+++ b/src/chrome/client/chromeDebugAdapter/cdaDIContainerCreator.ts
@@ -19,6 +19,7 @@ import { TerminatingCDA, TerminatingReason } from './terminatingCDA';
 import { ChromeTargetDiscovery } from '../../chromeTargetDiscoveryStrategy';
 import { ChromeConnection } from '../../chromeConnection';
 import { telemetry } from '../../../telemetry';
+import { isDefined, isNotEmpty } from '../../utils/typedOperators';
 
 export function createDIContainer(chromeDebugAdapter: ChromeDebugAdapter, rawDebugSession: ChromeDebugSession, debugSessionOptions: IChromeDebugSessionOpts): DependencyInjection {
     const session = new DelayMessagesUntilInitializedSession(new DoNotPauseWhileSteppingSession(rawDebugSession));
@@ -60,7 +61,7 @@ export function createDIContainer(chromeDebugAdapter: ChromeDebugAdapter, rawDeb
 function bindComponents(diContainer: DependencyInjection, args: ILaunchRequestArgs | IAttachRequestArgs, bindAdditionalComponents: (diContainer: DependencyInjection) => void): DependencyInjection {
     const replacements = [];
 
-    if (args.pathMapping && args.pathMapping['/']) {
+    if (isDefined(args.pathMapping) && isNotEmpty(args.pathMapping['/'])) {
         // replace the workspace path with 'ws' in the logs to avoid long lines
         const workspace = args.pathMapping['/'];
         const workspaceRegexp = utils.pathToRegex(workspace);

--- a/src/chrome/client/chromeDebugAdapter/chromeDebugAdapterV2.ts
+++ b/src/chrome/client/chromeDebugAdapter/chromeDebugAdapterV2.ts
@@ -11,6 +11,7 @@ import { createDIContainer } from './cdaDIContainerCreator';
 import { TYPES } from '../../dependencyInjection.ts/types';
 import { TerminatingCDA } from './terminatingCDA';
 import { logger } from 'vscode-debugadapter';
+import { isUndefined } from '../../utils/typedOperators';
 
 export class ChromeDebugAdapter implements IDebugAdapter, IObservableEvents<IStepStartedEventsEmitter & IFinishedStartingUpEventsEmitter>{
     public readonly events = new StepProgressEventsEmitter();
@@ -31,7 +32,7 @@ export class ChromeDebugAdapter implements IDebugAdapter, IObservableEvents<ISte
         await this.waitUntilInitialized;
 
         const response = await this._debugSessionOptions.extensibilityPoints.processRequest(requestName, args, customizedArgs => {
-            if (!this._state.processRequest) {
+            if (isUndefined(this._state.processRequest)) {
                 throw new Error(`Invalid state: ${this._state}`);
             }
             return this._state.processRequest(requestName, customizedArgs, telemetryPropertyCollector);
@@ -59,7 +60,7 @@ export class ChromeDebugAdapter implements IDebugAdapter, IObservableEvents<ISte
     private changeStateTo(newState: IDebugAdapterState) {
         logger.log(`Changing ChromeDebugAdapter state to ${newState}`);
         this._state = newState;
-        if (!this._state.processRequest) {
+        if (isUndefined(this._state.processRequest)) {
             throw new Error(`Invalid state: ${this._state}`);
         }
     }

--- a/src/chrome/client/chromeDebugAdapter/terminatingCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/terminatingCDA.ts
@@ -15,6 +15,7 @@ import { ConnectedCDAConfiguration } from './cdaConfiguration';
 import { DisconnectedCDA } from './disconnectedCDA';
 import { IDebuggeeRunner, IDebuggeeLauncher } from '../../debugeeStartup/debugeeLauncher';
 import { ScenarioType } from './unconnectedCDA';
+import { isTrue } from '../../utils/typedOperators';
 
 export enum TerminatingReason {
     DisconnectedFromWebsocket,
@@ -81,7 +82,7 @@ export class TerminatingCDA extends BaseCDAState {
            }
          */
         telemetry.reportEvent('debugStopped', { reason });
-        if ((<ILaunchRequestArgs>this._configuration.args).noDebug) {
+        if (isTrue((<ILaunchRequestArgs>this._configuration.args).noDebug)) {
             this._session.sendEvent(new TerminatedEvent(restart));
         }
 

--- a/src/chrome/client/chromeDebugAdapter/unconnectedCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/unconnectedCDA.ts
@@ -14,6 +14,7 @@ import { CommandText } from '../requests';
 import { injectable, inject } from 'inversify';
 import { ConnectingCDAProvider } from './connectingCDA';
 import { ISession } from '../session';
+import { isTrue } from '../../utils/typedOperators';
 
 export enum ScenarioType {
     Launch,
@@ -55,9 +56,16 @@ export class UnconnectedCDA implements IDebugAdapterState {
     }
 
     private parseLoggingConfiguration(args: ILaunchRequestArgs | IAttachRequestArgs): ILoggingConfiguration {
-        const traceMapping: { [key: string]: Logger.LogLevel | undefined } = { true: Logger.LogLevel.Warn, verbose: Logger.LogLevel.Verbose };
-        const traceValue = args.trace && traceMapping[args.trace.toString().toLowerCase()];
-        return { logLevel: traceValue || undefined, logFilePath: args.logFilePath, shouldLogTimestamps: !!args.logTimestamps };
+        let traceValue: Logger.LogLevel;
+        switch (args.trace) {
+            case 'verbose':
+                traceValue = Logger.LogLevel.Verbose;
+                break;
+            default:
+                traceValue = Logger.LogLevel.Warn;
+        }
+
+        return { logLevel: traceValue, logFilePath: args.logFilePath, shouldLogTimestamps: isTrue(args.logTimestamps) };
     }
 
     private async createConnection(scenarioType: ScenarioType, args: ILaunchRequestArgs | IAttachRequestArgs, telemetryPropertyCollector: ITelemetryPropertyCollector): Promise<IDebugAdapterState> {

--- a/src/chrome/client/chromeDebugAdapter/uninitializedCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/uninitializedCDA.ts
@@ -10,6 +10,7 @@ import { IDebugAdapterState, IInitializeRequestArgs, ITelemetryPropertyCollector
 import { BaseCDAState } from './baseCDAState';
 import { TYPES } from '../../dependencyInjection.ts/types';
 import { inject, injectable } from 'inversify';
+import { isNotEmpty } from '../../utils/typedOperators';
 let localize = nls.loadMessageBundle(); // Initialize to an unlocalized version until we know which locale to use
 
 @injectable()
@@ -22,8 +23,8 @@ export class UninitializedCDA extends BaseCDAState {
     }
 
     public async initialize(args: IInitializeRequestArgs, _telemetryPropertyCollector?: ITelemetryPropertyCollector): Promise<{ capabilities: DebugProtocol.Capabilities, newState: IDebugAdapterState }> {
-        if (args.locale) {
-            localize = nls.config({ locale: args.locale })(); // Replace with the proper locale
+        if (isNotEmpty(args.locale)) {
+                localize = nls.config({ locale: args.locale })(); // Replace with the proper locale
         }
 
         const exceptionBreakpointFilters = [

--- a/src/chrome/internal/stackTraces/callFrameDescription.ts
+++ b/src/chrome/internal/stackTraces/callFrameDescription.ts
@@ -4,6 +4,7 @@
 import * as path from 'path';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { ScriptCallFrame, CallFrameWithState } from './callFrame';
+import { isTrue, isDefined } from '../../utils/typedOperators';
 
 /** The clients can requests the stack traces frames descriptions in different formats.
  * We use this class to create the description for the call frame according to the parameters supplied by the client.
@@ -24,12 +25,12 @@ export class CustomCallFrameDescriptionFormatter implements ICallFrameDescriptio
 
         let formattedDescription = this._callFrame.functionName;
 
-        if (this._formatArgs) {
-            if (this._formatArgs.module) {
+        if (isDefined(this._formatArgs)) {
+            if (isTrue(this._formatArgs.module)) {
                 formattedDescription += ` [${path.basename(locationInLoadedSource.source.identifier.textRepresentation)}]`;
             }
 
-            if (this._formatArgs.line) {
+            if (isTrue(this._formatArgs.line)) {
                 formattedDescription += ` Line ${locationInLoadedSource.position.lineNumber}`;
             }
         }

--- a/src/chrome/internal/stackTraces/callFrameFunction.ts
+++ b/src/chrome/internal/stackTraces/callFrameFunction.ts
@@ -2,6 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 import { IScript } from '../scripts/script';
+import { isNotEmpty } from '../../utils/typedOperators';
 
 /** We use these classes to generate a proper description for the function
  * based on wheter it is named, and the script where it's at is named
@@ -31,7 +32,7 @@ class CallFrameForUnamedFunctionInNamedScript implements ICallFrameFunction {
 }
 
 export function createCallFrameFunction(script: IScript, functionName: string) {
-    if (functionName) {
+    if (isNotEmpty(functionName)) {
         return new CallFrameForNamedFunction(functionName);
     } else if (script.runtimeSource.doesScriptHasUrl()) {
         return new CallFrameForUnamedFunctionInNamedScript();

--- a/src/chrome/internal/stackTraces/callFramePresentation.ts
+++ b/src/chrome/internal/stackTraces/callFramePresentation.ts
@@ -8,6 +8,7 @@ import { ILoadedSource } from '../sources/loadedSource';
 import { CodeFlowFrame, ICallFrame, CallFrame, ICallFrameState } from './callFrame';
 import { CallFramePresentationHint, IStackTracePresentationRow } from './stackTracePresentationRow';
 import { IStackTraceFormat, StackTraceCustomFormat } from './stackTracePresenter';
+import { isTrue, isNotEmpty } from '../../utils/typedOperators';
 
 export type SourcePresentationHint = 'normal' | 'emphasize' | 'deemphasize';
 
@@ -57,11 +58,11 @@ export class CallFramePresentation implements IStackTracePresentationRow {
         let formattedDescription = functionDescription(this.callFrame.codeFlow.functionName, location.source);
 
         if (this._descriptionFormatArgs instanceof StackTraceCustomFormat) {
-            if (this._descriptionFormatArgs.formatOptions.module) {
+            if (isTrue(this._descriptionFormatArgs.formatOptions.module)) {
                 formattedDescription += ` [${path.basename(location.source.identifier.textRepresentation)}]`;
             }
 
-            if (this._descriptionFormatArgs.formatOptions.line) {
+            if (isTrue(this._descriptionFormatArgs.formatOptions.line)) {
                 // The description property intended for the user, so we don't care if the client uses 0-index or 1-index line number. We send this as 1-index line number always
                 const oneBasedLineNumber = location.position.lineNumber + 1;
 
@@ -74,7 +75,7 @@ export class CallFramePresentation implements IStackTracePresentationRow {
 }
 
 export function functionDescription(functionName: string | undefined, functionModule: ILoadedSource): string {
-    if (functionName) {
+    if (isNotEmpty(functionName)) {
         return functionName;
     } else if (functionModule.doesScriptHasUrl()) {
         return '(anonymous function)';

--- a/src/chrome/internal/stackTraces/currentStackTraceProvider.ts
+++ b/src/chrome/internal/stackTraces/currentStackTraceProvider.ts
@@ -6,6 +6,7 @@ import { IActionToTakeWhenPaused, NoActionIsNeededForThisPause } from '../featur
 import { ScriptCallFrame, CallFrameWithState } from './callFrame';
 import { CodeFlowStackTrace } from './codeFlowStackTrace';
 import { ILoadedSource } from '../sources/loadedSource';
+import { isDefined } from '../../utils/typedOperators';
 
 interface ICurrentStackTraceProviderState {
     isPaused(): boolean;
@@ -34,7 +35,7 @@ class CurrentStackTraceProviderWhenPaused implements ICurrentStackTraceProviderS
     public isSourceInCurrentStack(source: ILoadedSource): boolean {
         const asyncStackTrace = this.asyncStackTrace();
         return this.isSourceInCurrentSyncStack(source)
-            || (asyncStackTrace ? this.isSourceInAsyncStack(asyncStackTrace, source) : false);
+            || (isDefined(asyncStackTrace) ? this.isSourceInAsyncStack(asyncStackTrace, source) : false);
     }
 
     private isSourceInCurrentSyncStack(source: ILoadedSource<string>): boolean {
@@ -44,9 +45,9 @@ class CurrentStackTraceProviderWhenPaused implements ICurrentStackTraceProviderS
     private isSourceInAsyncStack(asyncStackTrace: CodeFlowStackTrace, source: ILoadedSource<string>): boolean {
         return asyncStackTrace.codeFlowFrames.some(frame => {
             const mappedSource = frame.location.mappedToSource();
-            return mappedSource ? mappedSource.source.isEquivalentTo(source) : false;
+            return mappedSource.source.isEquivalentTo(source);
         })
-            || (asyncStackTrace.parent ? this.isSourceInAsyncStack(asyncStackTrace.parent, source) : false);
+            || (isDefined(asyncStackTrace.parent) ? this.isSourceInAsyncStack(asyncStackTrace.parent, source) : false);
     }
 
     public async onPaused(pausedEvent: PausedEvent): Promise<IActionToTakeWhenPaused> {

--- a/src/chrome/internal/stackTraces/formatCallFrameDescription.ts
+++ b/src/chrome/internal/stackTraces/formatCallFrameDescription.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { LoadedSourceCallFrame, CallFrameWithState } from './callFrame';
 import { functionDescription } from './callFramePresentation';
+import { isDefined, isTrue } from '../../utils/typedOperators';
 
 /**
  * The clients can requests the stack traces frames descriptions in different formats.
@@ -16,12 +17,12 @@ export function formatCallFrameDescription(callFrame: LoadedSourceCallFrame<Call
 
     let formattedDescription = functionDescription(callFrame.codeFlow.functionName, location.source);
 
-    if (formatArgs) {
-        if (formatArgs.module) {
+    if (isDefined(formatArgs)) {
+        if (isTrue(formatArgs.module)) {
             formattedDescription += ` [${path.basename(location.source.identifier.textRepresentation)}]`;
         }
 
-        if (formatArgs.line) {
+        if (isTrue(formatArgs.line)) {
             formattedDescription += ` Line ${location.position.lineNumber}`;
         }
     }

--- a/src/chrome/internal/stackTraces/stackTracePresenter.ts
+++ b/src/chrome/internal/stackTraces/stackTracePresenter.ts
@@ -24,7 +24,7 @@ import { StackTraceLabel, CallFramePresentationHint, IStackTracePresentationRow 
 import { ConnectedCDAConfiguration } from '../../client/chromeDebugAdapter/cdaConfiguration';
 import { CurrentStackTraceProvider } from './currentStackTraceProvider';
 import { ICDTPDebuggeeExecutionEventsProvider } from '../../cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider';
-import _ = require('lodash');
+import * as _ from 'lodash';
 import { isDefined, isNotEmpty } from '../../utils/typedOperators';
 
 export interface IStackTracePresentationDetailsProvider {

--- a/src/chrome/internal/stackTraces/stackTracePresenter.ts
+++ b/src/chrome/internal/stackTraces/stackTracePresenter.ts
@@ -1,3 +1,4 @@
+
 /*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
@@ -24,6 +25,7 @@ import { ConnectedCDAConfiguration } from '../../client/chromeDebugAdapter/cdaCo
 import { CurrentStackTraceProvider } from './currentStackTraceProvider';
 import { ICDTPDebuggeeExecutionEventsProvider } from '../../cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider';
 import _ = require('lodash');
+import { isDefined, isNotEmpty } from '../../utils/typedOperators';
 
 export interface IStackTracePresentationDetailsProvider {
     callFrameAdditionalDetails(locationInLoadedSource: LocationInLoadedSource): ICallFramePresentationDetails[];
@@ -60,7 +62,7 @@ export class StackTracePresenter implements IInstallableComponent {
 
         const syncFrames: IStackTracePresentationRow[] = await this.syncCallFrames(format);
         const asyncStackTraceOrUndefined = this._currentStackStraceProvider.asyncStackTrace();
-        const asyncFrames = !!asyncStackTraceOrUndefined
+        const asyncFrames = isDefined(asyncStackTraceOrUndefined)
             ? await this.asyncCallFrames(asyncStackTraceOrUndefined, format)
             : [];
         const allStackFrames = syncFrames.concat(asyncFrames);
@@ -82,9 +84,9 @@ export class StackTracePresenter implements IInstallableComponent {
     private async asyncCallFrames(stackTrace: CodeFlowStackTrace, formatArgs?: IStackTraceFormat): Promise<IStackTracePresentationRow[]> {
         const thisSectionAsyncFrames = await asyncMap(stackTrace.codeFlowFrames,
             frame => this.toPresentation(this.codeFlowToCallFrame(frame), formatArgs));
-        const parentAsyncFrames = stackTrace.parent ? await this.asyncCallFrames(stackTrace.parent, formatArgs) : [];
+        const parentAsyncFrames = isDefined(stackTrace.parent) ? await this.asyncCallFrames(stackTrace.parent, formatArgs) : [];
 
-        return (stackTrace.description
+        return (isNotEmpty(stackTrace.description)
             ? [/* Description of this section of async frames */<IStackTracePresentationRow>new StackTraceLabel(stackTrace.description)]
             : [])
             .concat(thisSectionAsyncFrames, parentAsyncFrames);

--- a/src/chrome/internal/stackTraces/stackTraceRequestHandler.ts
+++ b/src/chrome/internal/stackTraces/stackTraceRequestHandler.ts
@@ -15,6 +15,7 @@ import { asyncMap } from '../../collections/async';
 import { RemoveProperty } from '../../../typeUtils';
 import { LocationInSourceToClientConverter } from '../../client/locationInSourceToClientConverter';
 import { LineColTransformer } from '../../../transformers/lineNumberTransformer';
+import { isDefined } from '../../utils/typedOperators';
 
 /**
  * Handles and responds to the stackTrace requests from the client
@@ -37,7 +38,7 @@ export class StackTraceRequestHandler implements ICommandHandlerDeclarer {
     }
 
     public async stackTrace(args: DebugProtocol.StackTraceArguments): Promise<IStackTraceResponseBody> {
-        const format = args.format
+        const format = isDefined(args.format)
             ? new StackTraceCustomFormat(args.format)
             : new StackTraceDefaultFormat();
 


### PR DESCRIPTION
Prepare to enable the strict boolean expressions from TSLint. Stop using non-boolean values as booleans.
(This change will be split among several PRs)

We are replacing the expressions flagged by the rule with: https://github.com/Microsoft/vscode-chrome-debug-core/blob/v2/src/chrome/utils/typedOperators.ts