### PR TITLE
TSLint - strict boolean expressions - 3

### DIFF
--- a/src/sourceMaps/sourceMap.ts
+++ b/src/sourceMaps/sourceMap.ts
@@ -16,6 +16,8 @@ import * as _ from 'lodash';
 import { IValidatedMap } from '../chrome/collections/validatedMap';
 import { Range } from '../chrome/internal/locations/rangeInScript';
 import { SetUsingProjection } from '../chrome/collections/setUsingProjection';
+import { isNotEmpty, isDefined } from '../chrome/utils/typedOperators';
+import isNull = require('lodash/isNull');
 
 export type MappedPosition = MappedPosition;
 
@@ -25,7 +27,7 @@ export type MappedPosition = MappedPosition;
 export interface ISourcePathDetails {
     originalPath: IResourceIdentifier;
     inferredPath: IResourceIdentifier;
-    startPosition: IGeneratedPosition;
+    startPosition: IGeneratedPosition | null;
 }
 
 export interface NonNullablePosition extends NullablePosition {
@@ -53,20 +55,27 @@ class SourcePathMappingCalculator {
         // is not always needed.
         return this._normalizedSourcesInOrder.map((inferredPath: IResourceIdentifier, i: number) => {
             const originalSource = this._originalSourcesInOrder[i];
-            const originalPath = this._originalSourceRoot
+            const originalPath = isNotEmpty(this._originalSourceRoot)
                 ? sourceMapUtils.getFullSourceEntry(this._originalSourceRoot, originalSource)
                 : originalSource;
+
+            let starPosition;
+            try {
+                starPosition = this._sourceMap.generatedPositionFor(inferredPath, 0, 0);
+            } catch {
+                starPosition = null;
+            }
             return <ISourcePathDetails>{
                 inferredPath,
                 originalPath,
-                startPosition: this._sourceMap.generatedPositionFor(inferredPath, 0, 0)
+                startPosition: starPosition
             };
         }).sort((a, b) => {
             // https://github.com/Microsoft/vscode-chrome-debug/issues/353
-            if (!a.startPosition) {
+            if (isNull(a.startPosition)) {
                 logger.log(`Could not map start position for: ${a.inferredPath}`);
                 return -1;
-            } else if (!b.startPosition) {
+            } else if (isNull(b.startPosition)) {
                 logger.log(`Could not map start position for: ${b.inferredPath}`);
                 return 1;
             }
@@ -102,11 +111,11 @@ export class SourceMap {
         const sourceMap: RawSourceMap = JSON.parse(json);
         logger.log(`SourceMap: creating for ${generatedPath}`);
         logger.log(`SourceMap: sourceRoot: ${sourceMap.sourceRoot}`);
-        if (sourceMap.sourceRoot && sourceMap.sourceRoot.toLowerCase() === '/source/') {
+        if (isNotEmpty(sourceMap.sourceRoot) && sourceMap.sourceRoot.toLowerCase() === '/source/') {
             logger.log('Warning: if you are using gulp-sourcemaps < 2.0 directly or indirectly, you may need to set sourceRoot manually in your build config, if your files are not actually under a directory called /source');
         }
         logger.log(`SourceMap: sources: ${JSON.stringify(sourceMap.sources)}`);
-        if (pathMapping) {
+        if (isDefined(pathMapping)) {
             logger.log(`SourceMap: pathMapping: ${JSON.stringify(pathMapping)}`);
         }
 
@@ -117,7 +126,7 @@ export class SourceMap {
         // resolve them to file:/// urls, using computedSourceRoot, to be simpler and unambiguous, since
         // it needs to look them up later in exactly the same format.
         const normalizedSources = sourceMap.sources.map(sourcePath => {
-            if (sourceMapPathOverrides) {
+            if (isDefined(sourceMapPathOverrides)) {
                 const fullSourceEntry = sourceMapUtils.getFullSourceEntry(sourceMap.sourceRoot, sourcePath);
                 const mappedFullSourceEntry = sourceMapUtils.applySourceMapPathOverrides(fullSourceEntry.textRepresentation, sourceMapPathOverrides, isVSClient);
                 if (fullSourceEntry.textRepresentation !== mappedFullSourceEntry) {
@@ -241,7 +250,7 @@ export class SourceMap {
         return validPositions.map(position => Range.acrossSingleLine(
             createLineNumber(position.line - 1), // Back to 0-indexed lines
             createColumnNumber(position.column),
-            createColumnNumber((position.lastColumn || position.column) + 1)) // position.lastColumn is inclusive and Range uses exclusive ranges, so we add 1
+            createColumnNumber(_.defaultTo(position.lastColumn, position.column) + 1)) // position.lastColumn is inclusive and Range uses exclusive ranges, so we add 1
         );
     }
 

--- a/src/sourceMaps/sourceMap.ts
+++ b/src/sourceMaps/sourceMap.ts
@@ -59,16 +59,16 @@ class SourcePathMappingCalculator {
                 ? sourceMapUtils.getFullSourceEntry(this._originalSourceRoot, originalSource)
                 : originalSource;
 
-            let starPosition;
+            let startPosition;
             try {
-                starPosition = this._sourceMap.generatedPositionFor(inferredPath, 0, 0);
+                startPosition = this._sourceMap.generatedPositionFor(inferredPath, 0, 0);
             } catch {
-                starPosition = null;
+                startPosition = null;
             }
             return <ISourcePathDetails>{
                 inferredPath,
                 originalPath,
-                startPosition: starPosition
+                startPosition: startPosition
             };
         }).sort((a, b) => {
             // https://github.com/Microsoft/vscode-chrome-debug/issues/353

--- a/src/sourceMaps/sourceMap.ts
+++ b/src/sourceMaps/sourceMap.ts
@@ -16,8 +16,7 @@ import * as _ from 'lodash';
 import { IValidatedMap } from '../chrome/collections/validatedMap';
 import { Range } from '../chrome/internal/locations/rangeInScript';
 import { SetUsingProjection } from '../chrome/collections/setUsingProjection';
-import { isNotEmpty, isDefined } from '../chrome/utils/typedOperators';
-import isNull = require('lodash/isNull');
+import { isNotEmpty, isDefined, isNull } from '../chrome/utils/typedOperators';
 
 export type MappedPosition = MappedPosition;
 

--- a/src/sourceMaps/sourceMapFactory.ts
+++ b/src/sourceMaps/sourceMapFactory.ts
@@ -13,7 +13,7 @@ import * as utils from '../utils';
 import { logger } from 'vscode-debugadapter';
 import { SourceMap } from './sourceMap';
 import { ISourceMapPathOverrides, IPathMapping } from '../debugAdapterInterfaces';
-import { isDefined, isNotNull, isNull, ifDefinedDo, isTrue } from '../chrome/utils/typedOperators';
+import { isDefined, isNotNull, isNull, isTrue } from '../chrome/utils/typedOperators';
 
 export class SourceMapFactory {
     constructor(
@@ -126,7 +126,7 @@ export class SourceMapFactory {
                         logger.log(`SourceMaps.loadSourceMapContents: Could not read sourcemap file - ` + err.message);
                         resolve(null);
                     } else {
-                        resolve(ifDefinedDo(data, data => data.toString()));
+                        resolve(isDefined(data) ? data.toString() : undefined);
                     }
                 });
             });

--- a/src/sourceMaps/sourceMapFactory.ts
+++ b/src/sourceMaps/sourceMapFactory.ts
@@ -13,6 +13,7 @@ import * as utils from '../utils';
 import { logger } from 'vscode-debugadapter';
 import { SourceMap } from './sourceMap';
 import { ISourceMapPathOverrides, IPathMapping } from '../debugAdapterInterfaces';
+import { isDefined, isNotNull, isNull, ifDefinedDo, isTrue } from '../chrome/utils/typedOperators';
 
 export class SourceMapFactory {
     constructor(
@@ -27,7 +28,7 @@ export class SourceMapFactory {
      */
     getMapForGeneratedPath(pathToGenerated: string, mapPath: string, isVSClient = false): Promise<SourceMap | null> {
         let msg = `SourceMaps.getMapForGeneratedPath: Finding SourceMap for ${pathToGenerated} by URI: ${mapPath}`;
-        if (this._pathMapping) {
+        if (isDefined(this._pathMapping)) {
             msg += ` and webRoot/pathMapping: ${JSON.stringify(this._pathMapping)}`;
         }
 
@@ -45,7 +46,7 @@ export class SourceMapFactory {
         }
 
         return sourceMapContentsP.then(async contents => {
-            if (contents) {
+            if (isNotNull(contents)) {
                 try {
                     // Throws for invalid JSON
                     return await SourceMap.create(pathToGenerated, contents, this._pathMapping, this._sourceMapPathOverrides, isVSClient);
@@ -91,12 +92,12 @@ export class SourceMapFactory {
      */
     private getSourceMapContent(pathToGenerated: string, mapPathArg: string): Promise<string | null> {
         const mapPath = sourceMapUtils.resolveMapPath(pathToGenerated, mapPathArg, this._pathMapping);
-        if (!mapPath) {
+        if (isNull(mapPath)) {
             return Promise.resolve(null);
         }
 
         return this.loadSourceMapContents(mapPath).then(contents => {
-            if (!contents) {
+            if (isNull(contents)) {
                 // Last ditch effort - just look for a .js.map next to the script
                 const mapPathNextToSource = pathToGenerated + '.map';
                 if (mapPathNextToSource !== mapPath) {
@@ -120,12 +121,12 @@ export class SourceMapFactory {
             mapPathOrURL = utils.canonicalizeUrl(mapPathOrURL);
             contentsP = new Promise((resolve) => {
                 logger.log(`SourceMaps.loadSourceMapContents: Reading local sourcemap file from ${mapPathOrURL}`);
-                fs.readFile(mapPathOrURL, (err, data) => {
-                    if (err) {
+                fs.readFile(mapPathOrURL, (err?: NodeJS.ErrnoException, data?: Buffer) => {
+                    if (isDefined(err)) {
                         logger.log(`SourceMaps.loadSourceMapContents: Could not read sourcemap file - ` + err.message);
                         resolve(null);
                     } else {
-                        resolve(data && data.toString());
+                        resolve(ifDefinedDo(data, data => data.toString()));
                     }
                 });
             });
@@ -150,7 +151,7 @@ export class SourceMapFactory {
     private async _downloadSourceMapContents(sourceMapUri: string): Promise<string | null> {
         // use sha256 to ensure the hash value can be used in filenames
         let cachedSourcemapPath: string | null = null;
-        if (this._enableSourceMapCaching) {
+        if (isTrue(this._enableSourceMapCaching)) {
             const hash = crypto.createHash('sha256').update(sourceMapUri).digest('hex');
 
             const cachePath = path.join(os.tmpdir(), 'com.microsoft.VSCode', 'node-debug2', 'sm-cache');
@@ -164,7 +165,7 @@ export class SourceMapFactory {
         }
 
         const responseText = await utils.getURL(sourceMapUri);
-        if (cachedSourcemapPath && this._enableSourceMapCaching) {
+        if (isNotNull(cachedSourcemapPath) && isTrue(this._enableSourceMapCaching)) {
             logger.log(`Sourcemaps.downloadSourceMapContents: Caching sourcemap file at ${cachedSourcemapPath}`);
             await utils.writeFileP(cachedSourcemapPath, responseText);
         }

--- a/src/sourceMaps/sourceMapUtils.ts
+++ b/src/sourceMaps/sourceMapUtils.ts
@@ -12,7 +12,7 @@ import { ISourceMapPathOverrides, IPathMapping } from '../debugAdapterInterfaces
 import { IResourceIdentifier } from '..';
 import { parseResourceIdentifier } from '../chrome/internal/sources/resourceIdentifier';
 import { isNotEmpty, hasNoMatches, isEmpty } from '../chrome/utils/typedOperators';
-import _ = require('lodash');
+import * as _ from 'lodash';
 
 /**
  * Resolves a relative path in terms of another file

--- a/src/sourceMaps/sourceMaps.ts
+++ b/src/sourceMaps/sourceMaps.ts
@@ -9,6 +9,7 @@ import { Position, LocationInLoadedSource, LocationInScript } from '../chrome/in
 import { createLineNumber, createColumnNumber } from '../chrome/internal/locations/subtypes';
 import { parseResourceIdentifier, IResourceIdentifier } from '../chrome/internal/sources/resourceIdentifier';
 import { CDTPScriptsRegistry } from '../chrome/cdtpDebuggee/registries/cdtpScriptsRegistry';
+import { isNotNull } from '../chrome/utils/typedOperators';
 
 export class SourceMaps {
     // Maps absolute paths to generated/authored source files to their corresponding SourceMap object
@@ -55,7 +56,7 @@ export class SourceMaps {
      */
     public async processNewSourceMap(pathToGenerated: string, sourceMapURL: string, isVSClient = false): Promise<SourceMap | null> {
         const sourceMap = await this._sourceMapFactory.getMapForGeneratedPath(pathToGenerated, sourceMapURL, isVSClient);
-        if (sourceMap) {
+        if (isNotNull(sourceMap)) {
             this._generatedPathToSourceMap.set(pathToGenerated.toLowerCase(), sourceMap);
             return sourceMap;
         } else {

--- a/src/transformers/basePathTransformer.ts
+++ b/src/transformers/basePathTransformer.ts
@@ -7,7 +7,7 @@ import { DebugProtocol } from 'vscode-debugprotocol';
 import { IResourceIdentifier } from '../chrome/internal/sources/resourceIdentifier';
 import { IStackTracePresentation } from '../chrome/internal/stackTraces/stackTracePresentation';
 import { injectable } from 'inversify';
-import _ = require('lodash');
+import * as _ from 'lodash';
 
 /**
  * Converts a local path from Code to a path on the target.

--- a/src/transformers/basePathTransformer.ts
+++ b/src/transformers/basePathTransformer.ts
@@ -7,6 +7,7 @@ import { DebugProtocol } from 'vscode-debugprotocol';
 import { IResourceIdentifier } from '../chrome/internal/sources/resourceIdentifier';
 import { IStackTracePresentation } from '../chrome/internal/stackTraces/stackTracePresentation';
 import { injectable } from 'inversify';
+import _ = require('lodash');
 
 /**
  * Converts a local path from Code to a path on the target.
@@ -23,7 +24,7 @@ export class BasePathTransformer {
     }
 
     public breakpointResolved(_bp: DebugProtocol.Breakpoint, targetPath: IResourceIdentifier): IResourceIdentifier {
-        return this.getClientPathFromTargetPath(targetPath) || targetPath;
+        return _.defaultTo(this.getClientPathFromTargetPath(targetPath), targetPath);
     }
 
     public stackTraceResponse(_response: IStackTracePresentation): void {

--- a/src/transformers/baseSourceMapTransformer.ts
+++ b/src/transformers/baseSourceMapTransformer.ts
@@ -17,7 +17,7 @@ import { IResourceIdentifier } from '..';
 import { LocationInLoadedSource } from '../chrome/internal/locations/location';
 import { CDTPScriptsRegistry } from '../chrome/cdtpDebuggee/registries/cdtpScriptsRegistry';
 import { isTrue, isDefined, isEmpty, isNotNull, isNull, isUndefined, isNotEmpty } from '../chrome/utils/typedOperators';
-import _ = require('lodash');
+import * as _ from 'lodash';
 
 export interface ISourceLocation {
     source: ILoadedSource;

--- a/src/transformers/configurationBasedPathTransformer.ts
+++ b/src/transformers/configurationBasedPathTransformer.ts
@@ -8,7 +8,7 @@ import { DebugProtocol } from 'vscode-debugprotocol';
 import { IStackTracePresentation } from '../chrome/internal/stackTraces/stackTracePresentation';
 import { IResourceIdentifier } from '../chrome/internal/sources/resourceIdentifier';
 import { isTrue } from '../chrome/utils/typedOperators';
-import _ = require('lodash');
+import * as _ from 'lodash';
 
 /**
  * We use this class to be able to choose between different path transformer classes based on the supportsMapURLToFilePathRequest parameter

--- a/src/transformers/configurationBasedPathTransformer.ts
+++ b/src/transformers/configurationBasedPathTransformer.ts
@@ -7,6 +7,8 @@ import { RemotePathTransformer } from './remotePathTransformer';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { IStackTracePresentation } from '../chrome/internal/stackTraces/stackTracePresentation';
 import { IResourceIdentifier } from '../chrome/internal/sources/resourceIdentifier';
+import { isTrue } from '../chrome/utils/typedOperators';
+import _ = require('lodash');
 
 /**
  * We use this class to be able to choose between different path transformer classes based on the supportsMapURLToFilePathRequest parameter
@@ -16,9 +18,9 @@ export class ConfigurationBasedPathTransformer extends BasePathTransformer {
 
     constructor(@inject(TYPES.ConnectedCDAConfiguration) private readonly configuration: IConnectedCDAConfiguration) {
         super();
-        const pathTransformerClass = this.configuration.clientCapabilities.supportsMapURLToFilePathRequest
+        const pathTransformerClass = isTrue(this.configuration.clientCapabilities.supportsMapURLToFilePathRequest)
             ? FallbackToClientPathTransformer
-            : this.configuration.extensibilityPoints.pathTransformer || RemotePathTransformer;
+            : _.defaultTo(this.configuration.extensibilityPoints.pathTransformer, RemotePathTransformer);
         this._pathTransformer = new pathTransformerClass(configuration);
     }
 

--- a/src/transformers/fallbackToClientPathTransformer.ts
+++ b/src/transformers/fallbackToClientPathTransformer.ts
@@ -9,6 +9,7 @@ import { IResourceIdentifier } from '../chrome/internal/sources/resourceIdentifi
 import { IConnectedCDAConfiguration } from '../chrome/client/chromeDebugAdapter/cdaConfiguration';
 import { inject } from 'inversify';
 import { TYPES } from '../chrome/dependencyInjection.ts/types';
+import { isNotEmpty } from '../chrome/utils/typedOperators';
 
 /**
  * Converts a local path from Code to a path on the target. Uses the UrlPathTransforme logic and fallbacks to asking the client if neccesary
@@ -28,7 +29,7 @@ export class FallbackToClientPathTransformer extends UrlPathTransformer {
         return super.targetUrlToClientPath(scriptUrl).then(filePath => {
                 // If it returns a valid non empty file path then that should be a valid result, so we use that
                 // If it's an eval script we won't be able to map it, so we also return that
-                return (filePath || ChromeUtils.isEvalScript(scriptUrl))
+                return (isNotEmpty(filePath.textRepresentation) || ChromeUtils.isEvalScript(scriptUrl))
                     ? filePath
                     // In any other case we ask the client to map it as a fallback, and return filePath if there is any failures
                     : this.requestClientToMapURLToFilePath(scriptUrl).catch(rejection => {

--- a/src/transformers/lineNumberTransformer.ts
+++ b/src/transformers/lineNumberTransformer.ts
@@ -8,6 +8,7 @@ import { IDebugTransformer, IScopesResponseBody, IStackTraceResponseBody } from 
 import { inject, injectable } from 'inversify';
 import { TYPES } from '../chrome/dependencyInjection.ts/types';
 import { ConnectedCDAConfiguration } from '../chrome/client/chromeDebugAdapter/cdaConfiguration';
+import { isTrue } from '../chrome/utils/typedOperators';
 
 /**
  * Converts from 1 based lines/cols on the client side to 0 based lines/cols on the target side
@@ -18,8 +19,8 @@ export class LineColTransformer implements IDebugTransformer {
     private _clientToDebuggerColumnsDifference: number; // Similar to line numbers
 
     constructor(@inject(TYPES.ConnectedCDAConfiguration) configuration: ConnectedCDAConfiguration) {
-        this._clientToDebuggerLineNumberDifference = configuration.clientCapabilities.linesStartAt1 ? 1 : 0;
-        this._clientToDebuggerColumnsDifference = configuration.clientCapabilities.columnsStartAt1 ? 1 : 0;
+        this._clientToDebuggerLineNumberDifference = isTrue(configuration.clientCapabilities.linesStartAt1) ? 1 : 0;
+        this._clientToDebuggerColumnsDifference = isTrue(configuration.clientCapabilities.columnsStartAt1) ? 1 : 0;
     }
 
     public stackTraceResponse(response: IStackTraceResponseBody): void {

--- a/src/transformers/remotePathTransformer.ts
+++ b/src/transformers/remotePathTransformer.ts
@@ -15,7 +15,7 @@ import { inject } from 'inversify';
 import { TYPES } from '../chrome/dependencyInjection.ts/types';
 import { IConnectedCDAConfiguration } from '../chrome/client/chromeDebugAdapter/cdaConfiguration';
 import { isNotEmpty, hasMatches } from '../chrome/utils/typedOperators';
-import _ = require('lodash');
+import * as _ from 'lodash';
 
 interface IRootsState {
     install(): Promise<void>;


### PR DESCRIPTION
Prepare to enable the strict boolean expressions from TSLint. Stop using non-boolean values as booleans.
(This change will be split among several PRs)

We are replacing the expressions flagged by the rule with: https://github.com/Microsoft/vscode-chrome-debug-core/blob/v2/src/chrome/utils/typedOperators.ts