### PR TITLE
Fix stop bug, and logging bug

### DIFF
--- a/src/chrome/internal/services/logging.ts
+++ b/src/chrome/internal/services/logging.ts
@@ -4,8 +4,8 @@
 
 import { Logger, logger } from 'vscode-debugadapter';
 import { IExtensibilityPoints } from '../../extensibility/extensibilityPoints';
-import { isNotEmpty } from '../../utils/typedOperators';
 import { LogLevel } from 'vscode-debugadapter/lib/logger';
+import * as _ from 'lodash';
 
 export interface ILoggingConfiguration {
     logLevel: Logger.LogLevel;
@@ -38,7 +38,7 @@ export class Logging implements ILogger {
 
         // The debug configuration provider should have set logFilePath on the launch config. If not, default to 'true' to use the
         // "legacy" log file path from the CDA subclass
-        const logFilePath = isNotEmpty(configuration.logFilePath) || isNotEmpty(extensibilityPoints.logFilePath) || logToFile;
+        const logFilePath = _.defaultTo(configuration.logFilePath, _.defaultTo(extensibilityPoints.logFilePath, logToFile));
         logger.setup(configuration.logLevel, logFilePath, configuration.shouldLogTimestamps);
     }
 }


### PR DESCRIPTION
- We were calling this._debuggeeLauncher.stop two times, once inside TerminatingCDA.disconnect and one inside ChromeConnection.close. We remove the first call.
At the moment it also make sense to me to first terminate the session before calling the shutdown method, so I changed that order too. Similar with the TerminatedEvent

- The logging bug in src/chrome/internal/services/logging.ts. Variable logFilePath  was a boolean when it should've been a string