### PR TITLE
More fixes for node v2

### DIFF
--- a/src/chrome/client/chromeDebugAdapter/requestProcessor.ts
+++ b/src/chrome/client/chromeDebugAdapter/requestProcessor.ts
@@ -26,6 +26,6 @@ export class RequestProcessor {
     }
 
     public toString(): string {
-        return printArray(`Request processor for`, Array.from(this._requestHandlerDeclarers.keys()));
+        return printArray(`Request processor for`, Array.from(this._requestNameToHandler.keys()));
     }
 }

--- a/src/chrome/client/chromeDebugAdapter/terminatingCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/terminatingCDA.ts
@@ -47,7 +47,7 @@ export class TerminatingCDA extends BaseCDAState {
 
         await this.terminateSession(this._reason === TerminatingReason.DisconnectedFromWebsocket ? 'Got disconnect request' : 'Disconnected from websocket');
 
-        return new TerminatedCDA(this._session);
+        return new TerminatedCDA(this._session).install();
     }
 
     public async terminateSession(reason: string, restart?: IRestartRequestArgs): Promise<void> {

--- a/src/chrome/client/frameParser.ts
+++ b/src/chrome/client/frameParser.ts
@@ -1,0 +1,25 @@
+import { HandlesRegistry } from './handlesRegistry';
+import { LoadedSourceCallFrame, CallFrameWithState } from '../internal/stackTraces/callFrame';
+import { CallFramePresentation } from '../internal/stackTraces/callFramePresentation';
+import { isDefined } from '../utils/typedOperators';
+import { injectable } from 'inversify';
+
+@injectable()
+export class FrameParser {
+    public constructor(private readonly _handlesRegistry: HandlesRegistry) { }
+
+    public optionalFrameById(frameId: number | undefined): LoadedSourceCallFrame<CallFrameWithState> | undefined {
+        return isDefined(frameId)
+            ? this.frameById(frameId)
+            : undefined;
+    }
+
+    public frameById(frameId: number): LoadedSourceCallFrame<CallFrameWithState> | undefined {
+        const stackTrace = this._handlesRegistry.frames.getObjectById(frameId);
+        if (stackTrace instanceof CallFramePresentation && stackTrace.callFrame.hasState()) {
+            return stackTrace.callFrame;
+        } else {
+            return undefined;
+        }
+    }
+}

--- a/src/chrome/collections/mapUsingProjection.ts
+++ b/src/chrome/collections/mapUsingProjection.ts
@@ -85,8 +85,8 @@ export class MapUsingProjection<K, V, P> implements IValidatedMap<K, V> {
         return this;
     }
 
-    public setAndReplaceIfExist(key: K, value: V): this {
-        this._projectionToKeyAndvalue.setAndReplaceIfExist(this._projection(key), new KeyAndValue(key, value));
+    public setAndReplaceIfExists(key: K, value: V): this {
+        this._projectionToKeyAndvalue.setAndReplaceIfExists(this._projection(key), new KeyAndValue(key, value));
         return this;
     }
 

--- a/src/chrome/collections/setUsingProjection.ts
+++ b/src/chrome/collections/setUsingProjection.ts
@@ -56,6 +56,11 @@ export class SetUsingProjection<T, P> implements Set<T> {
         return this;
     }
 
+    public addAndReplaceIfExists(element: T): this {
+        this._projectionToElement.setAndReplaceIfExists(this._projection(element), element);
+        return this;
+    }
+
     public get size(): number {
         return this._projectionToElement.size;
     }

--- a/src/chrome/collections/validatedMap.ts
+++ b/src/chrome/collections/validatedMap.ts
@@ -12,7 +12,7 @@ export interface IValidatedMap<K, V> extends Map<K, V> {
     tryGetting(key: K): V | undefined;
     getOr(key: K, elementDoesntExistAction: () => V): V;
     getOrAdd(key: K, obtainValueToAdd: () => V): V;
-    setAndReplaceIfExist(key: K, value: V): this;
+    setAndReplaceIfExists(key: K, value: V): this;
     replaceExisting(key: K, value: V): this;
     setAndIgnoreDuplicates(key: K, value: V, comparer?: ValueComparerFunction<V>): this;
 }
@@ -99,7 +99,7 @@ export class ValidatedMap<K, V> implements IValidatedMap<K, V> {
             throw new Error(`Cannot set key ${key} because it already exists`);
         }
 
-        return this.setAndReplaceIfExist(key, value);
+        return this.setAndReplaceIfExists(key, value);
     }
 
     public replaceExisting(key: K, value: V): this {
@@ -108,10 +108,10 @@ export class ValidatedMap<K, V> implements IValidatedMap<K, V> {
             throw new Error(`Cannot replace key ${key} because it doesn't exists`);
         }
 
-        return this.setAndReplaceIfExist(key, value);
+        return this.setAndReplaceIfExists(key, value);
     }
 
-    public setAndReplaceIfExist(key: K, value: V): this {
+    public setAndReplaceIfExists(key: K, value: V): this {
         this._wrappedMap.set(key, value);
         return this;
     }
@@ -123,7 +123,7 @@ export class ValidatedMap<K, V> implements IValidatedMap<K, V> {
             throw new Error(`Cannot set key ${key} for value ${value} because it already exists and it's associated to a different value: ${existingValueOrUndefined}`);
         }
 
-        return this.setAndReplaceIfExist(key, value);
+        return this.setAndReplaceIfExists(key, value);
     }
 
     [Symbol.iterator](): IterableIterator<[K, V]> {

--- a/src/chrome/dependencyInjection.ts/bind.ts
+++ b/src/chrome/dependencyInjection.ts/bind.ts
@@ -39,6 +39,7 @@ import { ConnectedCDA } from '../client/chromeDebugAdapter/connectedCDA';
 import { SupportedDomains } from '../internal/domains/supportedDomains';
 import { TerminatingCDA } from '../client/chromeDebugAdapter/terminatingCDA';
 import { isDefined } from '../utils/typedOperators';
+import { CompletionsRequestHandler } from '../internal/completions/completionsRequestHandler';
 
 // TODO: This file needs a lot of work. We need to improve/simplify all this code when possible
 interface IHasContainerName {
@@ -76,6 +77,7 @@ export function bindAll(loggingConfiguration: MethodsCalledLoggerConfiguration, 
     bind(loggingConfiguration, di, TYPES.ICommandHandlerDeclarer, ThreadsRequestHandler, callback);
     bind(loggingConfiguration, di, TYPES.ICommandHandlerDeclarer, ToggleSkipFileStatusRequestHandler, callback);
     bind(loggingConfiguration, di, TYPES.ICommandHandlerDeclarer, VariablesRequestHandler, callback);
+    bind(loggingConfiguration, di, TYPES.ICommandHandlerDeclarer, CompletionsRequestHandler, callback);
 
     bind(loggingConfiguration, di, TYPES.BaseSourceMapTransformer, EagerSourceMapTransformer, callback);
     bind(loggingConfiguration, di, TYPES.BasePathTransformer, ConfigurationBasedPathTransformer, callback);

--- a/src/chrome/internal/breakpoints/registries/bprsDeltaCalculatorFromStoredBPRs.ts
+++ b/src/chrome/internal/breakpoints/registries/bprsDeltaCalculatorFromStoredBPRs.ts
@@ -31,7 +31,7 @@ export class BPRsDeltaCalculatorFromStoredBPRs {
     }
 
     private storeCurrentBPRecipes(requestedSourceIdentifier: IResourceIdentifier, bpRecipes: BPRecipeInSource[]): void {
-        this._requestedSourcePathToCurrentBPRecipes.setAndReplaceIfExist(requestedSourceIdentifier, Array.from(bpRecipes));
+        this._requestedSourcePathToCurrentBPRecipes.setAndReplaceIfExists(requestedSourceIdentifier, Array.from(bpRecipes));
     }
 
     public toString(): string {

--- a/src/chrome/internal/completions/completionsRequestHandler.ts
+++ b/src/chrome/internal/completions/completionsRequestHandler.ts
@@ -1,0 +1,24 @@
+import { ChromeDebugLogic } from '../../chromeDebugAdapter';
+import { ICommandHandlerDeclaration, CommandHandlerDeclaration, ICommandHandlerDeclarer } from '../features/components';
+import { injectable, inject } from 'inversify';
+import { DebugProtocol } from 'vscode-debugprotocol';
+import { TYPES } from '../../dependencyInjection.ts/types';
+import { FrameParser } from '../../client/frameParser';
+
+@injectable()
+export class CompletionsRequestHandler implements ICommandHandlerDeclarer {
+    public constructor(
+        @inject(TYPES.ChromeDebugLogic) protected readonly _chromeDebugAdapter: ChromeDebugLogic,
+        private readonly _frameParser: FrameParser) { }
+
+    public getCommandHandlerDeclarations(): ICommandHandlerDeclaration[] {
+        return CommandHandlerDeclaration.fromLiteralObject({
+            completions: (args: DebugProtocol.CompletionsArguments) => this.completions(args)
+        });
+    }
+
+    private async completions(args: DebugProtocol.CompletionsArguments): Promise<DebugProtocol.CompletionsResponse['body']> {
+        const frame = this._frameParser.optionalFrameById(args.frameId);
+        return await this._chromeDebugAdapter.completions({ frame, text: args.text, column: args.column, line: args.line });
+    }
+}

--- a/src/chrome/internal/features/skipFiles.ts
+++ b/src/chrome/internal/features/skipFiles.ts
@@ -107,7 +107,7 @@ export class SkipFilesLogic implements IStackTracePresentationDetailsProvider {
 
             const newStatus = isFalse(this.shouldSkipSource(resolvedSource));
             logger.log(`Setting the skip file status for: ${resolvedSource} to ${newStatus}`);
-            this._skipFileStatuses.setAndReplaceIfExist(resolvedSource.identifier, newStatus);
+            this._skipFileStatuses.setAndReplaceIfExists(resolvedSource.identifier, newStatus);
 
             const scripts = resolvedSource.scriptMapper().scripts;
             for (const script of scripts) {
@@ -190,7 +190,7 @@ export class SkipFilesLogic implements IStackTracePresentationDetailsProvider {
                     ? parentIsSkipped // Inherit the parent's status
                     : skippingConfiguration;
 
-                this._skipFileStatuses.setAndReplaceIfExist(s.identifier, isTrue(isSkippedFile));
+                this._skipFileStatuses.setAndReplaceIfExists(s.identifier, isTrue(isSkippedFile));
 
                 if ((isSkippedFile && !inLibRange) || (!isSkippedFile && inLibRange)) {
                     const sourcesMapper = script.sourceMapper;

--- a/src/chrome/internal/sources/resourceIdentifier.ts
+++ b/src/chrome/internal/sources/resourceIdentifier.ts
@@ -95,9 +95,7 @@ export class LocalFileURL<TString extends string = string> extends IsEquivalentC
     }
 
     public get textRepresentation(): TString {
-        // TODO: need to handle invalid chars, but we can't URLencode the entire path
-        // Need to replace backslashes with forward (even on windows) otherwise we can't match the path in Chrome
-        return `file:///${this._localResourcePath.textRepresentation.replace(/\\/g, '/')}` as TString;
+        return <TString>utils.pathToFileURL(this._localResourcePath.textRepresentation);
     }
 
     public get filePathRepresentation(): string {

--- a/src/chrome/internal/variables/evaluateRequestHandler.ts
+++ b/src/chrome/internal/variables/evaluateRequestHandler.ts
@@ -7,16 +7,13 @@ import { ConnectedCDA } from '../../client/chromeDebugAdapter/connectedCDA';
 import { ITelemetryPropertyCollector } from '../../../telemetry';
 import { IEvaluateResponseBody, ISetExpressionResponseBody } from '../../../debugAdapterInterfaces';
 import { DotScriptsRequestHandler } from './dotScriptsRequestHandler';
-import { HandlesRegistry } from '../../client/handlesRegistry';
-import { isDefined } from '../../utils/typedOperators';
-import { CallFramePresentation } from '../stackTraces/callFramePresentation';
-import { LoadedSourceCallFrame, CallFrameWithState } from '../stackTraces/callFrame';
+import { FrameParser } from '../../client/frameParser';
 
 @injectable()
 export class EvaluateRequestHandler implements ICommandHandlerDeclarer {
     public constructor(
         public readonly _dotScriptsRequestHandler: DotScriptsRequestHandler,
-        private readonly _handlesRegistry: HandlesRegistry,
+        private readonly _frameParser: FrameParser,
         @inject(TYPES.ChromeDebugLogic) protected readonly _chromeDebugAdapter: ChromeDebugLogic) { }
 
     public getCommandHandlerDeclarations(): ICommandHandlerDeclaration[] {
@@ -31,19 +28,8 @@ export class EvaluateRequestHandler implements ICommandHandlerDeclarer {
             await this._dotScriptsRequestHandler.dotScript(args);
             return <IEvaluateResponseBody>{ result: '', variablesReference: 0 };
         } else {
-            const frame = isDefined(args.frameId)
-                ? this.frameById(args.frameId)
-                : undefined;
+            const frame = this._frameParser.optionalFrameById(args.frameId);
             return this._chromeDebugAdapter.evaluate({ context: args.context, expression: args.expression, format: args.format, frame });
-        }
-    }
-
-    private frameById(frameId: number): LoadedSourceCallFrame<CallFrameWithState> | undefined {
-        const stackTrace = this._handlesRegistry.frames.getObjectById(frameId);
-        if (stackTrace instanceof CallFramePresentation && stackTrace.callFrame.hasState()) {
-            return stackTrace.callFrame;
-        } else {
-            return undefined;
         }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,8 @@ import { IActionToTakeWhenPaused, NoActionIsNeededForThisPause, BasePauseShouldB
 import { MakePropertyRequired } from './typeUtils';
 import { printClassDescription } from './chrome/utils/printing';
 import { IDebuggeeExecutionController } from './chrome/cdtpDebuggee/features/cdtpDebugeeExecutionController';
+import { CDTPScriptsRegistry } from './chrome/cdtpDebuggee/registries/cdtpScriptsRegistry';
+import { EagerSourceMapTransformer } from './transformers/eagerSourceMapTransformer';
 
 export {
     chromeConnection,
@@ -201,5 +203,9 @@ export {
     BasePauseShouldBeAutoResumed,
 
     IDebuggeeExecutionController,
+
+    CDTPScriptsRegistry,
+
+    EagerSourceMapTransformer,
 
 };

--- a/src/sourceMaps/sourceMap.ts
+++ b/src/sourceMaps/sourceMap.ts
@@ -150,8 +150,8 @@ export class SourceMap {
         return new SourceMap(generatedPath, sourceMap, parseResourceIdentifiers(consumer.sources), setOfNormalizedSources, consumer);
     }
 
-    public generatedPath(): string {
-        return this._generatedPath;
+    public generatedPath(): IResourceIdentifier {
+        return parseResourceIdentifier(this._generatedPath);
     }
 
     /**
@@ -282,7 +282,7 @@ export class SourceMap {
                 const expandedRange = new Range(
                     Position.appearingFirstOf(range.start, positionInSource),
                     Position.appearingLastOf(range.exclusiveEnd, positionInSource));
-                sourceToRange.setAndReplaceIfExist(sourceIdentifier, expandedRange);
+                sourceToRange.setAndReplaceIfExists(sourceIdentifier, expandedRange);
             } else {
                 /**
                  * TODO: Report some telemetry. We've seen the line numbers and source be null in the Webpack scenario of our integration tests

--- a/src/sourceMaps/sourceMapFactory.ts
+++ b/src/sourceMaps/sourceMapFactory.ts
@@ -121,8 +121,8 @@ export class SourceMapFactory {
             mapPathOrURL = utils.canonicalizeUrl(mapPathOrURL);
             contentsP = new Promise((resolve) => {
                 logger.log(`SourceMaps.loadSourceMapContents: Reading local sourcemap file from ${mapPathOrURL}`);
-                fs.readFile(mapPathOrURL, (err?: NodeJS.ErrnoException, data?: Buffer) => {
-                    if (isDefined(err)) {
+                fs.readFile(mapPathOrURL, (err: NodeJS.ErrnoException | null, data?: Buffer) => {
+                    if (isNotNull(err)) {
                         logger.log(`SourceMaps.loadSourceMapContents: Could not read sourcemap file - ` + err.message);
                         resolve(null);
                     } else {

--- a/src/transformers/eagerSourceMapTransformer.ts
+++ b/src/transformers/eagerSourceMapTransformer.ts
@@ -4,13 +4,12 @@
 
 import * as path from 'path';
 
-import { BaseSourceMapTransformer } from './baseSourceMapTransformer';
+import { BaseSourceMapTransformer, SourceMapTransformerConfiguration } from './baseSourceMapTransformer';
 
 import { ILaunchRequestArgs, IAttachRequestArgs } from '../debugAdapterInterfaces';
 import * as utils from '../utils';
 import { logger } from 'vscode-debugadapter';
 import { injectable, inject } from 'inversify';
-import { IConnectedCDAConfiguration } from '../chrome/client/chromeDebugAdapter/cdaConfiguration';
 import { CDTPScriptsRegistry } from '../chrome/cdtpDebuggee/registries/cdtpScriptsRegistry';
 import { TYPES } from '../chrome/dependencyInjection.ts/types';
 import { isDefined, isNotEmpty, isNotNull, hasMatches } from '../chrome/utils/typedOperators';
@@ -24,7 +23,7 @@ export class EagerSourceMapTransformer extends BaseSourceMapTransformer {
     private static SOURCE_MAPPING_MATCHER = new RegExp('^//[#@] ?sourceMappingURL=(.+)$');
 
     constructor(
-        @inject(TYPES.ConnectedCDAConfiguration) configuration: IConnectedCDAConfiguration,
+        @inject(TYPES.ConnectedCDAConfiguration) configuration: SourceMapTransformerConfiguration,
         scriptsRegistry: CDTPScriptsRegistry) {
         super(configuration, scriptsRegistry);
     }

--- a/src/transformers/urlPathTransformer.ts
+++ b/src/transformers/urlPathTransformer.ts
@@ -46,8 +46,8 @@ export class UrlPathTransformer extends BasePathTransformer {
             const canonicalizedClientPath = clientPath;
 
             // an HTML file with multiple script tags will call this method several times with the same scriptUrl, so we use setAndReplaceIfExist
-            this._clientPathToTargetUrl.setAndReplaceIfExist(canonicalizedClientPath, scriptUrl);
-            this._targetUrlToClientPath.setAndReplaceIfExist(scriptUrl, clientPath);
+            this._clientPathToTargetUrl.setAndReplaceIfExists(canonicalizedClientPath, scriptUrl);
+            this._targetUrlToClientPath.setAndReplaceIfExists(scriptUrl, clientPath);
 
             scriptUrl = clientPath;
         }


### PR DESCRIPTION
- Renamed setAndReplaceIfExist to setAndReplaceIfExists

- terminatingCDA.ts: The terminatedCDA wasn't installed, so it failed when it received any requests from the client
- frameParser.ts: Created utility because we consume frames via id both in completions and in evaluate
- completionsRequestHandler.ts: We hadn't implemented support for the completions request
- resourceIdentifier.ts: Setting a breakpoint on c:\myProj\my file name.js was failing because we weren't escaping the spaces when converting it to a file url
- sourceMapFactory.ts: err is either null or an error, instead of undefined
- sourceMaps.ts: We weren't initializing this._authoredPathToSourceMap. This is needed when we use a typescript.ts file as a startup file in node, so we can convert it into a javascript file
- baseSourceMapTransformer.ts: We need to use this class before we are connected to the client, to convert a typescript.ts startup file to a javascript file. Modified the constructor parameter so we can create a "fake" version of this class before we are connected to the CRDP websocket
