### PR TITLE
Fixes, extra logging, and new extensibility points to make a "fast" version of Node v2 work

### DIFF
--- a/.pipelines/job.yml
+++ b/.pipelines/job.yml
@@ -8,8 +8,6 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   strategy:
     matrix:
-      node8:
-        nodeVersion: 8.x
       node10:
         nodeVersion: 10.x
       node11:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -45,11 +45,23 @@
             "cwd": "${workspaceFolder}/../vscode-node-debug2",
             "program": "${workspaceFolder}/../vscode-node-debug2/out/src/nodeDebug.js",
             "args": [ "--server=4712" ],
-            "outFiles": ["${workspaceFolder}/out/**/*.js"],
+            "outFiles": [
+                "${workspaceFolder}/out/**/*.js",
+                "${workspaceFolder}/../vscode-node-debug2/out/src/**/*.js"],
             "internalConsoleOptions": "openOnSessionStart",
             "smartStep": true,
+            "sourceMaps": true,
             "skipFiles": [
-                "<node_internals>/**"
+                "<node_internals>/**",
+                "async_hooks.js",
+                "transformedListenerRegistry.ts",
+                "logger.ts",
+                "methodsCalledLogger.ts",
+                "next_tick.js",
+                "inspector_async_hook.js",
+                "printObjectDescription.js",
+                "lodash.js",
+                "listeners.ts",
             ]
         },
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-chrome-debug-core",
-  "version": "6.7.35",
+  "version": "10.7.35",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,7 +10,7 @@
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "7.0.0"
       }
     },
     "@babel/highlight": {
@@ -19,9 +19,9 @@
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^4.0.0"
+        "chalk": "2.4.2",
+        "esutils": "2.0.2",
+        "js-tokens": "4.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -30,7 +30,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -39,9 +39,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "esutils": {
@@ -56,7 +56,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -67,8 +67,8 @@
       "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
       "dev": true,
       "requires": {
-        "normalize-path": "^2.0.1",
-        "through2": "^2.0.3"
+        "normalize-path": "2.1.1",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "core-util-is": {
@@ -95,7 +95,7 @@
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "^1.0.1"
+            "remove-trailing-separator": "1.1.0"
           }
         },
         "process-nextick-args": {
@@ -110,13 +110,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "remove-trailing-separator": {
@@ -137,7 +137,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "through2": {
@@ -146,8 +146,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         },
         "util-deprecate": {
@@ -170,7 +170,7 @@
       "integrity": "sha512-5qqtNia+m2I0/85+pd2YzAXaTyKO8j+svirO5aN+XaQJ5+eZ8nx0jPtEWZLxCi50xwYsX10xUHetFzfb1WEs4Q==",
       "dev": true,
       "requires": {
-        "@types/color-convert": "*"
+        "@types/color-convert": "1.9.0"
       }
     },
     "@types/color-convert": {
@@ -179,7 +179,7 @@
       "integrity": "sha512-OKGEfULrvSL2VRbkl/gnjjgbbF7ycIlpSsX7Nkab4MOWi5XxmgBYvuiQ7lcCFY5cPDz7MUNaKgxte2VRmtr4Fg==",
       "dev": true,
       "requires": {
-        "@types/color-name": "*"
+        "@types/color-name": "1.1.0"
       }
     },
     "@types/color-name": {
@@ -206,9 +206,9 @@
       "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "dev": true,
       "requires": {
-        "@types/events": "*",
-        "@types/minimatch": "*",
-        "@types/node": "*"
+        "@types/events": "1.2.0",
+        "@types/minimatch": "2.0.29",
+        "@types/node": "8.0.58"
       }
     },
     "@types/gulp-tslint": {
@@ -217,7 +217,7 @@
       "integrity": "sha512-Jmg3GETeS0x3ed3dqzVKT1d8S/A/StCOXtS6bxQ4Rc1mZaHkiPiFQFpCQ2L+6yWorhKsaq3MEOLgxuKVQNJE3Q==",
       "dev": true,
       "requires": {
-        "gulp-tslint": "*"
+        "gulp-tslint": "8.1.4"
       }
     },
     "@types/lodash": {
@@ -262,7 +262,7 @@
       "integrity": "sha512-LrnsgZIfJaysFkv9rRJp4/uAyqw87oVed3s1hhF83nwbo9c7MG9g5DqR0seHP+lkX4ldmMrVolPjQSe2ZfD0yA==",
       "dev": true,
       "requires": {
-        "source-map": "*"
+        "source-map": "0.7.3"
       }
     },
     "@types/ws": {
@@ -271,8 +271,8 @@
       "integrity": "sha512-i/dVaSjmTM92EFFFhmGL6AmHzvJ70XpAXmMLvNKh3JrRTGOiXvejfxe5+OSxcJK0paGOYHDaRLS8nXW6/FxSxg==",
       "dev": true,
       "requires": {
-        "@types/events": "*",
-        "@types/node": "*"
+        "@types/events": "1.2.0",
+        "@types/node": "8.0.58"
       }
     },
     "acorn": {
@@ -287,10 +287,10 @@
       "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "amdefine": {
@@ -305,7 +305,7 @@
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "dev": true,
       "requires": {
-        "ansi-wrap": "^0.1.0"
+        "ansi-wrap": "0.1.0"
       }
     },
     "ansi-cyan": {
@@ -359,8 +359,8 @@
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
       "requires": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
+        "micromatch": "3.1.10",
+        "normalize-path": "2.1.1"
       }
     },
     "append-buffer": {
@@ -369,7 +369,7 @@
       "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
       "dev": true,
       "requires": {
-        "buffer-equal": "^1.0.0"
+        "buffer-equal": "1.0.0"
       }
     },
     "archy": {
@@ -384,7 +384,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -399,7 +399,7 @@
       "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
       "dev": true,
       "requires": {
-        "make-iterator": "^1.0.0"
+        "make-iterator": "1.0.1"
       }
     },
     "arr-flatten": {
@@ -414,7 +414,7 @@
       "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
       "dev": true,
       "requires": {
-        "make-iterator": "^1.0.0"
+        "make-iterator": "1.0.1"
       }
     },
     "arr-union": {
@@ -441,8 +441,8 @@
       "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
       "dev": true,
       "requires": {
-        "array-slice": "^1.0.0",
-        "is-number": "^4.0.0"
+        "array-slice": "1.1.0",
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -459,7 +459,7 @@
       "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0"
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -482,9 +482,9 @@
       "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
       "dev": true,
       "requires": {
-        "default-compare": "^1.0.0",
-        "get-value": "^2.0.6",
-        "kind-of": "^5.0.2"
+        "default-compare": "1.0.0",
+        "get-value": "2.0.6",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -501,7 +501,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -528,7 +528,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "~2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "assert-plus": {
@@ -549,10 +549,10 @@
       "integrity": "sha512-R1BaUeJ4PMoLNJuk+0tLJgjmEqVsdN118+Z8O+alhnQDQgy0kmD5Mqi0DNEmMx2LM0Ed5yekKu+ZXYvIHceicg==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.2",
-        "process-nextick-args": "^1.0.7",
-        "stream-exhaust": "^1.0.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0",
+        "process-nextick-args": "1.0.7",
+        "stream-exhaust": "1.0.2"
       }
     },
     "async-each": {
@@ -572,7 +572,7 @@
       "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
       "dev": true,
       "requires": {
-        "async-done": "^1.2.2"
+        "async-done": "1.3.1"
       }
     },
     "asynckit": {
@@ -605,7 +605,7 @@
       "integrity": "sha1-PXW02Umtga8VdXAnOEb7Wa6w1Xw=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.9.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-runtime": {
@@ -614,8 +614,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.6.5",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "bach": {
@@ -624,15 +624,15 @@
       "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
       "dev": true,
       "requires": {
-        "arr-filter": "^1.1.1",
-        "arr-flatten": "^1.0.1",
-        "arr-map": "^2.0.0",
-        "array-each": "^1.0.0",
-        "array-initial": "^1.0.0",
-        "array-last": "^1.1.1",
-        "async-done": "^1.2.2",
-        "async-settle": "^1.0.0",
-        "now-and-later": "^2.0.0"
+        "arr-filter": "1.1.2",
+        "arr-flatten": "1.1.0",
+        "arr-map": "2.0.2",
+        "array-each": "1.0.1",
+        "array-initial": "1.1.0",
+        "array-last": "1.3.0",
+        "async-done": "1.3.1",
+        "async-settle": "1.0.0",
+        "now-and-later": "2.0.0"
       }
     },
     "balanced-match": {
@@ -646,13 +646,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.3.0",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -661,7 +661,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -670,7 +670,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -679,7 +679,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -688,9 +688,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -701,7 +701,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "beeper": {
@@ -731,16 +731,16 @@
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.3",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -749,7 +749,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -784,15 +784,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.3.0",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       }
     },
     "camelcase": {
@@ -813,11 +813,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -838,7 +838,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -849,18 +849,18 @@
       "integrity": "sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==",
       "dev": true,
       "requires": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.1",
-        "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.3",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.2.1",
-        "upath": "^1.1.1"
+        "anymatch": "2.0.0",
+        "async-each": "1.0.3",
+        "braces": "2.3.2",
+        "fsevents": "1.2.8",
+        "glob-parent": "3.1.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "4.0.1",
+        "normalize-path": "3.0.0",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.2.1",
+        "upath": "1.1.2"
       },
       "dependencies": {
         "normalize-path": {
@@ -883,10 +883,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "arr-union": {
@@ -901,7 +901,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -912,9 +912,9 @@
       "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "wrap-ansi": "2.1.0"
       }
     },
     "clone": {
@@ -941,9 +941,9 @@
       "integrity": "sha512-DNNEq6JdqBFPzS29TaoqZFPNLn5Xn3XyPFqLIhyBT8Xou4lHQEWzD6FinXoJUfhIfWX3aE1JkRa3cbWCHFbt1g==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^2.0.0",
-        "readable-stream": "^2.3.5"
+        "inherits": "2.0.3",
+        "process-nextick-args": "2.0.0",
+        "readable-stream": "2.3.5"
       },
       "dependencies": {
         "isarray": {
@@ -964,13 +964,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -979,7 +979,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -996,9 +996,9 @@
       "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
       "dev": true,
       "requires": {
-        "arr-map": "^2.0.2",
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "arr-map": "2.0.2",
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
       }
     },
     "collection-visit": {
@@ -1007,8 +1007,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color": {
@@ -1016,8 +1016,8 @@
       "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
       "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
       "requires": {
-        "color-convert": "^1.9.1",
-        "color-string": "^1.5.2"
+        "color-convert": "1.9.1",
+        "color-string": "1.5.3"
       }
     },
     "color-convert": {
@@ -1025,7 +1025,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -1038,8 +1038,8 @@
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
       "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
       "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
+        "color-name": "1.1.3",
+        "simple-swizzle": "0.2.2"
       }
     },
     "color-support": {
@@ -1054,7 +1054,7 @@
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -1080,10 +1080,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       },
       "dependencies": {
         "isarray": {
@@ -1104,13 +1104,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -1119,7 +1119,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -1142,8 +1142,8 @@
       "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
       "dev": true,
       "requires": {
-        "each-props": "^1.3.0",
-        "is-plain-object": "^2.0.1"
+        "each-props": "1.3.2",
+        "is-plain-object": "2.0.4"
       }
     },
     "core-js": {
@@ -1164,9 +1164,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.5",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       }
     },
     "css": {
@@ -1175,10 +1175,10 @@
       "integrity": "sha512-0W171WccAjQGGTKLhw4m2nnl0zPHUlTO/I8td4XzJgIB8Hg3ZZx71qT4G4eX8OVsSiaAKiUMy73E3nsbPlg2DQ==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "source-map": "^0.1.38",
-        "source-map-resolve": "^0.5.1",
-        "urix": "^0.1.0"
+        "inherits": "2.0.3",
+        "source-map": "0.1.43",
+        "source-map-resolve": "0.5.1",
+        "urix": "0.1.0"
       },
       "dependencies": {
         "source-map": {
@@ -1187,7 +1187,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -1198,7 +1198,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.49"
       }
     },
     "dashdash": {
@@ -1207,7 +1207,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "dateformat": {
@@ -1231,8 +1231,8 @@
       "integrity": "sha1-+gccXYdIRoVCSAdCHKSxawsaB2M=",
       "dev": true,
       "requires": {
-        "debug": "2.X",
-        "lazy-debug-legacy": "0.0.X",
+        "debug": "2.6.9",
+        "lazy-debug-legacy": "0.0.1",
         "object-assign": "4.1.0"
       },
       "dependencies": {
@@ -1262,7 +1262,7 @@
       "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^5.0.2"
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -1285,8 +1285,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
       }
     },
     "define-property": {
@@ -1295,8 +1295,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -1305,7 +1305,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -1314,7 +1314,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -1323,9 +1323,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -1336,13 +1336,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
       }
     },
     "delayed-stream": {
@@ -1380,7 +1380,7 @@
       "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
       "dev": true,
       "requires": {
-        "esutils": "^1.1.6",
+        "esutils": "1.1.6",
         "isarray": "0.0.1"
       }
     },
@@ -1396,7 +1396,7 @@
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
       "requires": {
-        "readable-stream": "~1.1.9"
+        "readable-stream": "1.1.14"
       }
     },
     "duplexify": {
@@ -1405,10 +1405,10 @@
       "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.5",
+        "stream-shift": "1.0.0"
       },
       "dependencies": {
         "end-of-stream": {
@@ -1417,7 +1417,7 @@
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
-            "once": "^1.4.0"
+            "once": "1.4.0"
           }
         },
         "isarray": {
@@ -1438,13 +1438,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -1453,7 +1453,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -1464,8 +1464,8 @@
       "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
       "dev": true,
       "requires": {
-        "is-plain-object": "^2.0.1",
-        "object.defaults": "^1.1.0"
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0"
       }
     },
     "ecc-jsbn": {
@@ -1474,8 +1474,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "end-of-stream": {
@@ -1484,7 +1484,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "error-ex": {
@@ -1493,7 +1493,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       },
       "dependencies": {
         "is-arrayish": {
@@ -1510,9 +1510,9 @@
       "integrity": "sha512-3NMEhi57E31qdzmYp2jwRArIUsj1HI/RxbQ4bgnSB+AIKIxsAmTiK83bYMifIcpWvEc3P1X30DhUKOqEtF/kvg==",
       "dev": true,
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "^1.0.0"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       }
     },
     "es6-iterator": {
@@ -1521,9 +1521,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.49",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-symbol": {
@@ -1532,8 +1532,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.49"
       }
     },
     "es6-weak-map": {
@@ -1542,10 +1542,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.49",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -1572,13 +1572,13 @@
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
+        "duplexer": "0.1.1",
+        "from": "0.1.7",
+        "map-stream": "0.1.0",
         "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
+        "split": "0.3.3",
+        "stream-combiner": "0.0.4",
+        "through": "2.3.8"
       },
       "dependencies": {
         "through": {
@@ -1595,13 +1595,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "expand-brackets": {
@@ -1610,13 +1610,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -1625,7 +1625,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -1634,7 +1634,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -1645,7 +1645,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.3"
       }
     },
     "extend": {
@@ -1660,7 +1660,7 @@
       "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
       "dev": true,
       "requires": {
-        "kind-of": "^1.1.0"
+        "kind-of": "1.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -1677,14 +1677,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -1693,7 +1693,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "extend-shallow": {
@@ -1702,7 +1702,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "is-accessor-descriptor": {
@@ -1711,7 +1711,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -1720,7 +1720,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -1729,9 +1729,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -1760,9 +1760,9 @@
       "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "dev": true,
       "requires": {
-        "ansi-gray": "^0.1.1",
-        "color-support": "^1.1.3",
-        "time-stamp": "^1.0.0"
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
+        "time-stamp": "1.1.0"
       },
       "dependencies": {
         "time-stamp": {
@@ -1791,7 +1791,7 @@
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
-        "pend": "~1.2.0"
+        "pend": "1.2.0"
       }
     },
     "fill-range": {
@@ -1800,10 +1800,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1812,7 +1812,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -1823,7 +1823,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "2.0.0"
       }
     },
     "findup-sync": {
@@ -1832,10 +1832,10 @@
       "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
       "dev": true,
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "micromatch": "^3.0.4",
-        "resolve-dir": "^1.0.1"
+        "detect-file": "1.0.0",
+        "is-glob": "4.0.1",
+        "micromatch": "3.1.10",
+        "resolve-dir": "1.0.1"
       }
     },
     "fined": {
@@ -1844,11 +1844,11 @@
       "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "is-plain-object": "^2.0.3",
-        "object.defaults": "^1.1.0",
-        "object.pick": "^1.2.0",
-        "parse-filepath": "^1.0.1"
+        "expand-tilde": "2.0.2",
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0",
+        "object.pick": "1.3.0",
+        "parse-filepath": "1.0.2"
       }
     },
     "flagged-respawn": {
@@ -1863,8 +1863,8 @@
       "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.4"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.5"
       },
       "dependencies": {
         "isarray": {
@@ -1885,13 +1885,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -1900,7 +1900,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -1917,7 +1917,7 @@
       "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "foreach": {
@@ -1938,9 +1938,9 @@
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.7",
+        "mime-types": "2.1.24"
       }
     },
     "fragment-cache": {
@@ -1949,7 +1949,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "from": {
@@ -1964,8 +1964,8 @@
       "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "through2": "^2.0.3"
+        "graceful-fs": "4.1.11",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "graceful-fs": {
@@ -1988,8 +1988,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "nan": "2.13.2",
+        "node-pre-gyp": "0.12.0"
       },
       "dependencies": {
         "abbrev": {
@@ -2001,8 +2001,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2016,23 +2015,21 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -2045,20 +2042,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2072,7 +2066,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "deep-extend": {
@@ -2099,7 +2093,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.5"
           }
         },
         "fs.realpath": {
@@ -2114,14 +2108,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.3"
           }
         },
         "glob": {
@@ -2130,12 +2124,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -2150,7 +2144,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -2159,7 +2153,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -2168,15 +2162,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2188,9 +2181,8 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -2203,25 +2195,22 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
           }
         },
         "minizlib": {
@@ -2230,14 +2219,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.5"
           }
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2254,9 +2242,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^4.1.0",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "4.1.1",
+            "iconv-lite": "0.4.24",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -2265,16 +2253,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.3.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.4.1",
+            "npmlog": "4.1.2",
+            "rc": "1.2.8",
+            "rimraf": "2.6.3",
+            "semver": "5.7.0",
+            "tar": "4.4.8"
           }
         },
         "nopt": {
@@ -2283,8 +2271,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -2299,8 +2287,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.6"
           }
         },
         "npmlog": {
@@ -2309,17 +2297,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.5",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2331,9 +2318,8 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -2354,8 +2340,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -2376,10 +2362,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.6.0",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -2396,13 +2382,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -2411,14 +2397,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.3"
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2454,11 +2439,10 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -2467,16 +2451,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -2491,13 +2474,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "chownr": "1.1.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.5",
+            "minizlib": "1.2.1",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
           }
         },
         "util-deprecate": {
@@ -2512,20 +2495,18 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2 || 2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2559,7 +2540,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "glob": {
@@ -2567,12 +2548,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-parent": {
@@ -2581,8 +2562,8 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
       },
       "dependencies": {
         "is-glob": {
@@ -2591,7 +2572,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -2602,16 +2583,16 @@
       "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
       "dev": true,
       "requires": {
-        "extend": "^3.0.0",
-        "glob": "^7.1.1",
-        "glob-parent": "^3.1.0",
-        "is-negated-glob": "^1.0.0",
-        "ordered-read-streams": "^1.0.0",
-        "pumpify": "^1.3.5",
-        "readable-stream": "^2.1.5",
-        "remove-trailing-separator": "^1.0.1",
-        "to-absolute-glob": "^2.0.0",
-        "unique-stream": "^2.0.2"
+        "extend": "3.0.1",
+        "glob": "7.1.3",
+        "glob-parent": "3.1.0",
+        "is-negated-glob": "1.0.0",
+        "ordered-read-streams": "1.0.1",
+        "pumpify": "1.4.0",
+        "readable-stream": "2.3.6",
+        "remove-trailing-separator": "1.0.2",
+        "to-absolute-glob": "2.0.2",
+        "unique-stream": "2.3.1"
       },
       "dependencies": {
         "isarray": {
@@ -2632,13 +2613,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -2647,7 +2628,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -2658,12 +2639,12 @@
       "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
       "dev": true,
       "requires": {
-        "anymatch": "^2.0.0",
-        "async-done": "^1.2.0",
-        "chokidar": "^2.0.0",
-        "is-negated-glob": "^1.0.0",
-        "just-debounce": "^1.0.0",
-        "object.defaults": "^1.1.0"
+        "anymatch": "2.0.0",
+        "async-done": "1.3.1",
+        "chokidar": "2.1.5",
+        "is-negated-glob": "1.0.0",
+        "just-debounce": "1.0.0",
+        "object.defaults": "1.1.0"
       }
     },
     "global-modules": {
@@ -2672,9 +2653,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
@@ -2683,11 +2664,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.3",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.0"
       }
     },
     "globby": {
@@ -2696,12 +2677,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.3",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "glogg": {
@@ -2710,7 +2691,7 @@
       "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
       "dev": true,
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.0"
       }
     },
     "graceful-fs": {
@@ -2731,10 +2712,10 @@
       "integrity": "sha512-yDVtVunxrAdsk7rIV/b7lVSBifPN1Eqe6wTjsESGrFcL+MEVzaaeNTkpUuGTUptloSOU+8oJm/lBJbgPV+tMAw==",
       "dev": true,
       "requires": {
-        "glob-watcher": "^5.0.3",
-        "gulp-cli": "^2.2.0",
-        "undertaker": "^1.2.1",
-        "vinyl-fs": "^3.0.0"
+        "glob-watcher": "5.0.3",
+        "gulp-cli": "2.2.0",
+        "undertaker": "1.2.1",
+        "vinyl-fs": "3.0.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2755,9 +2736,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           }
         },
         "gulp-cli": {
@@ -2766,24 +2747,24 @@
           "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
           "dev": true,
           "requires": {
-            "ansi-colors": "^1.0.1",
-            "archy": "^1.0.0",
-            "array-sort": "^1.0.0",
-            "color-support": "^1.1.3",
-            "concat-stream": "^1.6.0",
-            "copy-props": "^2.0.1",
-            "fancy-log": "^1.3.2",
-            "gulplog": "^1.0.0",
-            "interpret": "^1.1.0",
-            "isobject": "^3.0.1",
-            "liftoff": "^3.1.0",
-            "matchdep": "^2.0.0",
-            "mute-stdout": "^1.0.0",
-            "pretty-hrtime": "^1.0.0",
-            "replace-homedir": "^1.0.0",
-            "semver-greatest-satisfied-range": "^1.1.0",
-            "v8flags": "^3.0.1",
-            "yargs": "^7.1.0"
+            "ansi-colors": "1.1.0",
+            "archy": "1.0.0",
+            "array-sort": "1.0.0",
+            "color-support": "1.1.3",
+            "concat-stream": "1.6.2",
+            "copy-props": "2.0.4",
+            "fancy-log": "1.3.2",
+            "gulplog": "1.0.0",
+            "interpret": "1.2.0",
+            "isobject": "3.0.1",
+            "liftoff": "3.1.0",
+            "matchdep": "2.0.0",
+            "mute-stdout": "1.0.1",
+            "pretty-hrtime": "1.0.3",
+            "replace-homedir": "1.0.0",
+            "semver-greatest-satisfied-range": "1.1.0",
+            "v8flags": "3.1.2",
+            "yargs": "7.1.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -2792,7 +2773,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "os-locale": {
@@ -2801,7 +2782,7 @@
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
-            "lcid": "^1.0.0"
+            "lcid": "1.0.0"
           }
         },
         "string-width": {
@@ -2810,9 +2791,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-ansi": {
@@ -2821,7 +2802,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "which-module": {
@@ -2836,19 +2817,19 @@
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^5.0.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "5.0.0"
           }
         },
         "yargs-parser": {
@@ -2857,7 +2838,7 @@
           "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0"
+            "camelcase": "3.0.0"
           }
         }
       }
@@ -2868,13 +2849,13 @@
       "integrity": "sha1-L1/l9kvNH0zxicFg4IDIrQZUMJQ=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "gulp-util": "^3.0.0",
-        "object-assign": "^4.0.1",
-        "plur": "^2.0.0",
-        "stringify-object": "^2.3.0",
-        "through2": "^2.0.0",
-        "tildify": "^1.1.2"
+        "chalk": "1.1.3",
+        "gulp-util": "3.0.8",
+        "object-assign": "4.1.1",
+        "plur": "2.1.2",
+        "stringify-object": "2.4.0",
+        "through2": "2.0.3",
+        "tildify": "1.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2895,11 +2876,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "core-util-is": {
@@ -2920,7 +2901,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "inherits": {
@@ -2947,13 +2928,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "safe-buffer": {
@@ -2968,7 +2949,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -2977,7 +2958,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -2992,8 +2973,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         },
         "util-deprecate": {
@@ -3016,10 +2997,10 @@
       "integrity": "sha512-L/LJftsbKoHbVj6dN5pvMsyJn9jYI0wT0nMg3G6VZhDac4NesezecYTi8/48rHi+yEic3sUpw6jlSc7qNWh32A==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "fancy-log": "^1.3.2",
-        "plugin-error": "^0.1.2",
-        "through2": "^2.0.3"
+        "chalk": "1.1.3",
+        "fancy-log": "1.3.2",
+        "plugin-error": "0.1.2",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3040,11 +3021,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "core-util-is": {
@@ -3065,7 +3046,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "inherits": {
@@ -3092,13 +3073,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "safe-buffer": {
@@ -3113,7 +3094,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -3122,7 +3103,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -3137,8 +3118,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         },
         "util-deprecate": {
@@ -3164,7 +3145,7 @@
         "babel-plugin-transform-runtime": "6.15.0",
         "cross-spawn": "4.0.0",
         "spawn-args": "0.2.0",
-        "timeout-as-promise": "^1.0.0"
+        "timeout-as-promise": "1.0.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -3173,8 +3154,8 @@
           "integrity": "sha1-glR3SrR4a4xbPPTfumbOVjkywlI=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.5",
+            "which": "1.3.0"
           }
         }
       }
@@ -3185,17 +3166,17 @@
       "integrity": "sha1-tDfR89mAzyboEYSCNxjOFa5ll7Y=",
       "dev": true,
       "requires": {
-        "@gulp-sourcemaps/map-sources": "1.X",
-        "acorn": "4.X",
-        "convert-source-map": "1.X",
-        "css": "2.X",
-        "debug-fabulous": "0.0.X",
-        "detect-newline": "2.X",
-        "graceful-fs": "4.X",
-        "source-map": "~0.6.0",
-        "strip-bom": "2.X",
-        "through2": "2.X",
-        "vinyl": "1.X"
+        "@gulp-sourcemaps/map-sources": "1.0.0",
+        "acorn": "4.0.13",
+        "convert-source-map": "1.5.1",
+        "css": "2.2.3",
+        "debug-fabulous": "0.0.4",
+        "detect-newline": "2.1.0",
+        "graceful-fs": "4.1.11",
+        "source-map": "0.6.1",
+        "strip-bom": "2.0.0",
+        "through2": "2.0.3",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "convert-source-map": {
@@ -3246,13 +3227,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "safe-buffer": {
@@ -3273,7 +3254,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-bom": {
@@ -3282,7 +3263,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "through2": {
@@ -3291,8 +3272,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         },
         "util-deprecate": {
@@ -3307,8 +3288,8 @@
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         },
@@ -3327,11 +3308,11 @@
       "dev": true,
       "requires": {
         "@types/fancy-log": "1.3.0",
-        "ansi-colors": "^1.0.1",
+        "ansi-colors": "1.1.0",
         "fancy-log": "1.3.3",
-        "map-stream": "~0.0.7",
+        "map-stream": "0.0.7",
         "plugin-error": "1.0.1",
-        "through": "~2.3.8"
+        "through": "2.3.8"
       },
       "dependencies": {
         "arr-union": {
@@ -3346,8 +3327,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           }
         },
         "fancy-log": {
@@ -3356,10 +3337,10 @@
           "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
           "dev": true,
           "requires": {
-            "ansi-gray": "^0.1.1",
-            "color-support": "^1.1.3",
-            "parse-node-version": "^1.0.0",
-            "time-stamp": "^1.0.0"
+            "ansi-gray": "0.1.1",
+            "color-support": "1.1.3",
+            "parse-node-version": "1.0.1",
+            "time-stamp": "1.1.0"
           }
         },
         "is-extendable": {
@@ -3368,7 +3349,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         },
         "map-stream": {
@@ -3383,10 +3364,10 @@
           "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
           "dev": true,
           "requires": {
-            "ansi-colors": "^1.0.1",
-            "arr-diff": "^4.0.0",
-            "arr-union": "^3.1.0",
-            "extend-shallow": "^3.0.2"
+            "ansi-colors": "1.1.0",
+            "arr-diff": "4.0.0",
+            "arr-union": "3.1.0",
+            "extend-shallow": "3.0.2"
           }
         }
       }
@@ -3397,12 +3378,12 @@
       "integrity": "sha512-BGdaBC1R4SJosXEkkEieeZ21qCZHnfSV78k7zzDljqAxvzDeGRTUqF4geckVclKEeiS3EYOBwNlxoHjJtn20vg==",
       "dev": true,
       "requires": {
-        "ansi-colors": "^1.0.1",
-        "plugin-error": "^0.1.2",
-        "source-map": "^0.6.1",
-        "through2": "^2.0.3",
-        "vinyl": "^2.1.0",
-        "vinyl-fs": "^3.0.0"
+        "ansi-colors": "1.1.0",
+        "plugin-error": "0.1.2",
+        "source-map": "0.6.1",
+        "through2": "2.0.3",
+        "vinyl": "2.1.0",
+        "vinyl-fs": "3.0.2"
       },
       "dependencies": {
         "clone": {
@@ -3423,8 +3404,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           }
         },
         "glob-stream": {
@@ -3433,16 +3414,16 @@
           "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
           "dev": true,
           "requires": {
-            "extend": "^3.0.0",
-            "glob": "^7.1.1",
-            "glob-parent": "^3.1.0",
-            "is-negated-glob": "^1.0.0",
-            "ordered-read-streams": "^1.0.0",
-            "pumpify": "^1.3.5",
-            "readable-stream": "^2.1.5",
-            "remove-trailing-separator": "^1.0.1",
-            "to-absolute-glob": "^2.0.0",
-            "unique-stream": "^2.0.2"
+            "extend": "3.0.1",
+            "glob": "7.1.3",
+            "glob-parent": "3.1.0",
+            "is-negated-glob": "1.0.0",
+            "ordered-read-streams": "1.0.1",
+            "pumpify": "1.4.0",
+            "readable-stream": "2.3.5",
+            "remove-trailing-separator": "1.0.2",
+            "to-absolute-glob": "2.0.2",
+            "unique-stream": "2.2.1"
           }
         },
         "graceful-fs": {
@@ -3463,7 +3444,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "isarray": {
@@ -3478,7 +3459,7 @@
           "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.0.1"
+            "readable-stream": "2.3.5"
           }
         },
         "process-nextick-args": {
@@ -3493,13 +3474,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "replace-ext": {
@@ -3520,7 +3501,7 @@
           "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "unique-stream": {
@@ -3529,8 +3510,8 @@
           "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
           "dev": true,
           "requires": {
-            "json-stable-stringify": "^1.0.0",
-            "through2-filter": "^2.0.0"
+            "json-stable-stringify": "1.0.1",
+            "through2-filter": "2.0.0"
           }
         },
         "vinyl": {
@@ -3539,12 +3520,12 @@
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "dev": true,
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.1",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.1",
+            "remove-trailing-separator": "1.0.2",
+            "replace-ext": "1.0.0"
           }
         },
         "vinyl-fs": {
@@ -3553,23 +3534,23 @@
           "integrity": "sha512-AUSFda1OukBwuLPBTbyuO4IRWgfXmqC4UTW0f8xrCa8Hkv9oyIU+NSqBlgfOLZRoUt7cHdo75hKQghCywpIyIw==",
           "dev": true,
           "requires": {
-            "fs-mkdirp-stream": "^1.0.0",
-            "glob-stream": "^6.1.0",
-            "graceful-fs": "^4.0.0",
-            "is-valid-glob": "^1.0.0",
-            "lazystream": "^1.0.0",
-            "lead": "^1.0.0",
-            "object.assign": "^4.0.4",
-            "pumpify": "^1.3.5",
-            "readable-stream": "^2.3.3",
-            "remove-bom-buffer": "^3.0.0",
-            "remove-bom-stream": "^1.2.0",
-            "resolve-options": "^1.1.0",
-            "through2": "^2.0.0",
-            "to-through": "^2.0.0",
-            "value-or-function": "^3.0.0",
-            "vinyl": "^2.0.0",
-            "vinyl-sourcemap": "^1.1.0"
+            "fs-mkdirp-stream": "1.0.0",
+            "glob-stream": "6.1.0",
+            "graceful-fs": "4.1.11",
+            "is-valid-glob": "1.0.0",
+            "lazystream": "1.0.0",
+            "lead": "1.0.0",
+            "object.assign": "4.1.0",
+            "pumpify": "1.4.0",
+            "readable-stream": "2.3.5",
+            "remove-bom-buffer": "3.0.0",
+            "remove-bom-stream": "1.2.0",
+            "resolve-options": "1.1.0",
+            "through2": "2.0.3",
+            "to-through": "2.0.0",
+            "value-or-function": "3.0.0",
+            "vinyl": "2.1.0",
+            "vinyl-sourcemap": "1.1.0"
           }
         }
       }
@@ -3580,24 +3561,24 @@
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-uniq": "^1.0.2",
-        "beeper": "^1.0.0",
-        "chalk": "^1.0.0",
-        "dateformat": "^2.0.0",
-        "fancy-log": "^1.1.0",
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "lodash._reescape": "^3.0.0",
-        "lodash._reevaluate": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.template": "^3.0.0",
-        "minimist": "^1.1.0",
-        "multipipe": "^0.1.2",
-        "object-assign": "^3.0.0",
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.2.0",
+        "fancy-log": "1.3.2",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
         "replace-ext": "0.0.1",
-        "through2": "^2.0.0",
-        "vinyl": "^0.5.0"
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3618,11 +3599,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "core-util-is": {
@@ -3643,7 +3624,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "inherits": {
@@ -3676,13 +3657,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "safe-buffer": {
@@ -3697,7 +3678,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -3706,7 +3687,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -3721,8 +3702,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         },
         "util-deprecate": {
@@ -3745,7 +3726,7 @@
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
-        "glogg": "^1.0.0"
+        "glogg": "1.0.1"
       }
     },
     "har-schema": {
@@ -3760,8 +3741,8 @@
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
+        "ajv": "6.10.0",
+        "har-schema": "2.0.0"
       }
     },
     "has-ansi": {
@@ -3770,7 +3751,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3793,7 +3774,7 @@
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "dev": true,
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.0"
       }
     },
     "has-symbols": {
@@ -3808,9 +3789,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "has-values": {
@@ -3819,8 +3800,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3829,7 +3810,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         }
       }
@@ -3846,7 +3827,7 @@
       "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
       "dev": true,
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -3861,9 +3842,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.16.1"
       }
     },
     "iconv-lite": {
@@ -3872,7 +3853,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "inflight": {
@@ -3880,8 +3861,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       },
       "dependencies": {
         "once": {
@@ -3889,7 +3870,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "wrappy": {
@@ -3945,8 +3926,8 @@
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "dev": true,
       "requires": {
-        "is-relative": "^1.0.0",
-        "is-windows": "^1.0.1"
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.2"
       }
     },
     "is-accessor-descriptor": {
@@ -3955,7 +3936,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3964,7 +3945,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         }
       }
@@ -3980,7 +3961,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.13.1"
       }
     },
     "is-buffer": {
@@ -3995,7 +3976,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4004,7 +3985,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         }
       }
@@ -4015,9 +3996,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -4052,7 +4033,7 @@
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "dev": true,
       "requires": {
-        "is-extglob": "^2.1.1"
+        "is-extglob": "2.1.1"
       }
     },
     "is-negated-glob": {
@@ -4067,7 +4048,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4076,7 +4057,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         }
       }
@@ -4093,7 +4074,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -4102,7 +4083,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-obj": {
@@ -4117,7 +4098,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -4140,7 +4121,7 @@
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "dev": true,
       "requires": {
-        "is-unc-path": "^1.0.0"
+        "is-unc-path": "1.0.0"
       }
     },
     "is-stream": {
@@ -4161,7 +4142,7 @@
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "dev": true,
       "requires": {
-        "unc-path-regex": "^0.1.2"
+        "unc-path-regex": "0.1.2"
       }
     },
     "is-utf8": {
@@ -4212,8 +4193,8 @@
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "jsbn": {
@@ -4240,7 +4221,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stable-stringify-without-jsonify": {
@@ -4291,8 +4272,8 @@
       "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
       "dev": true,
       "requires": {
-        "default-resolution": "^2.0.0",
-        "es6-weak-map": "^2.0.1"
+        "default-resolution": "2.0.0",
+        "es6-weak-map": "2.0.2"
       }
     },
     "lazy-debug-legacy": {
@@ -4307,7 +4288,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.5"
+        "readable-stream": "2.3.5"
       },
       "dependencies": {
         "isarray": {
@@ -4328,13 +4309,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -4343,7 +4324,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -4354,7 +4335,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "lead": {
@@ -4363,7 +4344,7 @@
       "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
       "dev": true,
       "requires": {
-        "flush-write-stream": "^1.0.2"
+        "flush-write-stream": "1.0.2"
       }
     },
     "liftoff": {
@@ -4372,14 +4353,14 @@
       "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
       "dev": true,
       "requires": {
-        "extend": "^3.0.0",
-        "findup-sync": "^3.0.0",
-        "fined": "^1.0.1",
-        "flagged-respawn": "^1.0.0",
-        "is-plain-object": "^2.0.4",
-        "object.map": "^1.0.0",
-        "rechoir": "^0.6.2",
-        "resolve": "^1.1.7"
+        "extend": "3.0.1",
+        "findup-sync": "3.0.0",
+        "fined": "1.2.0",
+        "flagged-respawn": "1.0.1",
+        "is-plain-object": "2.0.4",
+        "object.map": "1.0.1",
+        "rechoir": "0.6.2",
+        "resolve": "1.3.3"
       }
     },
     "load-json-file": {
@@ -4388,11 +4369,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.1.15",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       }
     },
     "locate-path": {
@@ -4401,8 +4382,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -4470,7 +4451,7 @@
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "dev": true,
       "requires": {
-        "lodash._root": "^3.0.0"
+        "lodash._root": "3.0.1"
       }
     },
     "lodash.isarguments": {
@@ -4491,9 +4472,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "lodash.restparam": {
@@ -4508,15 +4489,15 @@
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash._basetostring": "^3.0.0",
-        "lodash._basevalues": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0",
-        "lodash.keys": "^3.0.0",
-        "lodash.restparam": "^3.0.0",
-        "lodash.templatesettings": "^3.0.0"
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
       }
     },
     "lodash.templatesettings": {
@@ -4525,8 +4506,8 @@
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
       }
     },
     "lru-cache": {
@@ -4535,8 +4516,8 @@
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "make-iterator": {
@@ -4545,7 +4526,7 @@
       "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
       "dev": true,
       "requires": {
-        "kind-of": "^6.0.2"
+        "kind-of": "6.0.2"
       }
     },
     "map-cache": {
@@ -4566,7 +4547,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "matchdep": {
@@ -4575,9 +4556,9 @@
       "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
       "dev": true,
       "requires": {
-        "findup-sync": "^2.0.0",
-        "micromatch": "^3.0.4",
-        "resolve": "^1.4.0",
+        "findup-sync": "2.0.0",
+        "micromatch": "3.1.10",
+        "resolve": "1.10.0",
         "stack-trace": "0.0.10"
       },
       "dependencies": {
@@ -4587,10 +4568,10 @@
           "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
           "dev": true,
           "requires": {
-            "detect-file": "^1.0.0",
-            "is-glob": "^3.1.0",
-            "micromatch": "^3.0.4",
-            "resolve-dir": "^1.0.1"
+            "detect-file": "1.0.0",
+            "is-glob": "3.1.0",
+            "micromatch": "3.1.10",
+            "resolve-dir": "1.0.1"
           }
         },
         "is-glob": {
@@ -4599,7 +4580,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "path-parse": {
@@ -4614,7 +4595,7 @@
           "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.6"
+            "path-parse": "1.0.6"
           }
         }
       }
@@ -4625,7 +4606,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "merge2": {
@@ -4640,19 +4621,19 @@
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.13",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -4661,8 +4642,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           }
         },
         "is-extendable": {
@@ -4671,7 +4652,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -4702,7 +4683,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.8"
       }
     },
     "minimist": {
@@ -4717,8 +4698,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -4727,7 +4708,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -4787,12 +4768,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "supports-color": {
@@ -4801,7 +4782,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -4846,17 +4827,17 @@
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -4865,8 +4846,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           }
         },
         "is-extendable": {
@@ -4875,7 +4856,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -4897,10 +4878,10 @@
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.7.1",
+        "resolve": "1.10.0",
+        "semver": "5.6.0",
+        "validate-npm-package-license": "3.0.4"
       },
       "dependencies": {
         "path-parse": {
@@ -4915,7 +4896,7 @@
           "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.6"
+            "path-parse": "1.0.6"
           }
         }
       }
@@ -4935,7 +4916,7 @@
       "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
       "dev": true,
       "requires": {
-        "once": "^1.3.2"
+        "once": "1.4.0"
       }
     },
     "npm-run-path": {
@@ -4944,7 +4925,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "number-is-nan": {
@@ -4971,9 +4952,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -4982,7 +4963,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "kind-of": {
@@ -4991,7 +4972,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         }
       }
@@ -5008,7 +4989,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       }
     },
     "object.assign": {
@@ -5017,10 +4998,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "object-keys": "1.0.11"
       }
     },
     "object.defaults": {
@@ -5029,10 +5010,10 @@
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "dev": true,
       "requires": {
-        "array-each": "^1.0.1",
-        "array-slice": "^1.0.0",
-        "for-own": "^1.0.0",
-        "isobject": "^3.0.0"
+        "array-each": "1.0.1",
+        "array-slice": "1.1.0",
+        "for-own": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "object.map": {
@@ -5041,8 +5022,8 @@
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "dev": true,
       "requires": {
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
       }
     },
     "object.pick": {
@@ -5051,7 +5032,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "object.reduce": {
@@ -5060,8 +5041,8 @@
       "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
       "dev": true,
       "requires": {
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
       }
     },
     "once": {
@@ -5078,7 +5059,7 @@
       "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "isarray": {
@@ -5099,13 +5080,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -5114,7 +5095,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -5131,9 +5112,9 @@
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
       }
     },
     "p-finally": {
@@ -5148,7 +5129,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -5157,7 +5138,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.3.0"
       }
     },
     "p-try": {
@@ -5172,9 +5153,9 @@
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "dev": true,
       "requires": {
-        "is-absolute": "^1.0.0",
-        "map-cache": "^0.2.0",
-        "path-root": "^0.1.1"
+        "is-absolute": "1.0.0",
+        "map-cache": "0.2.2",
+        "path-root": "0.1.1"
       }
     },
     "parse-json": {
@@ -5183,7 +5164,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.2"
       }
     },
     "parse-node-version": {
@@ -5245,7 +5226,7 @@
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "requires": {
-        "path-root-regex": "^0.1.0"
+        "path-root-regex": "0.1.2"
       }
     },
     "path-root-regex": {
@@ -5260,9 +5241,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "graceful-fs": "4.1.15",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "pause-stream": {
@@ -5271,7 +5252,7 @@
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
-        "through": "~2.3"
+        "through": "2.3.8"
       },
       "dependencies": {
         "through": {
@@ -5312,7 +5293,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "plugin-error": {
@@ -5321,11 +5302,11 @@
       "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
       "dev": true,
       "requires": {
-        "ansi-cyan": "^0.1.1",
-        "ansi-red": "^0.1.1",
-        "arr-diff": "^1.0.1",
-        "arr-union": "^2.0.1",
-        "extend-shallow": "^1.1.2"
+        "ansi-cyan": "0.1.1",
+        "ansi-red": "0.1.1",
+        "arr-diff": "1.1.0",
+        "arr-union": "2.1.0",
+        "extend-shallow": "1.1.4"
       },
       "dependencies": {
         "arr-diff": {
@@ -5334,8 +5315,8 @@
           "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1",
-            "array-slice": "^0.2.3"
+            "arr-flatten": "1.1.0",
+            "array-slice": "0.2.3"
           }
         },
         "array-slice": {
@@ -5352,7 +5333,7 @@
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "dev": true,
       "requires": {
-        "irregular-plurals": "^1.0.0"
+        "irregular-plurals": "1.4.0"
       }
     },
     "posix-character-classes": {
@@ -5397,8 +5378,8 @@
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       },
       "dependencies": {
         "end-of-stream": {
@@ -5407,7 +5388,7 @@
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
-            "once": "^1.4.0"
+            "once": "1.4.0"
           }
         }
       }
@@ -5418,9 +5399,9 @@
       "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
       "dev": true,
       "requires": {
-        "duplexify": "^3.5.3",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
+        "duplexify": "3.5.4",
+        "inherits": "2.0.3",
+        "pump": "2.0.1"
       }
     },
     "punycode": {
@@ -5441,9 +5422,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.5.0",
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
@@ -5452,8 +5433,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -5462,8 +5443,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-exists": {
@@ -5472,7 +5453,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         }
       }
@@ -5483,10 +5464,10 @@
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
         "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
+        "string_decoder": "0.10.31"
       },
       "dependencies": {
         "core-util-is": {
@@ -5509,9 +5490,9 @@
       "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
+        "graceful-fs": "4.1.15",
+        "micromatch": "3.1.10",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "isarray": {
@@ -5532,13 +5513,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -5547,7 +5528,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -5558,7 +5539,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.3.3"
       }
     },
     "reflect-metadata": {
@@ -5578,8 +5559,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -5588,8 +5569,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           }
         },
         "is-extendable": {
@@ -5598,7 +5579,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -5609,8 +5590,8 @@
       "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5",
-        "is-utf8": "^0.2.1"
+        "is-buffer": "1.1.5",
+        "is-utf8": "0.2.1"
       }
     },
     "remove-bom-stream": {
@@ -5619,9 +5600,9 @@
       "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
       "dev": true,
       "requires": {
-        "remove-bom-buffer": "^3.0.0",
-        "safe-buffer": "^5.1.0",
-        "through2": "^2.0.3"
+        "remove-bom-buffer": "3.0.0",
+        "safe-buffer": "5.1.1",
+        "through2": "2.0.3"
       }
     },
     "remove-trailing-separator": {
@@ -5654,9 +5635,9 @@
       "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1",
-        "is-absolute": "^1.0.0",
-        "remove-trailing-separator": "^1.1.0"
+        "homedir-polyfill": "1.0.3",
+        "is-absolute": "1.0.0",
+        "remove-trailing-separator": "1.1.0"
       },
       "dependencies": {
         "remove-trailing-separator": {
@@ -5673,26 +5654,26 @@
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.7",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.3",
+        "har-validator": "5.1.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.24",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       },
       "dependencies": {
         "extend": {
@@ -5736,8 +5717,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       }
     },
     "resolve-options": {
@@ -5746,7 +5727,7 @@
       "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
       "dev": true,
       "requires": {
-        "value-or-function": "^3.0.0"
+        "value-or-function": "3.0.0"
       }
     },
     "resolve-url": {
@@ -5767,7 +5748,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.3"
       }
     },
     "run-sequence": {
@@ -5776,8 +5757,8 @@
       "integrity": "sha1-UJWgvr6YczsBQL0I3YDsAw3azes=",
       "dev": true,
       "requires": {
-        "chalk": "*",
-        "gulp-util": "*"
+        "chalk": "1.1.3",
+        "gulp-util": "3.0.8"
       }
     },
     "safe-buffer": {
@@ -5792,7 +5773,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -5818,7 +5799,7 @@
       "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
       "dev": true,
       "requires": {
-        "sver-compat": "^1.5.0"
+        "sver-compat": "1.5.0"
       }
     },
     "set-blocking": {
@@ -5833,10 +5814,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -5845,7 +5826,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -5856,7 +5837,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -5876,7 +5857,7 @@
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
-        "is-arrayish": "^0.3.1"
+        "is-arrayish": "0.3.2"
       }
     },
     "snapdragon": {
@@ -5885,14 +5866,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "3.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -5901,7 +5882,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -5910,7 +5891,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "source-map": {
@@ -5927,9 +5908,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -5938,7 +5919,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -5947,7 +5928,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -5956,7 +5937,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -5965,9 +5946,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -5978,7 +5959,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5987,7 +5968,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         }
       }
