### PR TITLE
Fix Script Documents not appearing on VS

### DIFF
--- a/src/chrome/dependencyInjection.ts/bind.ts
+++ b/src/chrome/dependencyInjection.ts/bind.ts
@@ -41,6 +41,7 @@ import { TerminatingCDA } from '../client/chromeDebugAdapter/terminatingCDA';
 import { isDefined } from '../utils/typedOperators';
 import { CompletionsRequestHandler } from '../internal/completions/completionsRequestHandler';
 import { SourceToClientConverter } from '../client/sourceToClientConverter';
+import { NotifyClientOfLoadedSources } from '../internal/sources/features/notifyClientOfLoadedSources';
 
 // TODO: This file needs a lot of work. We need to improve/simplify all this code when possible
 interface IHasContainerName {
@@ -89,6 +90,9 @@ export function bindAll(loggingConfiguration: MethodsCalledLoggerConfiguration, 
     bind(loggingConfiguration, di, TYPES.ConnectedCDA, ConnectedCDA, callback);
     bind(loggingConfiguration, di, TYPES.ISupportedDomains, SupportedDomains, callback);
     bind(loggingConfiguration, di, TYPES.TerminatingCDA, TerminatingCDA, callback);
+
+    // Services
+    bind(loggingConfiguration, di, TYPES.IServiceComponent, NotifyClientOfLoadedSources, callback);
 }
 
 function bind<T extends object>(configuration: MethodsCalledLoggerConfiguration, container: Container,

--- a/src/chrome/internal/sources/features/notifyClientOfLoadedSources.ts
+++ b/src/chrome/internal/sources/features/notifyClientOfLoadedSources.ts
@@ -10,12 +10,13 @@ import { IScriptParsedEvent, IScriptParsedProvider } from '../../../cdtpDebuggee
 import { ILoadedSource, ContentsLocation } from '../loadedSource';
 import { newResourceIdentifierMap } from '../resourceIdentifier';
 import { LoadedSourceEventReason } from '../../../chromeDebugAdapter';
+import { IServiceComponent } from '../../features/components';
 
 /**
  * This class will keep the client updated of the sources that are associated with the scripts that are currently loaded in the debuggee
  */
 @injectable()
-export class NotifyClientOfLoadedSources {
+export class NotifyClientOfLoadedSources implements IServiceComponent {
     // TODO DIEGO: Ask VS what index do they use internally to verify if the source is the same or a new one
     private _notifiedSourceByIdentifier = newResourceIdentifierMap<ILoadedSource>();
 
@@ -23,6 +24,10 @@ export class NotifyClientOfLoadedSources {
         @inject(TYPES.IScriptParsedProvider) public readonly _cdtpOnScriptParsedEventProvider: IScriptParsedProvider,
         @inject(TYPES.IEventsToClientReporter) private readonly _eventsToClientReporter: IEventsToClientReporter) {
         this._cdtpOnScriptParsedEventProvider.onScriptParsed(scriptParsed => this.onScriptParsed(scriptParsed));
+    }
+
+    public install(): this {
+        return this;
     }
 
     public async onScriptParsed(scriptParsed: IScriptParsedEvent): Promise<void> {


### PR DESCRIPTION
NotifyClientOfLoadedSources wasn't referenced by any component, so it wasn't getting initialized, so the script documents weren't showing up...