### PR TITLE
TSLint - strict boolean expressions - 4

### DIFF
--- a/src/chrome/consoleHelper.ts
+++ b/src/chrome/consoleHelper.ts
@@ -8,9 +8,8 @@ import * as variables from './variables';
 import { CodeFlowStackTrace } from './internal/stackTraces/codeFlowStackTrace';
 import { IExceptionDetails } from './cdtpDebuggee/eventsProviders/cdtpExceptionThrownEventsProvider';
 import { functionDescription } from './internal/stackTraces/callFramePresentation';
-import isUndefined = require('lodash/isUndefined');
 import * as _ from 'lodash';
-import { isNotEmpty, isFalse, isDefined } from './utils/typedOperators';
+import { isNotEmpty, isFalse, isDefined, isUndefined } from './utils/typedOperators';
 
 export function formatExceptionDetails(e: IExceptionDetails): string {
     if (isUndefined(e.exception)) {

--- a/src/chrome/consoleHelper.ts
+++ b/src/chrome/consoleHelper.ts
@@ -126,7 +126,7 @@ function resolveParams(args: CDTP.Runtime.RemoteObject[], skipFormatSpecifiers?:
             // `formatted` is an object - split currentCollapsedStringArg around the current formatSpec and add the object
             const curSpecIdx = currentCollapsedStringArg.indexOf('%' + formatSpec);
             const processedPart = currentCollapsedStringArg.slice(0, curSpecIdx);
-            if (processedPart !== '') {
+            if (isNotEmpty(processedPart)) {
                 pushStringArg(processedPart);
             }
 

--- a/src/chrome/consoleHelper.ts
+++ b/src/chrome/consoleHelper.ts
@@ -9,7 +9,7 @@ import { CodeFlowStackTrace } from './internal/stackTraces/codeFlowStackTrace';
 import { IExceptionDetails } from './cdtpDebuggee/eventsProviders/cdtpExceptionThrownEventsProvider';
 import { functionDescription } from './internal/stackTraces/callFramePresentation';
 import isUndefined = require('lodash/isUndefined');
-import _ = require('lodash');
+import * as _ from 'lodash';
 import { isNotEmpty, isFalse, isDefined } from './utils/typedOperators';
 
 export function formatExceptionDetails(e: IExceptionDetails): string {

--- a/src/chrome/dependencyInjection.ts/bind.ts
+++ b/src/chrome/dependencyInjection.ts/bind.ts
@@ -38,6 +38,7 @@ import { ConnectingCDA } from '../client/chromeDebugAdapter/connectingCDA';
 import { ConnectedCDA } from '../client/chromeDebugAdapter/connectedCDA';
 import { SupportedDomains } from '../internal/domains/supportedDomains';
 import { TerminatingCDA } from '../client/chromeDebugAdapter/terminatingCDA';
+import { isDefined } from '../utils/typedOperators';
 
 // TODO: This file needs a lot of work. We need to improve/simplify all this code when possible
 interface IHasContainerName {
@@ -97,7 +98,7 @@ export function createWrapWithLoggerActivator<T extends object>(configuration: M
     return (_context: interfaces.Context, injectable: object) => {
         (<IHasContainerName>injectable).__containerName = configuration.containerName;
         const objectWithLogging = wrapWithLogging(configuration, injectable, `${configuration.containerName}.${getName(serviceIdentifier)}`);
-        const possibleOverwrittenComponent = callback
+        const possibleOverwrittenComponent = isDefined(callback)
             ? callback(serviceIdentifier, objectWithLogging, identifier => _context.container.get(identifier))
             : objectWithLogging;
         if (objectWithLogging === possibleOverwrittenComponent) {

--- a/src/chrome/internal/stackTraces/stackTracePresenter.ts
+++ b/src/chrome/internal/stackTraces/stackTracePresenter.ts
@@ -23,7 +23,7 @@ import { StackTraceLabel, CallFramePresentationHint, IStackTracePresentationRow 
 import { ConnectedCDAConfiguration } from '../../client/chromeDebugAdapter/cdaConfiguration';
 import { CurrentStackTraceProvider } from './currentStackTraceProvider';
 import { ICDTPDebuggeeExecutionEventsProvider } from '../../cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider';
-import _ = require('lodash');
+import * as _ from 'lodash';
 
 export interface IStackTracePresentationDetailsProvider {
     callFrameAdditionalDetails(locationInLoadedSource: LocationInLoadedSource): ICallFramePresentationDetails[];

--- a/src/chrome/internalSourceBreakpoint.ts
+++ b/src/chrome/internalSourceBreakpoint.ts
@@ -6,6 +6,7 @@ import { DebugProtocol } from 'vscode-debugprotocol';
 import { CodeFlowStackTrace } from './internal/stackTraces/codeFlowStackTrace';
 import { parseResourceIdentifier } from './internal/sources/resourceIdentifier';
 import { createCDTPScriptUrl } from './internal/sources/resourceIdentifierSubtypes';
+import { isNotEmpty, isNotNull } from './utils/typedOperators';
 
 export class InternalSourceBreakpoint {
     static readonly LOGPOINT_URL = 'vscode.logpoint.js';
@@ -20,19 +21,19 @@ export class InternalSourceBreakpoint {
         this.column = breakpoint.column;
         this.hitCondition = breakpoint.hitCondition;
 
-        if (breakpoint.logMessage) {
+        if (isNotEmpty(breakpoint.logMessage)) {
             this.condition = logMessageToExpression(breakpoint.logMessage);
-            if (breakpoint.condition) {
+            if (isNotEmpty(breakpoint.condition)) {
                 this.condition = `(${breakpoint.condition}) && ${this.condition}`;
             }
-        } else if (breakpoint.condition) {
+        } else if (isNotEmpty(breakpoint.condition)) {
             this.condition = breakpoint.condition;
         }
     }
 }
 
 function isLogpointStack(stackTrace: CodeFlowStackTrace | null): boolean {
-    return !!stackTrace && stackTrace.codeFlowFrames.length > 0
+    return isNotNull(stackTrace) && stackTrace.codeFlowFrames.length > 0
     && stackTrace.codeFlowFrames[0].script.runtimeSource.identifier.isEquivalentTo(parseResourceIdentifier(createCDTPScriptUrl(InternalSourceBreakpoint.LOGPOINT_URL)));
 }
 
@@ -65,6 +66,6 @@ function logMessageToExpression(msg: string): string {
 
     format = format.replace('\'', '\\\'');
 
-    const argStr = args.length ? `, ${args.join(', ')}` : '';
+    const argStr = args.length > 0 ? `, ${args.join(', ')}` : '';
     return `console.log('${format}'${argStr});\n//# sourceURL=${InternalSourceBreakpoint.LOGPOINT_URL}`;
 }

--- a/src/chrome/logging/methodsCalledLogger.ts
+++ b/src/chrome/logging/methodsCalledLogger.ts
@@ -4,6 +4,7 @@
 import * as _ from 'lodash';
 import { printTopLevelObjectDescription } from './printObjectDescription';
 import { logger } from 'vscode-debugadapter';
+import { isDefined } from '../utils/typedOperators';
 
 enum Synchronicity {
     Sync,
@@ -124,7 +125,7 @@ export class MethodsCalledLogger<T extends object> {
     }
 
     private logCall(propertyKey: PropertyKey, synchronicity: Synchronicity, methodCallArguments: any[], outcome: Outcome, resultOrException: unknown, callId?: number): void {
-        const endPrefix = callId ? `END   ${callId}: ` : '';
+        const endPrefix = isDefined(callId) ? `END   ${callId}: ` : '';
         const message = `${endPrefix}${this.printMethodCall(propertyKey, methodCallArguments)} ${this.printMethodSynchronicity(synchronicity)}  ${this.printMethodResponse(outcome, resultOrException)}`;
         logger.verbose(message);
     }

--- a/src/chrome/logging/printObjectDescription.ts
+++ b/src/chrome/logging/printObjectDescription.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import { isNotEmpty } from '../utils/typedOperators';
 
 export function printTopLevelObjectDescription(objectToPrint: unknown) {
     return printObjectDescription(objectToPrint, printFirstLevelProperties);
@@ -6,7 +7,7 @@ export function printTopLevelObjectDescription(objectToPrint: unknown) {
 
 export function printObjectDescription(objectToPrint: unknown, fallbackPrintDescription = (obj: unknown) => `${obj}`) {
     let printed = `<logic to print this object doesn't exist>`;
-    if (!objectToPrint) {
+    if (objectToPrint === null || objectToPrint === undefined) {
         printed = `${objectToPrint}`;
     } else if (typeof objectToPrint === 'object') {
         // Proxies throw an exception when toString is called, so we need to check this first
@@ -17,7 +18,7 @@ export function printObjectDescription(objectToPrint: unknown, fallbackPrintDesc
             // This if is actually unnecesary, the previous if (!objectToPrint) { does the same thing. For some reason the typescript compiler cannot infer the type from that if
             // so we just write this code to leave the compiler happy
             // TODO: Sync with the typescript team and figure out how to remove this
-            if (!objectToPrint) {
+            if (objectToPrint === null) {
                 printed = `${objectToPrint}`;
             } else {
                 const toString = objectToPrint.toString();
@@ -30,10 +31,10 @@ export function printObjectDescription(objectToPrint: unknown, fallbackPrintDesc
                 } else {
                     printed = `${objectToPrint}(${objectToPrint.constructor.name})`;
                 }
-                }
+            }
         }
     } else if (typeof objectToPrint === 'function') {
-        if (objectToPrint.name) {
+        if (isNotEmpty(objectToPrint.name)) {
             printed = objectToPrint.name;
         } else {
             const functionSourceCode = objectToPrint.toString();

--- a/src/chrome/stoppedEvent.ts
+++ b/src/chrome/stoppedEvent.ts
@@ -9,13 +9,14 @@ import { Protocol as CDTP } from 'devtools-protocol';
 import * as utils from '../utils';
 
 import * as nls from 'vscode-nls';
+import { isDefined, isNotEmpty } from './utils/typedOperators';
 const localize = nls.loadMessageBundle();
 
 export type ReasonType = 'step' | 'breakpoint' | 'exception' | 'pause' | 'entry' | 'debugger_statement' | 'frame_entry' | 'promise_rejection';
 
 export class StoppedEvent2 extends StoppedEvent {
     constructor(reason: ReasonType, threadId: number, exception?: CDTP.Runtime.RemoteObject) {
-        const exceptionText = exception && exception.description && utils.firstLine(exception.description);
+        const exceptionText = isDefined(exception) && isNotEmpty(exception.description) ? utils.firstLine(exception.description) : undefined;
         super(reason, threadId, exceptionText);
 
         switch (reason) {
@@ -26,7 +27,7 @@ export class StoppedEvent2 extends StoppedEvent {
                 (<DebugProtocol.StoppedEvent>this).body.description = localize('reason.description.breakpoint', 'Paused on breakpoint');
                 break;
             case 'exception':
-                const uncaught = exception && (<any>exception).uncaught; // Currently undocumented
+                const uncaught = isDefined(exception) && (<any>exception).uncaught; // Currently undocumented
                 if (typeof uncaught === 'undefined') {
                     (<DebugProtocol.StoppedEvent>this).body.description = localize('reason.description.exception', 'Paused on exception');
                 } else if (uncaught) {

--- a/src/chrome/utils/namespaceReverseLookupCreator.ts
+++ b/src/chrome/utils/namespaceReverseLookupCreator.ts
@@ -1,3 +1,5 @@
+import { isNotEmpty } from './typedOperators';
+
 /*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
@@ -22,7 +24,7 @@ export class NamespaceReverseLookupCreator<T> {
 
     private exploreLeaf(currentRoot: NamespaceTree<T>, namePrefix: string): void {
         for (const propertyNamme in currentRoot) {
-            const propertyName = namePrefix ? `${namePrefix}.${propertyNamme}` : propertyNamme;
+            const propertyName = isNotEmpty(namePrefix) ? `${namePrefix}.${propertyNamme}` : propertyNamme;
             const propertyValue = currentRoot[propertyNamme];
             if (this._isLeaf(propertyValue)) {
                 this._leafToNameMapping.set(propertyValue as T, propertyName);

--- a/src/chrome/utils/printing.ts
+++ b/src/chrome/utils/printing.ts
@@ -1,5 +1,7 @@
+import { isNotEmpty } from './typedOperators';
+
 function _printClassDescription(this: Function): string {
-    return this.name ? `class ${this.name}` : Function.toString.call(this);
+    return isNotEmpty(this.name) ? `class ${this.name}` : Function.toString.call(this);
 }
 
 export function printClassDescription(functionConstructor: Function) {

--- a/src/chrome/variables.ts
+++ b/src/chrome/variables.ts
@@ -11,7 +11,7 @@ import * as utils from '../utils';
 import { LoadedSourceCallFrame, CallFrameWithState } from './internal/stackTraces/callFrame';
 import { CDTPNonPrimitiveRemoteObject, validateNonPrimitiveRemoteObject } from './cdtpDebuggee/cdtpPrimitives';
 import { isDefined, isUndefined, hasMatches, isNotEmpty, isTrue } from './utils/typedOperators';
-import _ = require('lodash');
+import * as _ from 'lodash';
 
 export interface IVariableContainer {
     expand(adapter: ChromeDebugLogic, filter?: string, start?: number, count?: number): Promise<DebugProtocol.Variable[]>;

--- a/src/executionTimingsReporter.ts
+++ b/src/executionTimingsReporter.ts
@@ -5,7 +5,7 @@
 import { HighResTimer, calculateElapsedTime } from './utils';
 import { EventEmitter } from 'events';
 import { notNullNorUndefinedElements } from './validation';
-import _ = require('lodash');
+import * as _ from 'lodash';
 
 export type TimingsReport = {[stepName: string]: [number] | number};
 

--- a/src/executionTimingsReporter.ts
+++ b/src/executionTimingsReporter.ts
@@ -5,6 +5,7 @@
 import { HighResTimer, calculateElapsedTime } from './utils';
 import { EventEmitter } from 'events';
 import { notNullNorUndefinedElements } from './validation';
+import _ = require('lodash');
 
 export type TimingsReport = {[stepName: string]: [number] | number};
 
@@ -193,8 +194,8 @@ export class ExecutionTimingsReporter {
         this.addElementToArrayProperty(this._requestProperties, propertyPrefix + 'timeTakenInMilliseconds', timeTakenInMilliseconds);
     }
 
-    private addElementToArrayProperty<T>(object: {[propertyName: string]: T[]}, propertyName: string, elementToAdd: T): void {
-        const propertiesArray = object[propertyName] = object[propertyName] || [] as T[];
+    private addElementToArrayProperty<T>(object: {[propertyName: string]: T[] | undefined}, propertyName: string, elementToAdd: T): void {
+        const propertiesArray = object[propertyName] = _.defaultTo(object[propertyName], [] as T[]);
         propertiesArray.push(elementToAdd);
     }
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -5,6 +5,7 @@
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { OutputEvent } from 'vscode-debugadapter';
 import { fillErrorDetails } from './utils';
+import { isDefined } from './chrome/utils/typedOperators';
 
 /* __GDPR__FRAGMENT__
    "IExecutionResultTelemetryProperties" : {
@@ -43,7 +44,7 @@ export class TelemetryReporter implements ITelemetryReporter {
     private _globalTelemetryProperties: any = {};
 
     reportEvent(name: string, data?: any): void {
-        if (this._sendEvent) {
+        if (isDefined(this._sendEvent)) {
             const combinedData = Object.assign({}, this._globalTelemetryProperties, data);
             const event = new OutputEvent(name, 'telemetry', combinedData);
             this._sendEvent(event);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -216,7 +216,7 @@ export function fixDriveLetter(aPath: string, uppercaseDriveLetter = false): str
             'file:///' +
             aPath[prefixLen].toLowerCase() +
             aPath.substr(prefixLen + 1);
-    } else if (aPath.match(/^[A-Za-z]:/) !== null) {
+    } else if (hasMatches(aPath.match(/^[A-Za-z]:/))) {
         // If the path starts with a drive letter, ensure lowercase. VS Code uses a lowercase drive letter
         const driveLetter = uppercaseDriveLetter ? aPath[0].toUpperCase() : aPath[0].toLowerCase();
         aPath = driveLetter + aPath.substr(1);
@@ -457,7 +457,7 @@ export function pathToRegex(aPath: string, guid = ''): string {
         aPath = escapeRegexSpecialChars(fileUrlPrefix) + aPath;
     }
 
-    if (guid !== '') {
+    if (isNotEmpty(guid)) {
         // Add a guid to the regexp to make it unique, without modifying what it matches. This will allow us to add duplicated breakpoints using CDTP
         aPath = aPath + `(?:${guid}){0}`;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -239,11 +239,11 @@ export function stripTrailingSlash(aPath: string): string {
  * when passing on a failure from a Promise error handler.
  * @param msg - Should be either a string or an Error
  */
-export function errP(msg?: string | Error): Promise<never> {
+export function errP(msg?: string): Promise<never> {
     const isErrorLike = (thing: any): thing is Error => !!thing.message;
 
     let e: Error;
-    if (msg === undefined) {
+    if (isEmpty(msg)) {
         e = new Error('Unknown error');
     } else if (isErrorLike(msg)) {
         // msg is already an Error object

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,6 +13,9 @@ import * as https from 'https';
 
 import { IExecutionResultTelemetryProperties } from './telemetry';
 import { ValidatedSet } from './chrome/collections/validatedSet';
+import { promisify } from 'util';
+import { isDefined, hasMatches, hasNoMatches, isNotEmpty, isTrue, isEmpty } from './chrome/utils/typedOperators';
+import _ = require('lodash');
 
 export interface IStringDictionary<T> {
     [name: string]: T;
@@ -48,8 +51,8 @@ export function existsSync(path: string): boolean {
 export function existsAsync(path: string): Promise<boolean> {
     return new Promise((resolve) => {
         try {
-            fs.access(path, (err) => {
-                resolve(err ? false : true);
+            fs.access(path, (err?: NodeJS.ErrnoException) => {
+                resolve(isDefined(err) ? false : true);
             });
         } catch (e) {
             resolve(false);
@@ -73,12 +76,12 @@ export function promiseTimeout(p?: Promise<any>, timeoutMs = 1000, timeoutMsg?: 
     }
 
     return new Promise((resolve, reject) => {
-        if (p) {
+        if (isDefined(p)) {
             p.then(resolve, reject);
         }
 
         setTimeout(() => {
-            if (p) {
+            if (isDefined(p)) {
                 reject(new Error(timeoutMsg));
             } else {
                 resolve();
@@ -142,7 +145,7 @@ function normalizeIfFSIsCaseInsensitive(urlOrPath: string): string {
 }
 
 function isWindowsFilePath(candidate: string): boolean {
-    return !!candidate.match(/[A-z]:[\\\/][^\\\/]/);
+    return hasMatches(candidate.match(/[A-z]:[\\\/][^\\\/]/));
 }
 
 export function isFileUrl(candidate: string): boolean {
@@ -156,7 +159,7 @@ export function fileUrlToPath(urlOrPath: string): string {
     if (isFileUrl(urlOrPath)) {
         urlOrPath = urlOrPath.replace('file:///', '');
         urlOrPath = decodeURIComponent(urlOrPath);
-        if (urlOrPath[0] !== '/' && !urlOrPath.match(/^[A-Za-z]:/)) {
+        if (urlOrPath[0] !== '/' && hasNoMatches(urlOrPath.match(/^[A-Za-z]:/))) {
             // If it has a : before the first /, assume it's a windows path or url.
             // Ensure unix-style path starts with /, it can be removed when file:/// was stripped.
             // Don't add if the url still has a protocol
@@ -193,15 +196,13 @@ export function forceForwardSlashes(aUrl: string): string {
  * Ensure lower case drive letter and \ on Windows
  */
 export function fixDriveLetterAndSlashes(aPath: string, uppercaseDriveLetter = false): string {
-    if (!aPath) return aPath;
-
     aPath = fixDriveLetter(aPath, uppercaseDriveLetter);
-    if (aPath.match(/file:\/\/\/[A-Za-z]:/)) {
+    if (hasMatches(aPath.match(/file:\/\/\/[A-Za-z]:/))) {
         const prefixLen = 'file:///'.length;
         aPath =
             aPath.substr(0, prefixLen + 1) +
             aPath.substr(prefixLen + 1).replace(/\//g, '\\');
-    } else if (aPath.match(/^[A-Za-z]:/)) {
+    } else if (hasMatches(aPath.match(/^[A-Za-z]:/))) {
         aPath = aPath.replace(/\//g, '\\');
     }
 
@@ -209,15 +210,13 @@ export function fixDriveLetterAndSlashes(aPath: string, uppercaseDriveLetter = f
 }
 
 export function fixDriveLetter(aPath: string, uppercaseDriveLetter = false): string {
-    if (!aPath) return aPath;
-
-    if (aPath.match(/file:\/\/\/[A-Za-z]:/)) {
+    if (hasMatches(aPath.match(/file:\/\/\/[A-Za-z]:/))) {
         const prefixLen = 'file:///'.length;
         aPath =
             'file:///' +
             aPath[prefixLen].toLowerCase() +
             aPath.substr(prefixLen + 1);
-    } else if (aPath.match(/^[A-Za-z]:/)) {
+    } else if (aPath.match(/^[A-Za-z]:/) !== null) {
         // If the path starts with a drive letter, ensure lowercase. VS Code uses a lowercase drive letter
         const driveLetter = uppercaseDriveLetter ? aPath[0].toUpperCase() : aPath[0].toLowerCase();
         aPath = driveLetter + aPath.substr(1);
@@ -240,11 +239,11 @@ export function stripTrailingSlash(aPath: string): string {
  * when passing on a failure from a Promise error handler.
  * @param msg - Should be either a string or an Error
  */
-export function errP(msg: string | Error): Promise<never> {
+export function errP(msg?: string | Error): Promise<never> {
     const isErrorLike = (thing: any): thing is Error => !!thing.message;
 
     let e: Error;
-    if (!msg) {
+    if (msg === undefined) {
         e = new Error('Unknown error');
     } else if (isErrorLike(msg)) {
         // msg is already an Error object
@@ -291,8 +290,9 @@ export function getURL(aUrl: string, options: https.RequestOptions = {}): Promis
 /**
  * Returns true if urlOrPath is like "http://localhost" and not like "c:/code/file.js" or "/code/file.js"
  */
-export function isURL(urlOrPath: string): boolean {
-    return !!urlOrPath && !path.isAbsolute(urlOrPath) && !!url.parse(urlOrPath).protocol;
+export function isURL(urlOrPath?: string): boolean {
+    // Warning: url.parse(urlOrPath).protocol typing is wrong and it can actually be null
+    return isNotEmpty(urlOrPath) && !path.isAbsolute(urlOrPath) && isNotEmpty(url.parse(urlOrPath).protocol);
 }
 
 export function isAbsolute(_path: string): boolean {
@@ -316,7 +316,7 @@ export function lstrip(s: string, lStr: string): string {
  */
 export function pathToFileURL(_absPath: string, normalize?: boolean): string {
     let absPath = forceForwardSlashes(_absPath);
-    if (normalize) {
+    if (isTrue(normalize)) {
         absPath = path.normalize(absPath);
         absPath = forceForwardSlashes(absPath);
     }
@@ -330,40 +330,16 @@ export function pathToFileURL(_absPath: string, normalize?: boolean): string {
 }
 
 export function fsReadDirP(path: string): Promise<string[]> {
-    return new Promise((resolve, reject) => {
-        fs.readdir(path, (err, files) => {
-            if (err) {
-                reject(err);
-            } else {
-                resolve(files);
-            }
-        });
-    });
+    return promisify(fs.readdir)(path);
 }
 
 export function readFileP(path: string, encoding = 'utf8'): Promise<string> {
-    return new Promise((resolve, reject) => {
-        fs.readFile(path, encoding, (err, fileContents) => {
-            if (err) {
-                reject(err);
-            } else {
-                resolve(fileContents);
-            }
-        });
-    });
+    return promisify(fs.readFile)(path, encoding);
 }
 
-export function writeFileP(filePath: string, data: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-        mkdirs(path.dirname(filePath));
-        fs.writeFile(filePath, data, err => {
-            if (err) {
-                reject(err);
-            } else {
-                resolve(data);
-            }
-        });
-    });
+export async function writeFileP(filePath: string, data: string): Promise<void> {
+    await mkdirs(path.dirname(filePath));
+    return promisify(fs.writeFile)(filePath, data);
 }
 
 /**
@@ -429,15 +405,7 @@ export function multiGlob(patterns: string[], opts?: any): Promise<string[]> {
     }
 
     return Promise.all(globTasks.map(task => {
-        return new Promise<string[]>((c, e) => {
-            glob(task.pattern, task.opts, (err, files: string[]) => {
-                if (err) {
-                    e(err);
-                } else {
-                    c(files);
-                }
-            });
-        });
+        return promisify(glob)(task.pattern, task.opts);
     })).then(results => {
         const set = new Set<string>();
         for (let paths of results) {
@@ -489,7 +457,7 @@ export function pathToRegex(aPath: string, guid = ''): string {
         aPath = escapeRegexSpecialChars(fileUrlPrefix) + aPath;
     }
 
-    if (guid) {
+    if (guid !== '') {
         // Add a guid to the regexp to make it unique, without modifying what it matches. This will allow us to add duplicated breakpoints using CDTP
         aPath = aPath + `(?:${guid}){0}`;
     }
@@ -514,7 +482,7 @@ const regexChars = '/\\.?*()^${}|[]+';
 export function escapeRegexSpecialChars(str: string, except?: string): string {
     const useRegexChars = regexChars
         .split('')
-        .filter(c => !except || except.indexOf(c) < 0)
+        .filter(c => isEmpty(except) || except.indexOf(c) < 0)
         .join('')
         .replace(/[\\\]]/g, '\\$&');
 
@@ -563,7 +531,7 @@ export function getLine(msg: string, n = 0): string {
 }
 
 export function firstLine(msg: string | undefined): string {
-    return getLine(msg || '');
+    return getLine(_.defaultTo(msg, ''));
 }
 
 export function isNumber(num: any): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,7 @@ import { IExecutionResultTelemetryProperties } from './telemetry';
 import { ValidatedSet } from './chrome/collections/validatedSet';
 import { promisify } from 'util';
 import { isDefined, hasMatches, hasNoMatches, isNotEmpty, isTrue, isEmpty } from './chrome/utils/typedOperators';
-import _ = require('lodash');
+import * as _ from 'lodash';
 
 export interface IStringDictionary<T> {
     [name: string]: T;


### PR DESCRIPTION
Prepare to enable the strict boolean expressions from TSLint. Stop using non-boolean values as booleans.
(This change will be split among several PRs)

We are replacing the expressions flagged by the rule with: https://github.com/Microsoft/vscode-chrome-debug-core/blob/v2/src/chrome/utils/typedOperators.ts