### PR TITLE
More DTL fixes

### DIFF
--- a/src/chrome/chromeUtils.ts
+++ b/src/chrome/chromeUtils.ts
@@ -15,6 +15,7 @@ import { LocationInScript } from './internal/locations/location';
 import { IResourceIdentifier } from './internal/sources/resourceIdentifier';
 import { isNotEmpty, isEmpty, isDefined, hasMatches, isUndefined } from './utils/typedOperators';
 import * as _ from 'lodash';
+import { notEmpty } from '../validation';
 
 /**
  * Takes the path component of a target url (starting with '/') and applies pathMapping
@@ -300,6 +301,8 @@ export function getEvaluateName(parentEvaluateName: string | undefined, name: st
 }
 
 export function selectBreakpointLocation(_lineNumber: number, columnNumber: number, locations: LocationInScript[]): LocationInScript {
+    notEmpty('locations', locations);
+
     for (let i = locations.length - 1; i >= 0; i--) {
         if (locations[i].position.columnNumber <= columnNumber) {
             return locations[i];

--- a/src/chrome/internal/breakpoints/baseMappedBPRecipe.ts
+++ b/src/chrome/internal/breakpoints/baseMappedBPRecipe.ts
@@ -9,6 +9,7 @@ import { IURL } from '../sources/resourceIdentifier';
 import { CDTPScriptUrl } from '../sources/resourceIdentifierSubtypes';
 import * as utils from '../../../utils';
 import { IMappedTokensInScript } from '../locations/mappedTokensInScript';
+import { notNullOrUndefined } from '../../../validation';
 
 export interface IMappedBPRecipe<TResource extends ScriptOrSourceOrURLOrURLRegexp, TBPActionWhenHit extends IBPActionWhenHit>
     extends IBPRecipe<TResource, TBPActionWhenHit> {
@@ -24,6 +25,7 @@ abstract class BaseMappedBPRecipe<TResource extends ScriptOrSourceOrURLOrURLRege
 
     constructor(public readonly unmappedBPRecipe: BPRecipeInSource<TBPActionWhenHit>, public readonly location: Location<TResource>) {
         super();
+        notNullOrUndefined('location', location);
     }
 
     public get bpActionWhenHit(): TBPActionWhenHit {

--- a/src/chrome/internal/services/sourceToScriptMapper.ts
+++ b/src/chrome/internal/services/sourceToScriptMapper.ts
@@ -55,7 +55,11 @@ export class SourceToScriptMapper {
             const lineNumber = range.start.position.lineNumber;
             const wholeLineRange = RangeInResource.wholeLine(range.resource, lineNumber);
             const manyPossibleLocations = await this._targetBreakpoints.getPossibleBreakpoints(wholeLineRange);
-            return ChromeUtils.selectBreakpointLocation(lineNumber, range.start.position.columnNumber, manyPossibleLocations);
+            if (manyPossibleLocations.length > 0) {
+                return ChromeUtils.selectBreakpointLocation(lineNumber, range.start.position.columnNumber, manyPossibleLocations);
+            } else {
+                return range.start;
+            }
         }
     }
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -4,8 +4,7 @@
 
 export function zeroOrPositive(name: string, value: number) {
     if (value < 0) {
-        breakWhileDebugging();
-        throw new Error(`Expected ${name} to be either zero or a positive number and instead it was ${value}`);
+        throwError(new Error(`Expected ${name} to be either zero or a positive number and instead it was ${value}`));
     }
 }
 
@@ -20,7 +19,23 @@ export function breakWhileDebugging() {
 export function notNullNorUndefinedElements(name: string, array: unknown[]): void {
     const index = array.findIndex(element => element === null || element === undefined);
     if (index >= 0) {
-        breakWhileDebugging();
-        throw new Error(`Expected ${name} to not have any null or undefined elements, yet the element at #${index} was ${array[index]}`);
+        throwError(new Error(`Expected ${name} to not have any null or undefined elements, yet the element at #${index} was ${array[index]}`));
     }
+}
+
+export function notNullOrUndefined(name: string, value: unknown): void {
+    if (value === null || value === undefined) {
+        throwError(new Error(`Expected ${name} to not be neither null nor undefined yet it was: ${value}`));
+    }
+}
+
+export function notEmpty(name: string, elements: unknown[]): void {
+    if (elements.length < 1) {
+        throwError(new Error(`Expected ${name} to not be empty: ${elements}`));
+    }
+}
+
+export function throwError(error: Error): never {
+    breakWhileDebugging();
+    throw error;
 }


### PR DESCRIPTION
chromeUtils.ts, baseMappedBPRecipe.ts and validation.ts : Added some new validations/assertions in while investigating this issue to figure out where the "undefined" value was coming from.

sourceToScriptMapper.ts: Fixed the issue. Get possible breakpoints wasn't returning any value for this line, so ChromeUtils.selectBreakpointLocation was returning an empty array, which was creating the undefined value. Now when we can't find the best place to set a breakpoint, we return range.start instead.

Fix fixes another one of our DTL issues