### PR TITLE
Fix promises

### DIFF
--- a/src/chrome/internal/exceptions/pauseOnExceptionRequestHandlers.ts
+++ b/src/chrome/internal/exceptions/pauseOnExceptionRequestHandlers.ts
@@ -3,7 +3,7 @@ import { injectable, inject } from 'inversify';
 import { PauseOnExceptionOrRejection, IExceptionInformation } from './pauseOnException';
 import { ICommandHandlerDeclaration, CommandHandlerDeclaration, ICommandHandlerDeclarer } from '../features/components';
 import { DebugProtocol } from 'vscode-debugprotocol';
-import { IPauseOnExceptionsStrategy, PauseOnAllExceptions, PauseOnUnhandledExceptions, DoNotPauseOnAnyExceptions, IPauseOnPromiseRejectionsStrategy, PauseOnAllRejections, DoNotPauseOnAnyRejections } from './strategies';
+import { IPauseOnExceptionsStrategy, PauseOnAllExceptions, PauseOnUnhandledExceptions, DoNotPauseOnAnyExceptions, IPauseOnPromiseRejectionsStrategy, PauseOnAllRejections } from './strategies';
 import { ExceptionStackTracePrinter } from './exceptionStackTracePrinter';
 import { ConnectedCDAConfiguration } from '../../client/chromeDebugAdapter/cdaConfiguration';
 import { TYPES } from '../../dependencyInjection.ts/types';
@@ -44,12 +44,14 @@ export class PauseOnExceptionRequestHandlers implements ICommandHandlerDeclarer 
         }
     }
 
-    private toPauseOnPromiseRejectionsStrategy(exceptionFilters: string[]): IPauseOnPromiseRejectionsStrategy {
-        if (exceptionFilters.indexOf('promise_reject') >= 0) {
-            return new PauseOnAllRejections();
-        } else {
-            return new DoNotPauseOnAnyRejections();
-        }
+    private toPauseOnPromiseRejectionsStrategy(_exceptionFilters: string[]): IPauseOnPromiseRejectionsStrategy {
+        return new PauseOnAllRejections();
+        // TODO: Figure out how to implement this for node-debug
+        // if (exceptionFilters.indexOf('promise_reject') >= 0) {
+        //     return new PauseOnAllRejections();
+        // } else {
+        //     return new DoNotPauseOnAnyRejections();
+        // }
     }
 
     private toExceptionInfo(info: IExceptionInformation): IExceptionInfoResponseBody {

--- a/src/chrome/internal/features/pauseActionsPriorities.ts
+++ b/src/chrome/internal/features/pauseActionsPriorities.ts
@@ -5,7 +5,7 @@ import { IActionToTakeWhenPaused } from './actionToTakeWhenPaused';
 import { ShouldStepInToAvoidSkippedSource } from './smartStep';
 import { HitBreakpoint, NoRecognizedBreakpoints } from '../breakpoints/features/bpRecipeAtLoadedSourceLogic';
 import { HitStillPendingBreakpoint, PausedWhileLoadingScriptToResolveBreakpoints } from '../breakpoints/features/pauseScriptLoadsToSetBPs';
-import { ExceptionWasThrown, PromiseWasRejected } from '../exceptions/pauseOnException';
+import { ExceptionWasThrown, PromiseWasRejected, PromiseWasRejectedWithFeatureTurnedOff } from '../exceptions/pauseOnException';
 import { HitAndSatisfiedHitCountBreakpoint, HitCountBreakpointWhenConditionWasNotSatisfied } from '../breakpoints/features/hitCountBreakpointsSetter';
 import { FinishedStepping, UserPaused } from '../stepping/features/syncStepping';
 import { PausedBecauseAsyncCallWasScheduled } from '../stepping/features/asyncStepping';
@@ -32,4 +32,6 @@ export const actionsFromHighestToLowestPriority: ActionToTakeWhenPausedClass[] =
     HitCountBreakpointWhenConditionWasNotSatisfied,
 
     NoRecognizedBreakpoints,
+
+    PromiseWasRejectedWithFeatureTurnedOff,
 ];


### PR DESCRIPTION
this._promiseRejectionsStrategy.shouldPauseOnRejections was false in chrome-debug so we weren't showing the error message when pausing due to a promise, because we used the default logic of pausing with a debugger paused statement.
Change the logic so if this._promiseRejectionsStrategy.shouldPauseOnRejections is false, we are going to try to auto-resume the promise rejection (for node-debug).
For chrome-debug this._promiseRejectionsStrategy.shouldPauseOnRejections should always be true (to match v1 behavior), so commented the code for the time being, so we always pause on rejections

cdtpExceptionThrownEventsProvider.ts: Sometimes we get an invalid script id in exceptionthrown

test: https://github.com/microsoft/vscode-chrome-debug/pull/868