### PR TITLE
Made logging more granular

### DIFF
--- a/src/chrome/logging/methodsCalledLogger.ts
+++ b/src/chrome/logging/methodsCalledLogger.ts
@@ -60,6 +60,7 @@ export class MethodsCalledLogger<T extends object> {
         const handler = {
             get: <K extends keyof T>(target: T, propertyKey: K, receiver: any) => {
                 const originalPropertyValue = target[propertyKey];
+                // tslint:disable-next-line: strict-type-predicates
                 if (typeof originalPropertyValue === 'function') {
                     return (...args: any) => {
                         const callId = this.generateCallId();

--- a/src/chrome/logging/methodsCalledLogger.ts
+++ b/src/chrome/logging/methodsCalledLogger.ts
@@ -4,7 +4,6 @@
 import * as _ from 'lodash';
 import { printTopLevelObjectDescription } from './printObjectDescription';
 import { logger } from 'vscode-debugadapter';
-import { isDefined } from '../utils/typedOperators';
 
 enum Synchronicity {
     Sync,
@@ -59,10 +58,11 @@ export class MethodsCalledLogger<T extends object> {
 
     public wrapped(): T {
         const handler = {
-            get: <K extends keyof T>(target: T, propertyKey: K, _receiver: any) => {
-                const originalPropertyValue: any = target[propertyKey];
+            get: <K extends keyof T>(target: T, propertyKey: K, receiver: any) => {
+                const originalPropertyValue = target[propertyKey];
                 if (typeof originalPropertyValue === 'function') {
                     return (...args: any) => {
+                        const callId = this.generateCallId();
                         try {
                             if (propertyKey === 'on' && args.length >= 2) {
                                 let listenerPossiblyWrapped = args[1];
@@ -70,27 +70,35 @@ export class MethodsCalledLogger<T extends object> {
                                 args[1] = listenerPossiblyWrapped;
                             }
 
+                            this.logCallStart(propertyKey, args, callId);
                             const result = originalPropertyValue.apply(target, args);
                             if (!result || !result.then) {
-                                this.logCall(propertyKey, Synchronicity.Sync, args, Outcome.Succesful, result);
-                                let resultPossiblyWrapped = result;
-                                this._configuration.decideWhetherToWrapMethodResult(propertyKey, args, result, name => resultPossiblyWrapped = new MethodsCalledLogger(this._configuration, result, name).wrapped());
-                                return resultPossiblyWrapped;
+                                this.logCall(propertyKey, Synchronicity.Sync, args, Outcome.Succesful, result, callId);
+                                if (result === target) {
+                                    return receiver;
+                                } else {
+                                    let resultPossiblyWrapped = result;
+                                    this._configuration.decideWhetherToWrapMethodResult(propertyKey, args, result, name => resultPossiblyWrapped = new MethodsCalledLogger(this._configuration, result, name).wrapped());
+                                    return resultPossiblyWrapped;
+                                }
                             } else {
-                                const callId = this.generateCallId();
-                                this.logCallStart(propertyKey, args, callId);
+                                this.logSyncPartFinished(propertyKey, args, callId);
                                 return result.then((promiseResult: unknown) => {
                                     this.logCall(propertyKey, Synchronicity.Async, args, Outcome.Succesful, promiseResult, callId);
-                                    let resultPossiblyWrapped = promiseResult;
-                                    this._configuration.decideWhetherToWrapMethodResult(propertyKey, args, promiseResult, name => resultPossiblyWrapped = new MethodsCalledLogger(this._configuration, <object>promiseResult, name).wrapped());
-                                    return resultPossiblyWrapped;
+                                    if (promiseResult === target) {
+                                        return receiver;
+                                    } else {
+                                        let resultPossiblyWrapped = promiseResult;
+                                        this._configuration.decideWhetherToWrapMethodResult(propertyKey, args, promiseResult, name => resultPossiblyWrapped = new MethodsCalledLogger(this._configuration, <object>promiseResult, name).wrapped());
+                                        return resultPossiblyWrapped;
+                                    }
                                 }, (error: unknown) => {
                                     this.logCall(propertyKey, Synchronicity.Async, args, Outcome.Failure, error, callId);
                                     return Promise.reject(error);
                                 });
                             }
                         } catch (exception) {
-                            this.logCall(propertyKey, Synchronicity.Sync, args, Outcome.Failure, exception);
+                            this.logCall(propertyKey, Synchronicity.Sync, args, Outcome.Failure, exception, callId);
                             throw exception;
                         }
                     };
@@ -120,12 +128,17 @@ export class MethodsCalledLogger<T extends object> {
     }
 
     private logCallStart(propertyKey: PropertyKey, methodCallArguments: any[], callId: number): void {
-        const message = `START ${callId}: ${this.printMethodCall(propertyKey, methodCallArguments)}`;
+        const message = `START            ${callId}: ${this.printMethodCall(propertyKey, methodCallArguments)}`;
         logger.verbose(message);
     }
 
-    private logCall(propertyKey: PropertyKey, synchronicity: Synchronicity, methodCallArguments: any[], outcome: Outcome, resultOrException: unknown, callId?: number): void {
-        const endPrefix = isDefined(callId) ? `END   ${callId}: ` : '';
+    private logSyncPartFinished(propertyKey: PropertyKey, methodCallArguments: any[], callId: number): void {
+        const message = `PROMISE-RETURNED ${callId}: ${this.printMethodCall(propertyKey, methodCallArguments)}`;
+        logger.verbose(message);
+    }
+
+    private logCall(propertyKey: PropertyKey, synchronicity: Synchronicity, methodCallArguments: any[], outcome: Outcome, resultOrException: unknown, callId: number): void {
+        const endPrefix = callId ? `END              ${callId}: ` : '';
         const message = `${endPrefix}${this.printMethodCall(propertyKey, methodCallArguments)} ${this.printMethodSynchronicity(synchronicity)}  ${this.printMethodResponse(outcome, resultOrException)}`;
         logger.verbose(message);
     }


### PR DESCRIPTION
The previous logging logic was logging only the start of the methods, and the end of the methods. It was logging the start in not the exact order where it was executed (because we waited to know if the method was sync or not).

This small changes logs 2 steps for each sync function, and 3 steps for each async function which should match 100% the exact order in which things are executed.
sync: Start and End
async: Start, Method returns the promise synchronically, Async End

This granularity was used to investigate some bugs in our integration tests