### PR TITLE
Fixes for DTL tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-chrome-debug-core",
   "displayName": "vscode-chrome-debug-core",
-  "version": "6.7.35",
+  "version": "10.7.35",
   "description": "A library for building VS Code debug adapters for targets that support the Chrome Remote Debug Protocol",
   "repository": {
     "type": "git",

--- a/src/chrome/internal/features/pauseActionsPriorities.ts
+++ b/src/chrome/internal/features/pauseActionsPriorities.ts
@@ -9,6 +9,7 @@ import { HitStillPendingBreakpoint, PausedWhileLoadingScriptToResolveBreakpoints
 import { ExceptionWasThrown, PromiseWasRejected } from '../exceptions/pauseOnException';
 import { HitAndSatisfiedHitCountBreakpoint, HitCountBreakpointWhenConditionWasNotSatisfied } from '../breakpoints/features/hitCountBreakpointsSetter';
 import { FinishedStepping, UserPaused } from '../stepping/features/syncStepping';
+import { PausedBecauseAsyncCallWasScheduled } from '../stepping/features/asyncStepping';
 
 export type ActionToTakeWhenPausedClass = { new(...args: any[]): IActionToTakeWhenPaused };
 
@@ -22,6 +23,8 @@ const actionsFromHighestToLowestPriority: ActionToTakeWhenPausedClass[] = [
     HitStillPendingBreakpoint,
     ExceptionWasThrown,
     PromiseWasRejected,
+
+    PausedBecauseAsyncCallWasScheduled,
 
     FinishedStepping,
 

--- a/src/chrome/internal/stepping/features/syncStepping.ts
+++ b/src/chrome/internal/stepping/features/syncStepping.ts
@@ -10,7 +10,7 @@ import { TYPES } from '../../../dependencyInjection.ts/types';
 import { PausedEvent } from '../../../cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider';
 import { IDebuggeeSteppingController } from '../../../cdtpDebuggee/features/cdtpDebugeeSteppingController';
 import { IDebuggeePausedHandler } from '../../features/debuggeePausedHandler';
-import { printClassDescription } from '../../../utils/printing';
+import { printClassDescription, printInstanceDescription } from '../../../utils/printing';
 import { IEventsToClientReporter } from '../../../client/eventsToClientReporter';
 import { logger } from 'vscode-debugadapter';
 
@@ -46,6 +46,7 @@ export class FinishedStepping extends BaseNotifyClientOfPause {
 @printClassDescription
 export class UserPaused extends BaseNotifyClientOfPause {
     protected readonly reason = 'pause';
+    public readonly toString = printInstanceDescription;
 
     public constructor(
         private readonly _changeStatus: (newStatus: SyncSteppingStatus) => void,
@@ -62,6 +63,8 @@ export class UserPaused extends BaseNotifyClientOfPause {
 
 @printClassDescription
 class CurrentlyStepping implements SyncSteppingStatus {
+    public readonly toString = printInstanceDescription;
+
     public constructor(
         private readonly _changeStatus: (newStatus: SyncSteppingStatus) => void,
         private readonly _eventsToClientReporter: IEventsToClientReporter) { }
@@ -91,6 +94,8 @@ class CurrentlyStepping implements SyncSteppingStatus {
 
 @printClassDescription
 class CurrentlyPausing implements SyncSteppingStatus {
+    public readonly toString = printInstanceDescription;
+
     public constructor(
         private readonly _changeStatus: (newStatus: SyncSteppingStatus) => void,
         private readonly _eventsToClientReporter: IEventsToClientReporter) { }
@@ -106,6 +111,8 @@ class CurrentlyPausing implements SyncSteppingStatus {
 
 @printClassDescription
 class CurrentlyIdle implements SyncSteppingStatus {
+    public readonly toString = printInstanceDescription;
+
     public constructor(
         private readonly _changeStatus: (newStatus: SyncSteppingStatus) => void,
         private readonly _eventsToClientReporter: IEventsToClientReporter) { }

--- a/src/chrome/internal/stepping/features/syncStepping.ts
+++ b/src/chrome/internal/stepping/features/syncStepping.ts
@@ -12,6 +12,7 @@ import { IDebuggeeSteppingController } from '../../../cdtpDebuggee/features/cdtp
 import { IDebuggeePausedHandler } from '../../features/debuggeePausedHandler';
 import { printClassDescription } from '../../../utils/printing';
 import { IEventsToClientReporter } from '../../../client/eventsToClientReporter';
+import { logger } from 'vscode-debugadapter';
 
 type SteppingAction = () => Promise<void>;
 
@@ -36,6 +37,10 @@ export class FinishedStepping extends BaseNotifyClientOfPause {
         this._changeStatus(new CurrentlyIdle(this._changeStatus, this._eventsToClientReporter));
         await super.execute();
     }
+
+    public toString(): string {
+        return 'Finished stepping';
+    }
 }
 
 @printClassDescription
@@ -55,6 +60,7 @@ export class UserPaused extends BaseNotifyClientOfPause {
     }
 }
 
+@printClassDescription
 class CurrentlyStepping implements SyncSteppingStatus {
     public constructor(
         private readonly _changeStatus: (newStatus: SyncSteppingStatus) => void,
@@ -65,6 +71,16 @@ class CurrentlyStepping implements SyncSteppingStatus {
     }
 
     public async onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
+        // At the moment, after we pause, if the reason is not because stepping finished then we don't know
+        // what the new state should be:
+        //   - We could be hitting a breakpoint, and then we'd be idle
+        //   - We could be triggering smart step, so we could potentially still be stepping.
+        // We change to the unknown state so we'll allow the user to step again if he wants to
+        // (If the FinishedStepping is choosen to resolve the pause, the state will be changed to Idle)
+        //
+        // TODO: The stepping state needs more work. Figure out what is the right thing to do here, and what to do about the stepping states
+        this._changeStatus(new UnknownState(this._changeStatus, this._eventsToClientReporter));
+
         if (paused.reason === 'other') {
             return new FinishedStepping(this._changeStatus, this._eventsToClientReporter);
         } else {
@@ -73,6 +89,7 @@ class CurrentlyStepping implements SyncSteppingStatus {
     }
 }
 
+@printClassDescription
 class CurrentlyPausing implements SyncSteppingStatus {
     public constructor(
         private readonly _changeStatus: (newStatus: SyncSteppingStatus) => void,
@@ -87,6 +104,7 @@ class CurrentlyPausing implements SyncSteppingStatus {
     }
 }
 
+@printClassDescription
 class CurrentlyIdle implements SyncSteppingStatus {
     public constructor(
         private readonly _changeStatus: (newStatus: SyncSteppingStatus) => void,
@@ -101,12 +119,15 @@ class CurrentlyIdle implements SyncSteppingStatus {
     }
 }
 
+@printClassDescription
+class UnknownState extends CurrentlyIdle { }
+
 /**
  * This class provides functionality to step thorugh the debuggee's code
  */
 @injectable()
 export class SyncStepping {
-    private _status: SyncSteppingStatus = new CurrentlyIdle(this.changeStatus(), this._eventsToClientReporter);
+    private _status: SyncSteppingStatus = new CurrentlyIdle(s => this.changeStatus(s), this._eventsToClientReporter);
 
     public stepOver = this.createSteppingMethod(() => this._debugeeStepping.stepOver());
     public stepInto = this.createSteppingMethod(() => this._debugeeStepping.stepInto({ breakOnAsyncCall: true }));
@@ -120,8 +141,9 @@ export class SyncStepping {
         this._debuggeePausedHandler.registerActionProvider(paused => this.onProvideActionForWhenPaused(paused));
     }
 
-    private changeStatus(): (newStatus: SyncSteppingStatus) => void {
-        return (newStatus: SyncSteppingStatus) => this._status = newStatus;
+    private changeStatus(newStatus: SyncSteppingStatus): void {
+        logger.log(`Changing sync-stepping state from: ${this._status} to ${newStatus}`);
+        this._status = newStatus;
     }
 
     public continue(): Promise<void> {
@@ -129,12 +151,14 @@ export class SyncStepping {
     }
 
     public pause(): Promise<void> {
-        this._status = new CurrentlyPausing(this.changeStatus(), this._eventsToClientReporter);
+        this.changeStatus(new CurrentlyPausing(s => this.changeStatus(s), this._eventsToClientReporter));
         return this._debugeeExecutionControl.pause();
     }
 
     private async onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
-        return this._status.onProvideActionForWhenPaused(paused);
+        const result = await this._status.onProvideActionForWhenPaused(paused);
+        logger.log(`${this}.onProvideActionForWhenPaused() returns ${result}`);
+        return result;
     }
 
     public async restartFrame(callFrame: ScriptCallFrame<CallFrameWithState>): Promise<void> {

--- a/src/chrome/utils/printing.ts
+++ b/src/chrome/utils/printing.ts
@@ -4,18 +4,10 @@ function _printClassDescription(this: Function): string {
     return isNotEmpty(this.name) ? `class ${this.name}` : Function.toString.call(this);
 }
 
-function _printInstanceDescription(this: object): string {
-    return isNotEmpty(this.constructor.name) ? `${this.constructor.name}` : 'an anonymous object';
+export function printInstanceDescription(this: object): string {
+    return `${this.constructor.name}`;
 }
 
 export function printClassDescription(functionConstructor: Function) {
     functionConstructor.toString = _printClassDescription;
-
-    /*
-     * If the class has the default toString method with returns [object Object] change it for our custom method
-     * that returns the class name instead
-     */
-    if (functionConstructor.prototype.toString === Object.prototype.toString) {
-        functionConstructor.prototype.toString = _printInstanceDescription;
-    }
 }

--- a/src/chrome/utils/printing.ts
+++ b/src/chrome/utils/printing.ts
@@ -4,6 +4,18 @@ function _printClassDescription(this: Function): string {
     return isNotEmpty(this.name) ? `class ${this.name}` : Function.toString.call(this);
 }
 
+function _printInstanceDescription(this: object): string {
+    return isNotEmpty(this.constructor.name) ? `${this.constructor.name}` : 'an anonymous object';
+}
+
 export function printClassDescription(functionConstructor: Function) {
     functionConstructor.toString = _printClassDescription;
+
+    /*
+     * If the class has the default toString method with returns [object Object] change it for our custom method
+     * that returns the class name instead
+     */
+    if (functionConstructor.prototype.toString === Object.prototype.toString) {
+        functionConstructor.prototype.toString = _printInstanceDescription;
+    }
 }

--- a/src/transformers/fallbackToClientPathTransformer.ts
+++ b/src/transformers/fallbackToClientPathTransformer.ts
@@ -5,7 +5,7 @@ import { logger } from 'vscode-debugadapter';
 
 import { UrlPathTransformer } from './urlPathTransformer';
 import * as ChromeUtils from '../chrome/chromeUtils';
-import { IResourceIdentifier } from '../chrome/internal/sources/resourceIdentifier';
+import { IResourceIdentifier, parseResourceIdentifier } from '../chrome/internal/sources/resourceIdentifier';
 import { IConnectedCDAConfiguration } from '../chrome/client/chromeDebugAdapter/cdaConfiguration';
 import { inject } from 'inversify';
 import { TYPES } from '../chrome/dependencyInjection.ts/types';
@@ -43,8 +43,9 @@ export class FallbackToClientPathTransformer extends UrlPathTransformer {
         return new Promise<IResourceIdentifier>((resolve, reject) => {
             this._session.sendRequest('mapURLToFilePath', { url: url.textRepresentation }, FallbackToClientPathTransformer.ASK_CLIENT_TO_MAP_URL_TO_FILE_PATH_TIMEOUT, response => {
                 if (response.success) {
-                    logger.log(`The client responded that the url "${url}" maps to the file path "${response.body.filePath}"`);
-                    resolve(response.body.filePath);
+                    const filePath: string | null = response.body.filePath;
+                    logger.log(`The client responded that the url "${url}" maps to the file path "${filePath}"`);
+                    resolve(filePath !== null ? parseResourceIdentifier(filePath) : url);
                 } else {
                     reject(new Error(`The client responded that the url "${url}" couldn't be mapped to a file path due to: ${response.message}`));
                 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "ES6",
+        "target": "es2017",
         "sourceMap": true,
         "outDir": "out",
         "declaration": true,


### PR DESCRIPTION
- package.json: Chaged to version 10 so it's easier to determine from logs and telemetry whether this is v2 or not...

- pauseActionsPriorities.ts: All actions should be in this list. PausedBecauseAsyncCallWasScheduled was missing it, so we added it.

- syncStepping.ts: Things were breaking when we hit a breakpoint while stepping. The SyncStepping class ended up stuck on the CurrentlyStepping state and it didn't allow further stepping. We also improved the toString of the stepping states and added some more logging

- evaluateRequestHandler.ts: We were missing the frame parameter. Because the parameter is optional, the compiler didn't complain.

- printing.ts: Improved the toString of some classes to add more information to the logs

- fallbackToClientPathTransformer.ts: response.body.filePath is of type string yet we were using it as it were a IResourceIdentifier. response.body.filePath has type any so the compiler didn't complain when we did this.

- tsconfig.json: Changed to es2017 which is fully supported by node 9.11.2