### PR TITLE
Fix error due to using old scriptId after reload

### DIFF
--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpExecutionContextEventsProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpExecutionContextEventsProvider.ts
@@ -29,5 +29,6 @@ export class CDTPExecutionContextEventsProvider extends CDTPEventsEmitterDiagnos
         @inject(TYPES.IDomainsEnabler) domainsEnabler: CDTPDomainsEnabler,
     ) {
         super(domainsEnabler);
+        this.onExecutionContextsCleared(() => this._scriptsRegistry.clearExecutionContexts());
     }
 }

--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpOnScriptParsedEventProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpOnScriptParsedEventProvider.ts
@@ -26,6 +26,7 @@ import { SourceMap } from '../../../sourceMaps/sourceMap';
 import { BasePathTransformer } from '../../../transformers/basePathTransformer';
 import { BaseSourceMapTransformer } from '../../../transformers/baseSourceMapTransformer';
 import { isNotEmpty, isNotNull } from '../../utils/typedOperators';
+import { CDTPExecutionContextEventsProvider } from './cdtpExecutionContextEventsProvider';
 
 /**
  * A new JavaScript Script has been parsed by the debuggee and it's about to be executed
@@ -104,9 +105,13 @@ export class CDTPOnScriptParsedEventProvider extends CDTPEventsEmitterDiagnostic
         @inject(TYPES.BaseSourceMapTransformer) private readonly _sourceMapTransformer: BaseSourceMapTransformer,
         @inject(TYPES.CDTPScriptsRegistry) private readonly _scriptsRegistry: CDTPScriptsRegistry,
         @inject(TYPES.IDomainsEnabler) domainsEnabler: CDTPDomainsEnabler,
+        @inject(TYPES.ExecutionContextEventsProvider) executionContextEventsProvider: CDTPExecutionContextEventsProvider,
         @inject(LoadedSourcesRegistry) private readonly _loadedSourcesRegistry: LoadedSourcesRegistry,
     ) {
         super(domainsEnabler);
+
+        // Discard the relationships of loaded sources to script after we reload the web-page
+        executionContextEventsProvider.onExecutionContextsCleared(() => this._loadedSourcesRegistry.clearAllRelationships());
     }
 
     private async toScriptParsedEvent(params: CDTP.Debugger.ScriptParsedEvent): Promise<IScriptParsedEvent> {

--- a/src/chrome/cdtpDebuggee/registries/cdtpScriptsRegistry.ts
+++ b/src/chrome/cdtpDebuggee/registries/cdtpScriptsRegistry.ts
@@ -21,7 +21,7 @@ import { printMap } from '../../collections/printing';
 @injectable()
 export class CDTPScriptsRegistry {
     private readonly _idToExecutionContext = new ValidatedMap<CDTP.Runtime.ExecutionContextId, ExecutionContext>();
-    private readonly _scripts = new CDTPCurrentGeneration();
+    private _scripts = new CDTPCurrentGeneration();
 
     public registerExecutionContext(executionContextId: CDTP.Runtime.ExecutionContextId, frameId: FrameId): IExecutionContext {
         const executionContext = new ExecutionContext(frameId);
@@ -58,6 +58,17 @@ export class CDTPScriptsRegistry {
 
     public getScriptsByPath(nameOrLocation: IResourceIdentifier): IScript[] {
         return this._scripts.getScriptByPath(nameOrLocation);
+    }
+
+    // After we refresh the page, we discard all information about scripts
+    public clearExecutionContexts(): void {
+        // Warning: Throwing away the scripts' information here only prevents code executed in the future from accessing the scripts
+        // If we have any code currently on-flight, that already accessed the script, this method won't fix that. If that code uses
+        // the scriptId, or performs any operation that is invalid with that script because the execution context was cleared, that operation
+        // will most likely fail.
+        // If Users start seeing those kind of issues, we'll need to figure out what enhancements we need to do to handle those cases
+        // Also see: loadedSourcesRegistry.ts
+        this._scripts = new CDTPCurrentGeneration();
     }
 
     public toString(): string {

--- a/src/chrome/cdtpDebuggee/registries/loadedSourcesRegistry.ts
+++ b/src/chrome/cdtpDebuggee/registries/loadedSourcesRegistry.ts
@@ -32,6 +32,17 @@ export class LoadedSourcesRegistry implements ICurrentScriptRelationshipsProvide
         return new ScriptMapper(Array.from(this._loadedSourceToCurrentScriptRelationships.get(loadedSource)));
     }
 
+    // After we refresh the page, we discard all relationships to scripts
+    public clearAllRelationships(): void {
+        // Warning: Throwing away the scripts' information here only prevents code executed in the future from accessing the scripts
+        //      If we have any code currently on-flight, that already accessed the script, this method won't fix that. If that code uses
+        //      the scriptId, or performs any operation that is invalid with that script because the execution context was cleared, that operation
+        //      will most likely fail.
+        //      If Users start seeing those kind of issues, we'll need to figure out what enhancements we need to do to handle those cases
+        // Also see: cdtpScriptsRegistry.ts
+        this._loadedSourceToCurrentScriptRelationships.clear();
+    }
+
     public toString(): string {
         return `Loaded sources: ${this._loadedSourceByPath}\nRelationships:\n${this._loadedSourceToCurrentScriptRelationships}`;
     }


### PR DESCRIPTION
Setting breakpoint after reloading the browser was failing because we were trying to use a scriptId that didn't exist any more.
Now after a refresh, we reset all the script data in both cdtpScriptsRegistry.ts and loadedSourcesRegistry.ts