### PR TITLE
Don't kill chrome when disconnected from websocket

### DIFF
--- a/src/chrome/chromeConnection.ts
+++ b/src/chrome/chromeConnection.ts
@@ -17,7 +17,7 @@ import { Protocol as CDTP } from 'devtools-protocol';
 import { TYPES } from './dependencyInjection.ts/types';
 import { inject, injectable } from 'inversify';
 import { ConnectedCDAConfiguration } from './client/chromeDebugAdapter/cdaConfiguration';
-import { IDebuggeeLauncher } from './debugeeStartup/debugeeLauncher';
+import { IDebuggeeLauncher, TerminatingReason } from './debugeeStartup/debugeeLauncher';
 import { ScenarioType } from './client/chromeDebugAdapter/unconnectedCDA';
 import { IAttachRequestArgs } from '../debugAdapterInterfaces';
 import { ITelemetryPropertyCollector } from '../telemetry';
@@ -189,12 +189,12 @@ export class ChromeConnection implements IObservableEvents<IStepStartedEventsEmi
             });
     }
 
-    public async close() {
+    public async close(reason: TerminatingReason) {
         this.validateConnectionIsOpen();
         this._socket!.close();
         this._socket = null;
         if (this._configuration.scenarioType === ScenarioType.Launch) {
-            await this._debuggeeLauncher.stop();
+            await this._debuggeeLauncher.stop(reason);
         }
     }
 

--- a/src/chrome/client/chromeDebugAdapter/cdaDIContainerCreator.ts
+++ b/src/chrome/client/chromeDebugAdapter/cdaDIContainerCreator.ts
@@ -15,11 +15,12 @@ import { ConnectedCDAConfiguration } from './cdaConfiguration';
 import { ReplacementInstruction } from '../../logging/methodsCalledLogger';
 import { Logging } from '../../internal/services/logging';
 import { ChromeDebugAdapter } from './chromeDebugAdapterV2';
-import { TerminatingCDA, TerminatingReason } from './terminatingCDA';
+import { TerminatingCDA } from './terminatingCDA';
 import { ChromeTargetDiscovery } from '../../chromeTargetDiscoveryStrategy';
 import { ChromeConnection } from '../../chromeConnection';
 import { telemetry } from '../../../telemetry';
 import { isDefined, isNotEmpty } from '../../utils/typedOperators';
+import { TerminatingReason } from '../../debugeeStartup/debugeeLauncher';
 
 export function createDIContainer(chromeDebugAdapter: ChromeDebugAdapter, rawDebugSession: ChromeDebugSession, debugSessionOptions: IChromeDebugSessionOpts): DependencyInjection {
     const session = new DelayMessagesUntilInitializedSession(new DoNotPauseWhileSteppingSession(rawDebugSession));

--- a/src/chrome/client/chromeDebugAdapter/connectedCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/connectedCDA.ts
@@ -14,10 +14,10 @@ import { InitializedEvent } from 'vscode-debugadapter';
 import { ISession } from '../session';
 import { ChromeConnection } from '../../chromeConnection';
 import { ChromeDebugAdapter } from './chromeDebugAdapterV2';
-import { TerminatingCDAProvider, TerminatingReason } from './terminatingCDA';
+import { TerminatingCDAProvider } from './terminatingCDA';
 import { BasePathTransformer } from '../../../transformers/basePathTransformer';
 import { DebugProtocol } from 'vscode-debugprotocol';
-import { IDebuggeeInitializer } from '../../debugeeStartup/debugeeLauncher';
+import { IDebuggeeInitializer, TerminatingReason } from '../../debugeeStartup/debugeeLauncher';
 
 export type ConnectedCDAProvider = (protocolApi: CDTP.ProtocolApi) => ConnectedCDA;
 

--- a/src/chrome/debugeeStartup/debugeeLauncher.ts
+++ b/src/chrome/debugeeStartup/debugeeLauncher.ts
@@ -12,9 +12,14 @@ export interface ILaunchResult {
     url?: string;
 }
 
+export enum TerminatingReason {
+    DisconnectedFromWebsocket,
+    ClientRequestedToDisconnect
+}
+
 export interface IDebuggeeLauncher {
     launch(args: ILaunchRequestArgs, telemetryPropertyCollector: ITelemetryPropertyCollector): Promise<ILaunchResult>;
-    stop(): Promise<void>;
+    stop(reasonToStop: TerminatingReason): Promise<void>;
 }
 
 export interface IDebuggeeInitializer {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ import { Version } from './chrome/utils/version';
 import { parseResourceIdentifier, IResourceIdentifier } from './chrome/internal/sources/resourceIdentifier';
 import { ChromeDebugAdapter } from './chrome/client/chromeDebugAdapter/chromeDebugAdapterV2';
 import { IExtensibilityPoints, OnlyProvideCustomLauncherExtensibilityPoints } from './chrome/extensibility/extensibilityPoints';
-import { IDebuggeeLauncher, ILaunchResult, IDebuggeeRunner, IDebuggeeInitializer } from './chrome/debugeeStartup/debugeeLauncher';
+import { IDebuggeeLauncher, ILaunchResult, IDebuggeeRunner, IDebuggeeInitializer, TerminatingReason } from './chrome/debugeeStartup/debugeeLauncher';
 import { inject, injectable, postConstruct, interfaces, multiInject } from 'inversify';
 import { ConnectedCDAConfiguration, IConnectedCDAConfiguration } from './chrome/client/chromeDebugAdapter/cdaConfiguration';
 import { IInstallableComponent, ICommandHandlerDeclarer, IServiceComponent } from './chrome/internal/features/components';
@@ -217,4 +217,6 @@ export {
     BaseNotifyClientOfPause,
 
     IEventsToClientReporter,
+
+    TerminatingReason
 };


### PR DESCRIPTION
Chrome was showing a message: "Chrome didn't finish properly, and you need to restore pages" when closing chrome directly instead of stopping the debug session from VS.

I found some comments from v1 that mention that we shouldn't be killing Chrome when we close due to the websocket, and it also makes sense... I'm modifying the code to pass the TerminatingReason to IDebuggeeLauncher, so we don't kill chrome when we are stopping because we disconnected from the websocket. That solves the issue

The change in chrome is at: https://github.com/microsoft/vscode-chrome-debug/pull/862