### PR TITLE
Fix attach

### DIFF
--- a/src/chrome/client/clientLifecycleRequestsHandler.ts
+++ b/src/chrome/client/clientLifecycleRequestsHandler.ts
@@ -5,6 +5,8 @@ import { ChromeDebugLogic } from '../chromeDebugAdapter';
 import { IDebuggeeRunner } from '../debugeeStartup/debugeeLauncher';
 import { StepProgressEventsEmitter } from '../../executionTimingsReporter';
 import { ICommandHandlerDeclarer, ICommandHandlerDeclaration, CommandHandlerDeclaration } from '../internal/features/components';
+import { ConnectedCDAConfiguration } from './chromeDebugAdapter/cdaConfiguration';
+import { ScenarioType } from '../..';
 
 @injectable()
 export class ClientLifecycleRequestsHandler implements ICommandHandlerDeclarer {
@@ -12,6 +14,7 @@ export class ClientLifecycleRequestsHandler implements ICommandHandlerDeclarer {
 
     constructor(
         @inject(TYPES.ChromeDebugLogic) protected readonly _chromeDebugAdapter: ChromeDebugLogic,
+        @inject(TYPES.ConnectedCDAConfiguration) protected readonly _configuration: ConnectedCDAConfiguration,
         @inject(TYPES.IDebuggeeRunner) public readonly _debuggeeRunner: IDebuggeeRunner,
     ) {
     }
@@ -23,7 +26,11 @@ export class ClientLifecycleRequestsHandler implements ICommandHandlerDeclarer {
     }
 
     public async configurationDone(): Promise<void> {
-        await this._debuggeeRunner.run(new TelemetryPropertyCollector());
+        if (this._configuration.scenarioType === ScenarioType.Launch) {
+            // At the moment it doesn't make sense to use the runner for attaching, so we only use it for launching
+            await this._debuggeeRunner.run(new TelemetryPropertyCollector());
+        }
+
         this.events.emitMilestoneReached('RequestedNavigateToUserPage'); // TODO DIEGO: Make sure this is reported
     }
 }


### PR DESCRIPTION
- When we attach and Enable the Runtime domain we can get a Runtime.consoleAPICalled message with a script id before we enable and process all the scriptParsed messages from the Debugger domain. We know retry for a little while on getScriptByCdtpId to give time to the scriptParsed message to be processed.

- The IDebuggeeRunner has logic to detect that the user requested url was loaded. This doesn't make sense for the attach scenario, so we don't call it.

- Modified retryAsync to also retry on sync exceptions.

Test: https://github.com/microsoft/vscode-chrome-debug/pull/874