### PR TITLE
TSLint - strict boolean expressions - 5

### DIFF
--- a/src/chrome/client/clientSourceParser.ts
+++ b/src/chrome/client/clientSourceParser.ts
@@ -4,6 +4,7 @@ import { HandlesRegistry } from './handlesRegistry';
 import { ILoadedSource } from '../internal/sources/loadedSource';
 import { parseResourceIdentifier } from '../internal/sources/resourceIdentifier';
 import { SourceResolver } from '../internal/sources/sourceResolver';
+import { isNotEmpty, isUndefined, isDefined } from '../utils/typedOperators';
 
 /**
  * Class used to parse a source of the VS Code protocol into the internal source model
@@ -14,10 +15,10 @@ export class ClientSourceParser {
         private readonly _sourceResolver: SourceResolver) { }
 
     public toSource(clientSource: DebugProtocol.Source): ISource {
-        if (clientSource.path && !clientSource.sourceReference) {
+        if (isNotEmpty(clientSource.path) && isUndefined(clientSource.sourceReference)) {
             const identifier = parseResourceIdentifier(clientSource.path);
             return this._sourceResolver.createUnresolvedSource(identifier);
-        } else if (clientSource.sourceReference) {
+        } else if (isDefined(clientSource.sourceReference)) {
             const source = this.getSourceFromId(clientSource.sourceReference);
             return new SourceAlreadyResolvedToLoadedSource(source);
         } else {

--- a/src/chrome/client/eventsToClientReporter.ts
+++ b/src/chrome/client/eventsToClientReporter.ts
@@ -21,6 +21,7 @@ import { SourceToClientConverter } from './sourceToClientConverter';
 import { BPRecipieStatusToClientConverter } from '../internal/breakpoints/features/bpRecipieStatusToClientConverter';
 import { ConnectedCDAConfiguration } from './chromeDebugAdapter/cdaConfiguration';
 import { LineColTransformer } from '../../transformers/lineNumberTransformer';
+import { isDefined } from '../utils/typedOperators';
 
 export interface IOutputParameters {
     readonly output: string;
@@ -79,11 +80,11 @@ export class EventsToClientReporter implements IEventsToClientReporter {
     public async sendOutput(params: IOutputParameters) {
         const event = new OutputEvent(params.output, params.category) as DebugProtocol.OutputEvent;
 
-        if (params.variablesReference) {
+        if (isDefined(params.variablesReference)) {
             event.body.variablesReference = params.variablesReference;
         }
 
-        if (params.location) {
+        if (isDefined(params.location)) {
             await this._locationInSourceToClientConverter.toLocationInSource(params.location, event.body);
         }
 

--- a/src/chrome/collections/bidirectionalMap.ts
+++ b/src/chrome/collections/bidirectionalMap.ts
@@ -6,6 +6,7 @@ import * as assert from 'assert';
 import { ValidatedMap } from './validatedMap';
 import { printMap } from './printing';
 import { breakWhileDebugging } from '../../validation';
+import { isDefined } from '../utils/typedOperators';
 
 /** A map where we can efficiently get the key from the value or the value from the key */
 export class BidirectionalMap<Left, Right> {
@@ -13,7 +14,7 @@ export class BidirectionalMap<Left, Right> {
     private readonly _rightToLeft = new ValidatedMap<Right, Left>();
 
     constructor(initialContents?: Iterable<[Left, Right]> | ReadonlyArray<[Left, Right]>) {
-        this._leftToRight = initialContents ? new ValidatedMap<Left, Right>(initialContents) :  new ValidatedMap<Left, Right>();
+        this._leftToRight = isDefined(initialContents) ? new ValidatedMap<Left, Right>(initialContents) :  new ValidatedMap<Left, Right>();
         const reversed = Array.from(this._leftToRight.entries()).map(e => <[Right, Left]>[e[1], e[0]]);
         this._rightToLeft = new ValidatedMap<Right, Left>(reversed);
     }

--- a/src/chrome/collections/mapUsingProjection.ts
+++ b/src/chrome/collections/mapUsingProjection.ts
@@ -5,6 +5,7 @@
 import { ValidatedMap, IValidatedMap, ValueComparerFunction } from './validatedMap';
 import { IProjection } from './setUsingProjection';
 import { printMap } from './printing';
+import * as _ from 'lodash';
 
 class KeyAndValue<K, V> {
     constructor(public readonly key: K, public readonly value: V) { }
@@ -19,7 +20,7 @@ export class MapUsingProjection<K, V, P> implements IValidatedMap<K, V> {
     private readonly _projectionToKeyAndvalue: IValidatedMap<P, KeyAndValue<K, V>>;
 
     constructor(private _projection: IProjection<K, P>, readonly initialContents?: Map<K, V> | Iterable<[K, V]> | ReadonlyArray<[K, V]>) {
-        const entries = Array.from(initialContents || []).map<[P, KeyAndValue<K, V>]>(pair => {
+        const entries = Array.from(_.defaultTo(initialContents, [])).map<[P, KeyAndValue<K, V>]>(pair => {
             const projected = this._projection(pair[0]);
             return [projected, new KeyAndValue(pair[0], pair[1])];
         });

--- a/src/chrome/collections/printing.ts
+++ b/src/chrome/collections/printing.ts
@@ -1,3 +1,5 @@
+import { isNotEmpty } from '../utils/typedOperators';
+
 /*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
@@ -15,7 +17,7 @@ export function printSet<T>(typeDescription: string, set: Set<T>): string {
 
 export function printArray<T>(typeDescription: string, elements: T[]): string {
     const elementsPrinted = printElements(elements, ', ');
-    return typeDescription ? `${typeDescription} [ ${elementsPrinted} ]` : `[ ${elementsPrinted} ]`;
+    return isNotEmpty(typeDescription) ? `${typeDescription} [ ${elementsPrinted} ]` : `[ ${elementsPrinted} ]`;
 }
 
 export function printIterable<T>(typeDescription: string, iterable: IterableIterator<T>): string {

--- a/src/chrome/collections/validatedMap.ts
+++ b/src/chrome/collections/validatedMap.ts
@@ -144,7 +144,7 @@ export class ValidatedMap<K, V> implements IValidatedMap<K, V> {
 
     // TODO: Remove the use of undefined
     public tryGetting(key: K): V | undefined {
-        return this._wrappedMap.get(key) || undefined;
+        return this._wrappedMap.get(key);
     }
 
     public toString(): string {

--- a/src/chrome/collections/validatedSet.ts
+++ b/src/chrome/collections/validatedSet.ts
@@ -1,5 +1,6 @@
 import { printSet } from './printing';
 import { breakWhileDebugging } from '../../validation';
+import { isDefined } from '../utils/typedOperators';
 
 export interface IValidatedSet<K> extends Set<K> {
     addOrReplaceIfExists(key: K): this;
@@ -15,7 +16,7 @@ export class ValidatedSet<K> implements IValidatedSet<K> {
     public constructor(iterable: Iterable<K>);
     public constructor(values?: ReadonlyArray<K>);
     public constructor(valuesOrIterable?: ReadonlyArray<K> | undefined | Iterable<K>) {
-        this._wrappedSet = valuesOrIterable
+        this._wrappedSet = isDefined(valuesOrIterable)
             ? new Set(valuesOrIterable)
             : new Set();
     }

--- a/src/chrome/internal/breakpoints/features/bpRecipeAtLoadedSourceLogic.ts
+++ b/src/chrome/internal/breakpoints/features/bpRecipeAtLoadedSourceLogic.ts
@@ -91,7 +91,7 @@ export class BPRecipeAtLoadedSourceSetter implements IBPRecipeAtLoadedSourceSett
     }
 
     public async onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
-        if (paused.hitBreakpoints && paused.hitBreakpoints.length > 0) {
+        if (paused.hitBreakpoints.length > 0) {
             const bpRecipes = paused.hitBreakpoints.filter(bp => this._bpRecipesRegistry.containsBPRecipe(bp.unmappedBPRecipe));
             if (bpRecipes.length >= 1) {
                 return this._onPausedForBreakpointCallback(bpRecipes.map(bpRecipe => bpRecipe.unmappedBPRecipe));

--- a/src/chrome/internal/breakpoints/features/breakpointsEventSystem.ts
+++ b/src/chrome/internal/breakpoints/features/breakpointsEventSystem.ts
@@ -6,6 +6,7 @@ import { BPRecipeAtLoadedSourceSetter } from './bpRecipeAtLoadedSourceLogic';
 import { SingleBreakpointSetter } from './singleBreakpointSetter';
 import { BPRecipeWasResolved } from '../../../cdtpDebuggee/features/cdtpDebuggeeBreakpointsSetter';
 import { BPRecipeStatusChanged } from '../registries/bpRecipeStatusCalculator';
+import * as _ from 'lodash';
 
 export interface IBreakpointsEventsListener {
     listenForOnClientBPRecipeAdded(listener: (bpRecipie: BPRecipeInSource) => void): void;
@@ -76,7 +77,7 @@ export class BreakpointsEventSystem implements IBreakpointsEventsListener {
         this._singleBreakpointSetter = breakpointsUpdater;
         this._bpRecipeAtLoadedSourceSetter = bpRecipeAtLoadedSourceLogic;
 
-        (this._scheduledActions || []).forEach(action => action());
+        _.defaultTo(this._scheduledActions, []).forEach(action => action());
         this._scheduledActions = null;
     }
 

--- a/src/chrome/internal/breakpoints/features/existingBPsForJustParsedScriptSetter.ts
+++ b/src/chrome/internal/breakpoints/features/existingBPsForJustParsedScriptSetter.ts
@@ -22,6 +22,7 @@ import { BPRecipesForSourceRetriever } from '../registries/bpRecipesForSourceRet
 import { IEventsConsumer, Synchronicity } from '../../../cdtpDebuggee/features/cdtpDebuggeeBreakpointsSetter';
 import { CDTPBreakpoint } from '../../../cdtpDebuggee/cdtpPrimitives';
 import { SourceToScriptMapper } from '../../services/sourceToScriptMapper';
+import { isDefined } from '../../../utils/typedOperators';
 
 class MakeAllEventsAsyncConsumer implements IEventsConsumer {
     public constructor(private readonly _wrappedEventsConsumer: IEventsConsumer) { }
@@ -63,13 +64,13 @@ export class ExistingBPsForJustParsedScriptSetter {
         }
     }
 
-    public waitUntilBPsAreSet(script: IScript): Promise<void> {
+    public async waitUntilBPsAreSet(script: IScript): Promise<void> {
         const doesScriptHaveAnyBPRecipes = script.allSources.find(source => this._bpRecipesForSourceRetriever.bpRecipesForSource(source.identifier).length >= 1);
-        if (doesScriptHaveAnyBPRecipes) {
+        if (isDefined(doesScriptHaveAnyBPRecipes)) {
             return this.finishedSettingBPsForScriptDefer(script).promise;
         } else {
             const defer = this._scriptToBPsAreSetDefer.tryGetting(script);
-            return Promise.resolve(defer && defer.promise);
+            return await (isDefined(defer) ? defer.promise : undefined);
         }
     }
 

--- a/src/chrome/internal/breakpoints/features/hitCountConditionParser.ts
+++ b/src/chrome/internal/breakpoints/features/hitCountConditionParser.ts
@@ -1,3 +1,6 @@
+import { hasMatches } from '../../../utils/typedOperators';
+import * as _ from 'lodash';
+
 /*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
@@ -11,7 +14,7 @@ export class HitCountConditionParser {
 
     public parse(): HitCountConditionFunction {
         const patternMatches = this.HIT_COUNT_CONDITION_PATTERN.exec(this._hitCountCondition.trim());
-        if (patternMatches && patternMatches.length >= 3) {
+        if (hasMatches(patternMatches) && patternMatches.length >= 3) {
             // eval safe because of the regex, and this is only a string that the current user will type in
             // tslint:disable-next-line: function-constructor
             const shouldPause: HitCountConditionFunction = <any>new Function('numHits', this.javaScriptCodeToEvaluateCondition(patternMatches));
@@ -35,7 +38,7 @@ export class HitCountConditionParser {
     }
 
     private parseOperator(patternMatches: RegExpExecArray): string {
-        let op = patternMatches[1] || '>=';
+        let op = _.defaultTo(patternMatches[1], '>=');
         if (op === '=')
             op = '==';
         return op;

--- a/src/chrome/internal/breakpoints/registries/breakpointsSetForScriptFinder.ts
+++ b/src/chrome/internal/breakpoints/registries/breakpointsSetForScriptFinder.ts
@@ -10,6 +10,7 @@ import { IBreakpointsEventsListener } from '../features/breakpointsEventSystem';
 import { injectable, inject } from 'inversify';
 import { PrivateTypes } from '../diTypes';
 import { BPRecipeWasResolved } from '../../../cdtpDebuggee/features/cdtpDebuggeeBreakpointsSetter';
+import * as _ from 'lodash';
 
 /**
  * Find the list of breakpoints that we set for a particular script
@@ -27,7 +28,7 @@ export class BreakpointsSetForScriptFinder {
     }
 
     public tryGettingBreakpointAtLocation(locationInScript: LocationInScript): CDTPBreakpoint[] {
-        const breakpoints = this._scriptToBreakpoints.tryGetting(locationInScript.script) || new Set();
+        const breakpoints = _.defaultTo(this._scriptToBreakpoints.tryGetting(locationInScript.script), new Set());
         const bpsAtLocation = [];
         for (const bp of breakpoints) {
             if (bp.actualLocation.isSameAs(locationInScript)) {

--- a/src/chrome/internal/exceptions/exceptionStackTracePrinter.ts
+++ b/src/chrome/internal/exceptions/exceptionStackTracePrinter.ts
@@ -3,6 +3,7 @@
  *--------------------------------------------------------*/
 import { IFormattedExceptionLineDescription } from '../formattedExceptionParser';
 import { ConnectedCDAConfiguration } from '../../client/chromeDebugAdapter/cdaConfiguration';
+import { isFalse } from '../../utils/typedOperators';
 
 /**
  * Print a stack trace to a format suitable for the client
@@ -11,7 +12,7 @@ export class ExceptionStackTracePrinter {
     public constructor(private readonly _configuration: ConnectedCDAConfiguration) { }
 
     public isZeroBased(): boolean {
-        return !this._configuration.clientCapabilities.linesStartAt1;
+        return isFalse(this._configuration.clientCapabilities.linesStartAt1);
     }
 
     public toStackTraceString(formattedExceptionLines: IFormattedExceptionLineDescription[]): string {

--- a/src/chrome/internal/formattedExceptionParser.ts
+++ b/src/chrome/internal/formattedExceptionParser.ts
@@ -8,6 +8,7 @@ import { CDTPScriptUrl } from './sources/resourceIdentifierSubtypes';
 import { createLineNumber, createColumnNumber } from './locations/subtypes';
 import { Position } from '../internal/locations/location';
 import { CDTPScriptsRegistry } from '../cdtpDebuggee/registries/cdtpScriptsRegistry';
+import { hasMatches } from '../utils/typedOperators';
 
 export interface IFormattedExceptionLineDescription {
     generateDescription(zeroBaseNumbers: boolean): string;
@@ -53,7 +54,7 @@ export class FormattedExceptionParser {
     public async parse(): Promise<IFormattedExceptionLineDescription[]> {
         return this.exceptionLines().map(line => {
             const matches = line.match(/^\s+at (.*?)\s*\(?([^ ]+):(\d+):(\d+)\)?$/);
-            if (matches) {
+            if (hasMatches(matches)) {
                 const url = parseResourceIdentifier(matches[2]) as IResourceIdentifier<CDTPScriptUrl>;
                 const lineNumber = parseInt(matches[3], 10);
                 const zeroBasedLineNumber = createLineNumber(lineNumber - 1);

--- a/src/chrome/internal/services/logging.ts
+++ b/src/chrome/internal/services/logging.ts
@@ -4,9 +4,11 @@
 
 import { Logger, logger } from 'vscode-debugadapter';
 import { IExtensibilityPoints } from '../../extensibility/extensibilityPoints';
+import { isNotEmpty } from '../../utils/typedOperators';
+import { LogLevel } from 'vscode-debugadapter/lib/logger';
 
 export interface ILoggingConfiguration {
-    logLevel?: Logger.LogLevel;
+    logLevel: Logger.LogLevel;
     shouldLogTimestamps: boolean;
     logFilePath?: string;
 }
@@ -32,11 +34,11 @@ export class Logging implements ILogger {
     }
 
     public configure(extensibilityPoints: IExtensibilityPoints, configuration: ILoggingConfiguration): void {
-        const logToFile = !!configuration.logLevel;
+        const logToFile = configuration.logLevel !== LogLevel.Stop;
 
         // The debug configuration provider should have set logFilePath on the launch config. If not, default to 'true' to use the
         // "legacy" log file path from the CDA subclass
-        const logFilePath = configuration.logFilePath || extensibilityPoints.logFilePath || logToFile;
-        logger.setup(configuration.logLevel || Logger.LogLevel.Warn, logFilePath, configuration.shouldLogTimestamps);
+        const logFilePath = isNotEmpty(configuration.logFilePath) || isNotEmpty(extensibilityPoints.logFilePath) || logToFile;
+        logger.setup(configuration.logLevel, logFilePath, configuration.shouldLogTimestamps);
     }
 }

--- a/src/chrome/internal/services/sourceToScriptMapper.ts
+++ b/src/chrome/internal/services/sourceToScriptMapper.ts
@@ -25,7 +25,7 @@ export class SourceToScriptMapper {
     public async mapBPRecipe(bpRecipe: BPRecipeInLoadedSource<ConditionalPause | AlwaysPause>, onlyKeepIfScript: (script: IScript) => boolean = () => true): Promise<BPRecipeInScript[]> {
         const tokensInManyScripts = bpRecipe.location.tokensWhenMappedToScript().filter(tokens => onlyKeepIfScript(tokens.script));
         return asyncMap(tokensInManyScripts, async manyTokensInScript => {
-            const bestLocation = this.doesTargetSupportColumnBreakpointsCached
+            const bestLocation = await this.doesTargetSupportColumnBreakpointsCached
                 ? await this.findBestLocationForBP(manyTokensInScript.enclosingRange)
                 : manyTokensInScript.enclosingRange.start; // If we don't support column breakpoints we set the breakpoint at the start of the range
             const bpRecipeAtBestLocation = new BPRecipeInScript(bpRecipe.unmappedBPRecipe, bestLocation);

--- a/src/chrome/internal/sources/features/dotScriptsCommand.ts
+++ b/src/chrome/internal/sources/features/dotScriptsCommand.ts
@@ -11,6 +11,7 @@ import { IScript } from '../../scripts/script';
 import { CDTPScriptsRegistry } from '../../../cdtpDebuggee/registries/cdtpScriptsRegistry';
 import { IScriptSourcesRetriever } from '../../../cdtpDebuggee/features/cdtpScriptSourcesRetriever';
 import { parseResourceIdentifier } from '../resourceIdentifier';
+import { isNotEmpty } from '../../../utils/typedOperators';
 
 @injectable()
 export class DotScriptCommand {
@@ -26,10 +27,10 @@ export class DotScriptCommand {
      */
     public handleScriptsCommand(scriptsRest: string): Promise<void> {
         let outputStringP: Promise<string>;
-        if (scriptsRest) {
+        if (isNotEmpty(scriptsRest)) {
             // `.scripts <url>` was used, look up the script by url
             const requestedScript = this._scriptsRegistry.getScriptsByPath(parseResourceIdentifier(scriptsRest));
-            if (requestedScript) {
+            if (requestedScript.length > 0) {
                 outputStringP = this._scriptSources.getScriptSource(requestedScript[0])
                     .then(result => {
                         const maxLength = 1e5;
@@ -65,7 +66,7 @@ export class DotScriptCommand {
 
         const sourcePathDetails = await this._sourceMapTransformer.allSourcePathDetails(script.runtimeSource.identifier.canonicalized);
         let mappedSourcesStr = sourcePathDetails.map(details => `    - ${details.originalPath} (${details.inferredPath})`).join('\n');
-        if (sourcePathDetails.length) {
+        if (sourcePathDetails.length > 0) {
             mappedSourcesStr = '\n' + mappedSourcesStr;
         }
 

--- a/src/chrome/internal/sources/resourceIdentifier.ts
+++ b/src/chrome/internal/sources/resourceIdentifier.ts
@@ -8,6 +8,7 @@ import { MapUsingProjection } from '../../collections/mapUsingProjection';
 import { IEquivalenceComparable } from '../../utils/equivalence';
 import * as utils from '../../../utils';
 import { SetUsingProjection } from '../../collections/setUsingProjection';
+import { hasMatches } from '../../utils/typedOperators';
 
 /**
  * Hierarchy:
@@ -172,8 +173,8 @@ export class WindowLocalFilePath<TString extends string = string> extends LocalF
         super(WindowLocalFilePath.normalize(textRepresentation));
     }
 
-    public static isValid(path: string) {
-        return path.match(/^[A-Za-z]:/);
+    public static isValid(path: string): boolean {
+        return hasMatches(path.match(/^[A-Za-z]:/));
     }
 
     private static normalize<TString extends string>(textRepresentation: TString): TString {

--- a/src/chrome/internal/sources/sourceRequestHandler.ts
+++ b/src/chrome/internal/sources/sourceRequestHandler.ts
@@ -10,6 +10,7 @@ import { ILoadedSourceTreeNode } from './loadedSource';
 import { asyncMap } from '../../collections/async';
 import { SourceToClientConverter } from '../../client/sourceToClientConverter';
 import { SourceResolver } from './sourceResolver';
+import { isDefined } from '../../utils/typedOperators';
 
 @injectable()
 export class SourceRequestHandler implements ICommandHandlerDeclarer {
@@ -33,7 +34,7 @@ export class SourceRequestHandler implements ICommandHandlerDeclarer {
     }
 
     public async source(args: DebugProtocol.SourceArguments, _telemetryPropertyCollector?: ITelemetryPropertyCollector, _requestSeq?: number): Promise<ISourceResponseBody> {
-        if (args.source) {
+        if (isDefined(args.source)) {
             const source = this._clientSourceParser.toSource(args.source);
             const sourceText = await this._sourcesLogic.text(source);
             return {

--- a/src/chrome/internal/stepping/features/asyncStepping.ts
+++ b/src/chrome/internal/stepping/features/asyncStepping.ts
@@ -10,6 +10,7 @@ import { IDebuggeeExecutionController } from '../../../cdtpDebuggee/features/cdt
 import { IDebuggeeSteppingController } from '../../../cdtpDebuggee/features/cdtpDebugeeSteppingController';
 import { IDebuggeePausedHandler } from '../../features/debuggeePausedHandler';
 import { printClassDescription } from '../../../utils/printing';
+import { isDefined } from '../../../utils/typedOperators';
 
 @printClassDescription
 export class PausedBecauseAsyncCallWasScheduled extends BasePauseShouldBeAutoResumed {
@@ -28,7 +29,7 @@ export class AsyncStepping {
     }
 
     public async onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
-        if (paused.asyncCallStackTraceId) {
+        if (isDefined(paused.asyncCallStackTraceId)) {
             await this._debugeeStepping.pauseOnAsyncCall({ parentStackTraceId: paused.asyncCallStackTraceId });
             return new PausedBecauseAsyncCallWasScheduled(this._debugeeExecutionControl);
         }


### PR DESCRIPTION
Prepare to enable the strict boolean expressions from TSLint. Stop using non-boolean values as booleans.
(This change will be split among several PRs)

We are replacing the expressions flagged by the rule with: https://github.com/Microsoft/vscode-chrome-debug-core/blob/v2/src/chrome/utils/typedOperators.ts