@@ -6003,11 +5984,11 @@
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
       "requires": {
-        "atob": "^2.0.0",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.0",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-url": {
@@ -6034,8 +6015,8 @@
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.4"
       }
     },
     "spdx-exceptions": {
@@ -6050,8 +6031,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.2.0",
+        "spdx-license-ids": "3.0.4"
       }
     },
     "spdx-license-ids": {
@@ -6066,7 +6047,7 @@
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "dev": true,
       "requires": {
-        "through": "2"
+        "through": "2.3.8"
       },
       "dependencies": {
         "through": {
@@ -6083,7 +6064,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -6092,8 +6073,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           }
         },
         "is-extendable": {
@@ -6102,7 +6083,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -6119,15 +6100,15 @@
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "stack-trace": {
@@ -6142,8 +6123,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -6152,7 +6133,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -6163,7 +6144,7 @@
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1"
+        "duplexer": "0.1.1"
       }
     },
     "stream-exhaust": {
@@ -6184,8 +6165,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       }
     },
     "string_decoder": {
@@ -6200,8 +6181,8 @@
       "integrity": "sha1-xi0RAj6yH+LZsIe+A5om3zsioJ0=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "^1.0.0",
-        "is-regexp": "^1.0.0"
+        "is-plain-obj": "1.1.0",
+        "is-regexp": "1.0.0"
       }
     },
     "strip-ansi": {
@@ -6210,7 +6191,7 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "3.0.0"
       }
     },
     "strip-bom": {
@@ -6219,7 +6200,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "^0.2.0"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-eof": {
@@ -6240,8 +6221,8 @@
       "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
       "dev": true,
       "requires": {
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "through": {
@@ -6256,8 +6237,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -6298,8 +6279,8 @@
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "dev": true,
       "requires": {
-        "through2": "~2.0.0",
-        "xtend": "~4.0.0"
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "xtend": {
@@ -6316,7 +6297,7 @@
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "time-stamp": {
@@ -6337,8 +6318,8 @@
       "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
       "dev": true,
       "requires": {
-        "is-absolute": "^1.0.0",
-        "is-negated-glob": "^1.0.0"
+        "is-absolute": "1.0.0",
+        "is-negated-glob": "1.0.0"
       },
       "dependencies": {
         "is-absolute": {
@@ -6347,8 +6328,8 @@
           "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
           "dev": true,
           "requires": {
-            "is-relative": "^1.0.0",
-            "is-windows": "^1.0.1"
+            "is-relative": "1.0.0",
+            "is-windows": "1.0.2"
           }
         },
         "is-relative": {
@@ -6357,7 +6338,7 @@
           "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
           "dev": true,
           "requires": {
-            "is-unc-path": "^1.0.0"
+            "is-unc-path": "1.0.0"
           }
         },
         "is-unc-path": {
@@ -6366,7 +6347,7 @@
           "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
           "dev": true,
           "requires": {
-            "unc-path-regex": "^0.1.2"
+            "unc-path-regex": "0.1.2"
           }
         },
         "is-windows": {
@@ -6383,7 +6364,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6392,7 +6373,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         }
       }
@@ -6403,10 +6384,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -6415,8 +6396,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           }
         },
         "is-extendable": {
@@ -6425,7 +6406,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -6436,8 +6417,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       }
     },
     "to-through": {
@@ -6446,7 +6427,7 @@
       "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
       "dev": true,
       "requires": {
-        "through2": "^2.0.3"
+        "through2": "2.0.3"
       }
     },
     "tough-cookie": {
@@ -6455,8 +6436,8 @@
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
+        "psl": "1.1.31",
+        "punycode": "1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -6479,19 +6460,19 @@
       "integrity": "sha512-UxG2yNxJ5pgGwmMzPMYh/CCnCnh0HfPgtlVRDs1ykZklufFBL1ZoTlWFRz2NQjcoEiDoRp+JyT0lhBbbH/obyA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^3.2.0",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.13.0",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.8.0",
-        "tsutils": "^2.29.0"
+        "@babel/code-frame": "7.0.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.4.2",
+        "commander": "2.15.1",
+        "diff": "3.5.0",
+        "glob": "7.1.3",
+        "js-yaml": "3.13.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "resolve": "1.3.3",
+        "semver": "5.6.0",
+        "tslib": "1.9.0",
+        "tsutils": "2.29.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6500,7 +6481,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -6509,9 +6490,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "supports-color": {
@@ -6520,7 +6501,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "tsutils": {
@@ -6529,7 +6510,7 @@
           "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
           "dev": true,
           "requires": {
-            "tslib": "^1.8.1"
+            "tslib": "1.9.0"
           }
         }
       }
@@ -6542,7 +6523,7 @@
       "requires": {
         "doctrine": "0.7.2",
         "tslib": "1.9.0",
-        "tsutils": "^3.0.0"
+        "tsutils": "3.10.0"
       },
       "dependencies": {
         "tsutils": {
@@ -6551,7 +6532,7 @@
           "integrity": "sha512-q20XSMq7jutbGB8luhKKsQldRKWvyBO2BGqni3p4yq8Ys9bEP/xQw3KepKmMRt9gJ4lvQSScrihJrcKdKoSU7Q==",
           "dev": true,
           "requires": {
-            "tslib": "^1.8.1"
+            "tslib": "1.9.0"
           }
         }
       }
@@ -6562,7 +6543,7 @@
       "integrity": "sha512-u6tK+tgt8Z1YRJxe4kpWWEx/6FTFxdga50+osnANifsfC7BMzh8c/t/XbNntTRiwMfpHkQ9xtUjizCDLxN1Yeg==",
       "dev": true,
       "requires": {
-        "tsutils": "^2.27.2 <2.29.0"
+        "tsutils": "2.28.0"
       }
     },
     "tsutils": {
@@ -6571,7 +6552,7 @@
       "integrity": "sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==",
       "dev": true,
       "requires": {
-        "tslib": "^1.8.1"
+        "tslib": "1.9.0"
       }
     },
     "tunnel-agent": {
@@ -6580,7 +6561,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "tweetnacl": {
@@ -6601,9 +6582,9 @@
       "integrity": "sha512-DtRNLb7x8yCTv/KHlwes+NI+aGb4Vl1iPC63Hhtcvk1DpxSAZzKWQv0RQFY0jX2Uqj0SDBNl8Na4e6MV6TNDgw==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "lodash": "^4.17.4",
-        "postinstall-build": "^5.0.1"
+        "circular-json": "0.3.3",
+        "lodash": "4.17.10",
+        "postinstall-build": "5.0.1"
       },
       "dependencies": {
         "lodash": {
@@ -6632,15 +6613,15 @@
       "integrity": "sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.0.1",
-        "arr-map": "^2.0.0",
-        "bach": "^1.0.0",
-        "collection-map": "^1.0.0",
-        "es6-weak-map": "^2.0.1",
-        "last-run": "^1.1.0",
-        "object.defaults": "^1.0.0",
-        "object.reduce": "^1.0.0",
-        "undertaker-registry": "^1.0.0"
+        "arr-flatten": "1.1.0",
+        "arr-map": "2.0.2",
+        "bach": "1.2.0",
+        "collection-map": "1.0.0",
+        "es6-weak-map": "2.0.2",
+        "last-run": "1.1.1",
+        "object.defaults": "1.1.0",
+        "object.reduce": "1.0.1",
+        "undertaker-registry": "1.0.1"
       }
     },
     "undertaker-registry": {
@@ -6655,10 +6636,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "arr-union": {
@@ -6673,7 +6654,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -6682,10 +6663,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -6696,8 +6677,8 @@
       "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
       "dev": true,
       "requires": {
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "through2-filter": "^3.0.0"
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "through2-filter": "3.0.0"
       },
       "dependencies": {
         "through2-filter": {
@@ -6706,8 +6687,8 @@
           "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
           "dev": true,
           "requires": {
-            "through2": "~2.0.0",
-            "xtend": "~4.0.0"
+            "through2": "2.0.3",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -6718,8 +6699,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -6728,9 +6709,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -6770,7 +6751,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "urix": {
@@ -6803,7 +6784,7 @@
       "integrity": "sha512-MtivA7GF24yMPte9Rp/BWGCYQNaUj86zeYxV/x2RRJMKagImbbv3u8iJC57lNhWLPcGLJmHcHmFWkNsplbbLWw==",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.3"
       }
     },
     "validate-npm-package-license": {
@@ -6812,8 +6793,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.1.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "value-or-function": {
@@ -6828,9 +6809,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "vinyl": {
@@ -6839,8 +6820,8 @@
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.0",
-        "clone-stats": "^0.0.1",
+        "clone": "1.0.4",
+        "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       }
     },
@@ -6850,23 +6831,23 @@
       "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
       "dev": true,
       "requires": {
-        "fs-mkdirp-stream": "^1.0.0",
-        "glob-stream": "^6.1.0",
-        "graceful-fs": "^4.0.0",
-        "is-valid-glob": "^1.0.0",
-        "lazystream": "^1.0.0",
-        "lead": "^1.0.0",
-        "object.assign": "^4.0.4",
-        "pumpify": "^1.3.5",
-        "readable-stream": "^2.3.3",
-        "remove-bom-buffer": "^3.0.0",
-        "remove-bom-stream": "^1.2.0",
-        "resolve-options": "^1.1.0",
-        "through2": "^2.0.0",
-        "to-through": "^2.0.0",
-        "value-or-function": "^3.0.0",
-        "vinyl": "^2.0.0",
-        "vinyl-sourcemap": "^1.1.0"
+        "fs-mkdirp-stream": "1.0.0",
+        "glob-stream": "6.1.0",
+        "graceful-fs": "4.1.15",
+        "is-valid-glob": "1.0.0",
+        "lazystream": "1.0.0",
+        "lead": "1.0.0",
+        "object.assign": "4.1.0",
+        "pumpify": "1.4.0",
+        "readable-stream": "2.3.6",
+        "remove-bom-buffer": "3.0.0",
+        "remove-bom-stream": "1.2.0",
+        "resolve-options": "1.1.0",
+        "through2": "2.0.3",
+        "to-through": "2.0.0",
+        "value-or-function": "3.0.0",
+        "vinyl": "2.2.0",
+        "vinyl-sourcemap": "1.1.0"
       },
       "dependencies": {
         "clone": {
@@ -6899,13 +6880,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "replace-ext": {
@@ -6920,7 +6901,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "vinyl": {
@@ -6929,12 +6910,12 @@
           "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
           "dev": true,
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.2",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.1",
+            "remove-trailing-separator": "1.0.2",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -6945,13 +6926,13 @@
       "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
       "dev": true,
       "requires": {
-        "append-buffer": "^1.0.2",
-        "convert-source-map": "^1.5.0",
-        "graceful-fs": "^4.1.6",
-        "normalize-path": "^2.1.1",
-        "now-and-later": "^2.0.0",
-        "remove-bom-buffer": "^3.0.0",
-        "vinyl": "^2.0.0"
+        "append-buffer": "1.0.2",
+        "convert-source-map": "1.5.0",
+        "graceful-fs": "4.1.11",
+        "normalize-path": "2.1.1",
+        "now-and-later": "2.0.0",
+        "remove-bom-buffer": "3.0.0",
+        "vinyl": "2.1.0"
       },
       "dependencies": {
         "clone": {
@@ -6984,12 +6965,12 @@
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "dev": true,
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.1",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.1",
+            "remove-trailing-separator": "1.0.2",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -6999,7 +6980,7 @@
       "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.33.0-pre.2.tgz",
       "integrity": "sha512-H5J1YTjsuiBmdnjl/zvrSTNClfcoz/i4tWDoxvW4FEE3jEfhW2npapiwJkLuzVFnv7tlU0iiJzqhv2iYwBFZoA==",
       "requires": {
-        "mkdirp": "^0.5.1",
+        "mkdirp": "0.5.1",
         "vscode-debugprotocol": "1.32.0"
       },
       "dependencies": {
@@ -7026,18 +7007,18 @@
       "integrity": "sha512-PsL6k363fp5vHZEVJX0ywT7Uem1WvqnFG/eRGxsjOIPYAXQQl8bhJSxm+kNofM8nchZOAnScbtFRz70z9evkqw==",
       "dev": true,
       "requires": {
-        "ansi-colors": "^3.2.3",
-        "clone": "^2.1.1",
-        "event-stream": "^3.3.4",
-        "fancy-log": "^1.3.3",
-        "glob": "^7.1.2",
-        "iconv-lite": "^0.4.19",
-        "is": "^3.2.1",
-        "source-map": "^0.6.1",
-        "typescript": "^2.6.2",
-        "vinyl": "^2.1.0",
-        "xml2js": "^0.4.19",
-        "yargs": "^10.1.1"
+        "ansi-colors": "3.2.4",
+        "clone": "2.1.2",
+        "event-stream": "3.3.4",
+        "fancy-log": "1.3.3",
+        "glob": "7.1.3",
+        "iconv-lite": "0.4.24",
+        "is": "3.3.0",
+        "source-map": "0.6.1",
+        "typescript": "2.9.2",
+        "vinyl": "2.2.0",
+        "xml2js": "0.4.19",
+        "yargs": "10.1.2"
       },
       "dependencies": {
         "ansi-colors": {
@@ -7064,10 +7045,10 @@
           "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
           "dev": true,
           "requires": {
-            "ansi-gray": "^0.1.1",
-            "color-support": "^1.1.3",
-            "parse-node-version": "^1.0.0",
-            "time-stamp": "^1.0.0"
+            "ansi-gray": "0.1.1",
+            "color-support": "1.1.3",
+            "parse-node-version": "1.0.1",
+            "time-stamp": "1.1.0"
           }
         },
         "replace-ext": {
@@ -7094,12 +7075,12 @@
           "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
           "dev": true,
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.2",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.1",
+            "remove-trailing-separator": "1.0.2",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -7115,7 +7096,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       },
       "dependencies": {
         "isexe": {
@@ -7134,12 +7115,12 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7154,7 +7135,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -7163,9 +7144,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-ansi": {
@@ -7174,7 +7155,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -7189,7 +7170,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-6.0.0.tgz",
       "integrity": "sha512-c2UlYcAZp1VS8AORtpq6y4RJIkJ9dQz18W32SpR/qXGfLDZ2jU4y4wKvvZwqbi7U6gxFQTeE+urMbXU/tsDy4w==",
       "requires": {
-        "async-limiter": "~1.0.0"
+        "async-limiter": "1.0.0"
       }
     },
     "xml2js": {
@@ -7198,8 +7179,8 @@
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "dev": true,
       "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
       }
     },
     "xmlbuilder": {
@@ -7232,18 +7213,18 @@
       "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
       "dev": true,
       "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.1.1",
-        "find-up": "^2.1.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^8.1.0"
+        "cliui": "4.1.0",
+        "decamelize": "1.2.0",
+        "find-up": "2.1.0",
+        "get-caller-file": "1.0.3",
+        "os-locale": "2.1.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "8.1.0"
       }
     },
     "yargs-parser": {
@@ -7252,7 +7233,7 @@
       "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
       "dev": true,
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "4.1.0"
       }
     },
     "yauzl": {
@@ -7261,7 +7242,7 @@
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "dev": true,
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "fd-slicer": "1.0.1"
       }
     }
   }

--- a/src/chrome/cdtpDebuggee/registries/cdtpScriptsRegistry.ts
+++ b/src/chrome/cdtpDebuggee/registries/cdtpScriptsRegistry.ts
@@ -10,6 +10,8 @@ import { injectable } from 'inversify';
 import { IResourceIdentifier, newResourceIdentifierMap } from '../../internal/sources/resourceIdentifier';
 import { FrameId } from '../cdtpPrimitives';
 import * as _ from 'lodash';
+import { DoNotLog } from '../../logging/decorators';
+import { printMap } from '../../collections/printing';
 
 /**
  * TODO: The CDTPScriptsRegistry is still a work in progress. We need to understand exactly how the ExecutionContexts, the Scripts, and the script "generations" work to figure out the best way to implement this
@@ -45,6 +47,7 @@ export class CDTPScriptsRegistry {
         return this._scripts.getCdtpId(script);
     }
 
+    @DoNotLog()
     public getScriptByCdtpId(runtimeScriptCrdpId: CDTP.Runtime.ScriptId): Promise<IScript> {
         return this._scripts.getScriptByCdtpId(runtimeScriptCrdpId);
     }
@@ -55,6 +58,10 @@ export class CDTPScriptsRegistry {
 
     public getScriptsByPath(nameOrLocation: IResourceIdentifier): IScript[] {
         return this._scripts.getScriptByPath(nameOrLocation);
+    }
+
+    public toString(): string {
+        return `${this._scripts}`;
     }
 }
 
@@ -102,5 +109,9 @@ class CDTPCurrentGeneration {
     public getScriptByPath(path: IResourceIdentifier): IScript[] {
         const runtimeScript = this._scriptByPath.tryGetting(path);
         return _.defaultTo(runtimeScript, []);
+    }
+
+    public toString(): string {
+        return printMap('Script to ID', this._scriptByCdtpId);
     }
 }

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -42,7 +42,7 @@ import { FormattedExceptionParser } from './internal/formattedExceptionParser';
 import { injectable, inject } from 'inversify';
 import { TYPES } from './dependencyInjection.ts/types';
 import { ICDTPDebuggeeExecutionEventsProvider, PausedEvent } from './cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider';
-import { ILogEntry, CDTPLogEventsProvider } from './cdtpDebuggee/eventsProviders/cdtpLogEventsProvider';
+import { ILogEntry, ILogEventsProvider } from './cdtpDebuggee/eventsProviders/cdtpLogEventsProvider';
 import { IConsoleEventsProvider, IConsoleAPICalledEvent } from './cdtpDebuggee/eventsProviders/cdtpConsoleEventsProvider';
 import { IPauseOnExceptionsConfigurer } from './cdtpDebuggee/features/cdtpPauseOnExceptionsConfigurer';
 import { CDTPExceptionThrownEventsProvider, IExceptionThrownEvent } from './cdtpDebuggee/eventsProviders/cdtpExceptionThrownEventsProvider';
@@ -131,7 +131,7 @@ export class ChromeDebugLogic {
         @inject(TYPES.ConnectedCDAConfiguration) private readonly _configuration: ConnectedCDAConfiguration,
         @inject(TYPES.ICDTPDebuggeeExecutionEventsProvider) private readonly _debuggerEvents: ICDTPDebuggeeExecutionEventsProvider,
         @inject(TYPES.IConsoleEventsProvider) private readonly _consoleEventsProvider: IConsoleEventsProvider,
-        @inject(TYPES.ILogEventsProvider) private readonly _logEventsProvider: CDTPLogEventsProvider,
+        @inject(TYPES.ILogEventsProvider) private readonly _logEventsProvider: ILogEventsProvider,
         @inject(TYPES.IPauseOnExceptions) private readonly _pauseOnExceptions: IPauseOnExceptionsConfigurer,
     ) {
         telemetry.setupEventHandler(e => session.sendEvent(e));

--- a/src/chrome/client/chromeDebugAdapter/cdaDIContainerCreator.ts
+++ b/src/chrome/client/chromeDebugAdapter/cdaDIContainerCreator.ts
@@ -36,6 +36,7 @@ export function createDIContainer(chromeDebugAdapter: ChromeDebugAdapter, rawDeb
             return diContainer.createComponent<UnconnectedCDA>(TYPES.UnconnectedCDA);
         })
         .configureClass(TYPES.IDebuggeeRunner, debugSessionOptions.extensibilityPoints.debuggeeRunner)
+        .configureClass(TYPES.IDebuggeeInitializer, debugSessionOptions.extensibilityPoints.debuggeeInitializer)
         .configureClass(TYPES.IDebuggeeLauncher, debugSessionOptions.extensibilityPoints.debuggeeLauncher)
         .configureClass(TYPES.ChromeTargetDiscovery, ChromeTargetDiscovery)
         .configureClass(TYPES.ChromeConnection, ChromeConnection)

--- a/src/chrome/debugeeStartup/debugeeLauncher.ts
+++ b/src/chrome/debugeeStartup/debugeeLauncher.ts
@@ -4,6 +4,7 @@
 
 import { ITelemetryPropertyCollector } from '../../telemetry';
 import { ILaunchRequestArgs } from '../../debugAdapterInterfaces';
+import { injectable } from 'inversify';
 
 export interface ILaunchResult {
     address?: string;
@@ -14,6 +15,15 @@ export interface ILaunchResult {
 export interface IDebuggeeLauncher {
     launch(args: ILaunchRequestArgs, telemetryPropertyCollector: ITelemetryPropertyCollector): Promise<ILaunchResult>;
     stop(): Promise<void>;
+}
+
+export interface IDebuggeeInitializer {
+    initialize(): Promise<void>;
+}
+
+@injectable()
+export class NoDebuggeeInitializer implements IDebuggeeInitializer {
+    public async initialize(): Promise<void> {}
 }
 
 export interface IDebuggeeRunner {

--- a/src/chrome/dependencyInjection.ts/types.ts
+++ b/src/chrome/dependencyInjection.ts/types.ts
@@ -36,6 +36,7 @@ const TYPES = {
     BasePathTransformer: Symbol.for('BasePathTransformer'),
     ChromeTargetDiscovery: Symbol.for('ChromeTargetDiscovery'),
     IRuntimeStarter: Symbol.for('IRuntimeStarter'),
+    IDebuggeeInitializer: Symbol.for('IDebuggeeInitializer'),
     SyncStepping: Symbol.for('SyncStepping'),
     AsyncStepping: Symbol.for('AsyncStepping'),
     ConnectedCDAConfiguration: Symbol.for('ConnectedCDAConfiguration'),

--- a/src/chrome/extensibility/extensibilityPoints.ts
+++ b/src/chrome/extensibility/extensibilityPoints.ts
@@ -8,7 +8,7 @@ import { BasePathTransformer } from '../../transformers/basePathTransformer';
 import { LineColTransformer } from '../../transformers/lineNumberTransformer';
 import { ILaunchRequestArgs, IAttachRequestArgs } from '../../debugAdapterInterfaces';
 import { interfaces } from 'inversify';
-import { IDebuggeeLauncher, IDebuggeeRunner } from '../debugeeStartup/debugeeLauncher';
+import { IDebuggeeLauncher, IDebuggeeRunner, IDebuggeeInitializer, NoDebuggeeInitializer } from '../debugeeStartup/debugeeLauncher';
 import { IConnectedCDAConfiguration } from '../client/chromeDebugAdapter/cdaConfiguration';
 import { ComponentCustomizationCallback, DependencyInjection } from '../dependencyInjection.ts/di';
 import { CommandText } from '../client/requests';
@@ -20,6 +20,7 @@ export interface IExtensibilityPoints {
     componentCustomizationCallback: ComponentCustomizationCallback;
     isPromiseRejectExceptionFilterEnabled: boolean;
     debuggeeLauncher: interfaces.Newable<IDebuggeeLauncher>;
+    debuggeeInitializer: interfaces.Newable<IDebuggeeInitializer>;
     debuggeeRunner: interfaces.Newable<IDebuggeeRunner>;
 
     targetFilter?: ITargetFilter;
@@ -48,14 +49,15 @@ export class OnlyProvideCustomLauncherExtensibilityPoints implements IExtensibil
         public readonly logFilePath: string,
         public readonly debuggeeLauncher: interfaces.Newable<IDebuggeeLauncher>,
         public readonly debuggeeRunner: interfaces.Newable<IDebuggeeRunner>,
-        public readonly componentCustomizationCallback: ComponentCustomizationCallback) {
+        public readonly componentCustomizationCallback: ComponentCustomizationCallback,
+        public readonly debuggeeInitializer: interfaces.Newable<IDebuggeeInitializer> = NoDebuggeeInitializer) {
     }
 
     public customizeProtocolApi(protocolApi: CDTP.ProtocolApi): CDTP.ProtocolApi {
         return protocolApi;
     }
 
-    public bindAdditionalComponents(_diContainer: DependencyInjection): void {}
+    public bindAdditionalComponents(_diContainer: DependencyInjection): void { }
 
     public updateArguments<T extends ILaunchRequestArgs | IAttachRequestArgs>(_scenarioType: ScenarioType, argumentsFromClient: T): T {
         return argumentsFromClient;

--- a/src/chrome/internal/features/pauseActionsPriorities.ts
+++ b/src/chrome/internal/features/pauseActionsPriorities.ts
@@ -1,7 +1,6 @@
 /*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
-import { ValidatedMap } from '../../collections/validatedMap';
 import { IActionToTakeWhenPaused } from './actionToTakeWhenPaused';
 import { ShouldStepInToAvoidSkippedSource } from './smartStep';
 import { HitBreakpoint, NoRecognizedBreakpoints } from '../breakpoints/features/bpRecipeAtLoadedSourceLogic';
@@ -13,7 +12,7 @@ import { PausedBecauseAsyncCallWasScheduled } from '../stepping/features/asyncSt
 
 export type ActionToTakeWhenPausedClass = { new(...args: any[]): IActionToTakeWhenPaused };
 
-const actionsFromHighestToLowestPriority: ActionToTakeWhenPausedClass[] = [
+export const actionsFromHighestToLowestPriority: ActionToTakeWhenPausedClass[] = [
     ShouldStepInToAvoidSkippedSource, // Stepping in to avoid a skipped source takes preference over hitting breakpoints, even user pausing, etc...
 
     UserPaused, // The user requesting to pause takes preferences over everything else
@@ -34,6 +33,3 @@ const actionsFromHighestToLowestPriority: ActionToTakeWhenPausedClass[] = [
 
     NoRecognizedBreakpoints,
 ];
-
-const priorityIndexAndActionClassPairs = actionsFromHighestToLowestPriority.map((situationClass, index) => <[ActionToTakeWhenPausedClass, number]>[situationClass, index]);
-export const actionClassToPriorityIndexMapping = new ValidatedMap(priorityIndexAndActionClassPairs);

--- a/src/chrome/internal/stackTraces/callFrame.ts
+++ b/src/chrome/internal/stackTraces/callFrame.ts
@@ -7,6 +7,7 @@ import { ILoadedSource } from '../sources/loadedSource';
 import { IScript } from '../scripts/script';
 import { Protocol as CDTP } from 'devtools-protocol';
 import { Scope } from './scopes';
+import { printArray } from '../../collections/printing';
 
 /**
  * CDTP has two types of stack traces:
@@ -46,7 +47,7 @@ export class CodeFlowFrame<TResource extends ScriptOrLoadedSource> {
     }
 
     public toString(): string {
-        return `${this.functionName} at ${this.location}`;
+        return `${this.index}: ${this.functionName} at ${this.location}`;
     }
 }
 
@@ -95,6 +96,10 @@ abstract class BaseCallFrame<TResource extends ScriptOrLoadedSource> implements 
     public get functionName(): string {
         return this.codeFlow.functionName;
     }
+
+    public toString(): string {
+        return `${this.codeFlow} {${this.state}}`;
+    }
 }
 
 export interface ICallFrameState {}
@@ -104,6 +109,10 @@ export class CallFrameWithState implements ICallFrameState {
         public readonly scopeChain: Scope[],
         public readonly frameThis: CDTP.Runtime.RemoteObject,
         public readonly returnValue?: CDTP.Runtime.RemoteObject) {}
+
+    public toString(): string {
+        return printArray('Scopes', this.scopeChain);
+    }
 }
 
 export class CallFrameWithoutState implements ICallFrameState {}

--- a/src/chrome/internal/stackTraces/callFramePresentation.ts
+++ b/src/chrome/internal/stackTraces/callFramePresentation.ts
@@ -72,6 +72,10 @@ export class CallFramePresentation implements IStackTracePresentationRow {
 
         return formattedDescription;
     }
+
+    public toString(): string {
+        return `${this.callFrame}[printed with ${this._descriptionFormatArgs} and ${JSON.stringify(this.additionalPresentationDetails)}](${this.presentationHint})`;
+    }
 }
 
 export function functionDescription(functionName: string | undefined, functionModule: ILoadedSource): string {

--- a/src/chrome/internal/stackTraces/currentStackTraceProvider.ts
+++ b/src/chrome/internal/stackTraces/currentStackTraceProvider.ts
@@ -57,6 +57,10 @@ class CurrentStackTraceProviderWhenPaused implements ICurrentStackTraceProviderS
     public onResumed(changeStateTo: (newState: ICurrentStackTraceProviderState) => void): void {
         changeStateTo(new CurrentStackTraceProviderWhenNotPaused());
     }
+
+    public toString(): string {
+        return `Paused on: ${this._currentPauseEvent}`;
+    }
 }
 
 class CurrentStackTraceProviderWhenNotPaused implements ICurrentStackTraceProviderState {

--- a/src/chrome/internal/stackTraces/scopes.ts
+++ b/src/chrome/internal/stackTraces/scopes.ts
@@ -2,7 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
- import { LocationInScript } from '../locations/location';
+import { LocationInScript } from '../locations/location';
 import { CDTPNonPrimitiveRemoteObject } from '../../cdtpDebuggee/cdtpPrimitives';
 
 /** This class represents a variable's scope (Globals, locals, block variables, etc...) */
@@ -13,4 +13,8 @@ export class Scope {
         public readonly name?: string,
         public readonly startLocation?: LocationInScript,
         public readonly endLocation?: LocationInScript) { }
+
+    public toString(): string {
+        return `${this.type}`;
+    }
 }

--- a/src/chrome/internal/stackTraces/stackTracePresenter.ts
+++ b/src/chrome/internal/stackTraces/stackTracePresenter.ts
@@ -35,9 +35,16 @@ export interface IStackTraceFormat {}
 
 export class StackTraceCustomFormat implements IStackTraceFormat {
     public constructor(public readonly formatOptions: DebugProtocol.StackFrameFormat) { }
+
+    public toString(): string {
+        return JSON.stringify(this.formatOptions);
+    }
 }
 
 export class StackTraceDefaultFormat implements IStackTraceFormat {
+    public toString(): string {
+        return `default format`;
+    }
 }
 
 /**

--- a/src/chrome/logging/decorators.ts
+++ b/src/chrome/logging/decorators.ts
@@ -1,0 +1,19 @@
+// tslint:disable-next-line: no-var-requires
+const util = require('util');
+
+const DoNotLogMark = Symbol();
+
+interface HasLoggingMarks {
+    [DoNotLogMark]?: boolean;
+}
+
+export function shouldLog(object: HasLoggingMarks) {
+    return util.types.isProxy(object) || !object || object[DoNotLogMark] !== true;
+}
+
+export function DoNotLog(): (target: any, propertyKey: string, descriptor: PropertyDescriptor) => void {
+    return (target: any, propertyKey: string, _descriptor: PropertyDescriptor) => {
+        const method: HasLoggingMarks = target[propertyKey];
+        method[DoNotLogMark] = true;
+    };
+}

--- a/src/chrome/logging/methodsCalledLogger.ts
+++ b/src/chrome/logging/methodsCalledLogger.ts
@@ -4,6 +4,7 @@
 import * as _ from 'lodash';
 import { printTopLevelObjectDescription } from './printObjectDescription';
 import { logger } from 'vscode-debugadapter';
+import { shouldLog } from './decorators';
 
 enum Synchronicity {
     Sync,
@@ -63,6 +64,10 @@ export class MethodsCalledLogger<T extends object> {
         const handler = {
             get: <K extends keyof T>(target: T, propertyKey: K, receiver: any) => {
                 const originalPropertyValue = target[propertyKey];
+                if (!shouldLog(originalPropertyValue)) {
+                    return originalPropertyValue;
+                }
+
                 // tslint:disable-next-line: strict-type-predicates
                 if (typeof originalPropertyValue === 'function') {
                     return (...args: any) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import * as telemetry from './telemetry';
 import * as variables from './chrome/variables';
 import { NullLogger } from './nullLogger';
 import * as executionTimingsReporter from './executionTimingsReporter';
+import * as ChromeUtils from './chrome/chromeUtils';
 
 import { Protocol as CDTP } from 'devtools-protocol';
 import { TargetVersions } from './chrome/chromeTargetDiscoveryStrategy';
@@ -35,9 +36,9 @@ import { Version } from './chrome/utils/version';
 import { parseResourceIdentifier, IResourceIdentifier } from './chrome/internal/sources/resourceIdentifier';
 import { ChromeDebugAdapter } from './chrome/client/chromeDebugAdapter/chromeDebugAdapterV2';
 import { IExtensibilityPoints, OnlyProvideCustomLauncherExtensibilityPoints } from './chrome/extensibility/extensibilityPoints';
-import { IDebuggeeLauncher, ILaunchResult, IDebuggeeRunner } from './chrome/debugeeStartup/debugeeLauncher';
+import { IDebuggeeLauncher, ILaunchResult, IDebuggeeRunner, IDebuggeeInitializer } from './chrome/debugeeStartup/debugeeLauncher';
 import { inject, injectable, postConstruct, interfaces, multiInject } from 'inversify';
-import { ConnectedCDAConfiguration } from './chrome/client/chromeDebugAdapter/cdaConfiguration';
+import { ConnectedCDAConfiguration, IConnectedCDAConfiguration } from './chrome/client/chromeDebugAdapter/cdaConfiguration';
 import { IInstallableComponent, ICommandHandlerDeclarer, IServiceComponent } from './chrome/internal/features/components';
 import { TYPES } from './chrome/dependencyInjection.ts/types';
 import { IDebuggeeStateInspector } from './chrome/cdtpDebuggee/features/cdtpDebugeeStateInspector';
@@ -46,7 +47,7 @@ import { ISupportedDomains } from './chrome/internal/domains/supportedDomains';
 import { ISession } from './chrome/client/session';
 import { IPausedOverlayConfigurer } from './chrome/cdtpDebuggee/features/cdtpPausedOverlayConfigurer';
 import { INetworkCacheConfigurer } from './chrome/cdtpDebuggee/features/cdtpNetworkCacheConfigurer';
-import { IDebuggeeRuntimeVersionProvider } from './chrome/cdtpDebuggee/features/cdtpDebugeeRuntimeVersionProvider';
+import { IDebuggeeRuntimeVersionProvider, CDTPComponentsVersions } from './chrome/cdtpDebuggee/features/cdtpDebugeeRuntimeVersionProvider';
 import { IBrowserNavigator } from './chrome/cdtpDebuggee/features/cdtpBrowserNavigator';
 import { ISourcesRetriever } from './chrome/internal/sources/sourcesRetriever';
 import { ISource } from './chrome/internal/sources/source';
@@ -58,8 +59,17 @@ import { GetComponentByID, DependencyInjection } from './chrome/dependencyInject
 import { BaseCDAState } from './chrome/client/chromeDebugAdapter/baseCDAState';
 import { UninitializedCDA } from './chrome/client/chromeDebugAdapter/uninitializedCDA';
 import { SourceResolver } from './chrome/internal/sources/sourceResolver';
-import { ICDTPDebuggeeExecutionEventsProvider } from './chrome/cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider';
+import { ICDTPDebuggeeExecutionEventsProvider, PausedEvent } from './chrome/cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider';
 import { ScenarioType } from './chrome/client/chromeDebugAdapter/unconnectedCDA';
+import { ILoggingConfiguration } from './chrome/internal/services/logging';
+import { IFinishedStartingUpEventArguments, StepProgressEventsEmitter } from './executionTimingsReporter';
+import { ILogEventsProvider, ILogEntry } from './chrome/cdtpDebuggee/eventsProviders/cdtpLogEventsProvider';
+import { IDOMInstrumentationBreakpointsSetter } from './chrome/cdtpDebuggee/features/cdtpDOMInstrumentationBreakpointsSetter';
+import { IDebuggeePausedHandler } from './chrome/internal/features/debuggeePausedHandler';
+import { IActionToTakeWhenPaused, NoActionIsNeededForThisPause, BasePauseShouldBeAutoResumed } from './chrome/internal/features/actionToTakeWhenPaused';
+import { MakePropertyRequired } from './typeUtils';
+import { printClassDescription } from './chrome/utils/printing';
+import { IDebuggeeExecutionController } from './chrome/cdtpDebuggee/features/cdtpDebugeeExecutionController';
 
 export {
     chromeConnection,
@@ -79,6 +89,7 @@ export {
     OnlyProvideCustomLauncherExtensibilityPoints,
 
     IDebuggeeLauncher,
+    IDebuggeeInitializer,
     IDebuggeeRunner,
     ILaunchResult,
     ConnectedCDAConfiguration,
@@ -155,5 +166,40 @@ export {
 
     DependencyInjection,
 
-    ScenarioType
+    ScenarioType,
+
+    ILoggingConfiguration,
+
+    IFinishedStartingUpEventArguments,
+
+    ChromeUtils,
+
+    ILogEventsProvider,
+
+    CDTPComponentsVersions,
+
+    ILogEntry,
+
+    IDOMInstrumentationBreakpointsSetter,
+
+    IDebuggeePausedHandler,
+
+    PausedEvent,
+
+    IActionToTakeWhenPaused,
+
+    NoActionIsNeededForThisPause,
+
+    StepProgressEventsEmitter,
+
+    IConnectedCDAConfiguration,
+
+    MakePropertyRequired,
+
+    printClassDescription,
+
+    BasePauseShouldBeAutoResumed,
+
+    IDebuggeeExecutionController,
+
 };

--- a/src/sourceMaps/sourceMap.ts
+++ b/src/sourceMaps/sourceMap.ts
@@ -150,6 +150,10 @@ export class SourceMap {
         return new SourceMap(generatedPath, sourceMap, parseResourceIdentifiers(consumer.sources), setOfNormalizedSources, consumer);
     }
 
+    public generatedPath(): string {
+        return this._generatedPath;
+    }
+
     /**
      * Returns list of ISourcePathDetails for all sources in this sourcemap, sorted by their
      * positions within the sourcemap.

--- a/src/sourceMaps/sourceMaps.ts
+++ b/src/sourceMaps/sourceMaps.ts
@@ -14,11 +14,23 @@ import { isNotNull } from '../chrome/utils/typedOperators';
 export class SourceMaps {
     // Maps absolute paths to generated/authored source files to their corresponding SourceMap object
     private _generatedPathToSourceMap = new Map<string, SourceMap>();
+    private _authoredPathToSourceMap = new Map<string, SourceMap>();
 
     private _sourceMapFactory: SourceMapFactory;
 
     public constructor(private readonly _scriptsRegistry: CDTPScriptsRegistry, pathMapping?: IPathMapping, sourceMapPathOverrides?: ISourceMapPathOverrides, enableSourceMapCaching?: boolean) {
         this._sourceMapFactory = new SourceMapFactory(pathMapping, sourceMapPathOverrides, enableSourceMapCaching);
+    }
+
+    /**
+     * Returns the generated script path for an authored source path
+     * @param pathToSource - The absolute path to the authored file
+     */
+    public getGeneratedPathFromAuthoredPath(authoredPath: string): string | null {
+        authoredPath = authoredPath.toLowerCase();
+        return this._authoredPathToSourceMap.has(authoredPath) ?
+            this._authoredPathToSourceMap.get(authoredPath)!.generatedPath() :
+            null;
     }
 
     public mapToAuthored(pathToGenerated: string, line: number, column: number): LocationInLoadedSource | null {

--- a/src/transformers/baseSourceMapTransformer.ts
+++ b/src/transformers/baseSourceMapTransformer.ts
@@ -139,6 +139,20 @@ export class BaseSourceMapTransformer {
         return this._sourceMaps.mapToAuthored(pathToGenerated, line, column);
     }
 
+    public async getGeneratedPathFromAuthoredPath(authoredPath: string): Promise<string | null> {
+        if (!this._sourceMaps) return authoredPath;
+
+        await this.wait();
+
+        // Find the generated path, or check whether this script is actually a runtime path - if so, return that
+        return this._sourceMaps.getGeneratedPathFromAuthoredPath(authoredPath) ||
+            (this.isRuntimeScript(authoredPath) ? authoredPath : null);
+    }
+
+    private isRuntimeScript(scriptPath: string): boolean {
+        return this._allRuntimeScriptPaths.has(this.fixPathCasing(scriptPath));
+    }
+
     public async allSources(pathToGenerated: string): Promise<IResourceIdentifier[]> {
         if (isUndefined(this._sourceMaps)) return [];
 

--- a/src/transformers/remotePathTransformer.ts
+++ b/src/transformers/remotePathTransformer.ts
@@ -19,7 +19,7 @@ import * as _ from 'lodash';
 
 interface IRootsState {
     install(): Promise<void>;
-    getClientPathFromTargetPath(remotePath: IResourceIdentifier): IResourceIdentifier;
+    getClientPathFromTargetPath(remotePath: IResourceIdentifier): IResourceIdentifier | undefined;
     getTargetPathFromClientPath(localPath: IResourceIdentifier): IResourceIdentifier;
 }
 
@@ -72,8 +72,8 @@ class BothRootsAreSet implements IRootsState {
 class MissingRoots implements IRootsState {
     public async install(): Promise<void> {}
 
-    public getClientPathFromTargetPath(_remotePath: IResourceIdentifier): IResourceIdentifier {
-        return parseResourceIdentifier('');
+    public getClientPathFromTargetPath(_remotePath: IResourceIdentifier): IResourceIdentifier | undefined {
+        return undefined;
     }
 
     public getTargetPathFromClientPath(localPath: IResourceIdentifier): IResourceIdentifier {
@@ -111,8 +111,8 @@ export class RemotePathTransformer extends UrlPathTransformer {
         return scriptPath;
     }
 
-    public getClientPathFromTargetPath(remotePath: IResourceIdentifier): IResourceIdentifier {
-        remotePath = _.defaultTo(this.getClientPathFromTargetPath(remotePath), remotePath);
+    public getClientPathFromTargetPath(remotePath: IResourceIdentifier): IResourceIdentifier | undefined {
+        remotePath = _.defaultTo(super.getClientPathFromTargetPath(remotePath), remotePath);
 
         // Map as non-file-uri because remoteRoot won't expect a file uri
         remotePath = parseResourceIdentifier(utils.fileUrlToPath(remotePath.canonicalized));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
         "strict": true,
 
         "lib": [
-            "es6"
+            "es2017"
             ]
     },
     "include": [


### PR DESCRIPTION
- Added several toString() methods while diagnosing some issues, to make inspecting objects easier while debugging
- IDebuggeeInitializer: Created a new step in the "Launching, Initializing, Running" sequence to give a chance to the debug adapter to customize the work we do without finalizing the initialization (On node we wait for a Debugger.paused event)

- cdtpScriptsRegistry.ts: getScriptByCdtpId appeared to often on the logs, not adding that much value. Implemented @DoNotLog() so it won't be logged any more
- connectedCDA.ts: Moved this._chromeConnection.onClose logic to the top of the method in case the connection gets closed before we finish the initialization. Added a call to the DebuggeeInitializer.
- debuggeePausedHandler.ts: Added new methods so custom debug adapters can add custom ActionToTakeWhenPausedClass and give them a priority
- decorators.ts: Added the DoNotLog decorator so we can avoid automatically logging a method that does't add a lot of value
- methodsCalledLogger.ts: Added support for the DoNotLog decorator
- index.ts: Added classes that we referenced while implementing the "fast" Node v2 version
- sourceMaps.ts: Re-added the method getGeneratedPathFromAuthoredPath. I originally deleted because it didn't had references on chrome-debug. node-debug uses it, so I'm re-adding it
- baseSourceMapTransformer.ts: Re-added methods getGeneratedPathFromAuthoredPath and isRuntimeScript that were deleted because they didn't had references on chrome-debug. node-debug uses it, so I'm re-adding them
- remotePathTransformer.ts: The refactoring to _.defaultTo(super.getClientPathFromTargetPath(remotePath), remotePath) introduced a bug: When super.getClientPathFromTargetPath(remotePath) returned parseResourceIdentifier('') the _.defaultTo returned parseResourceIdentifier('') because it's not falsy. Changed the method to return undefined instead, to achieve the correct behavior.