### PR TITLE
Do not crash on invalid source-maps

### DIFF
--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpOnScriptParsedEventProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpOnScriptParsedEventProvider.ts
@@ -7,7 +7,7 @@ import { CDTPEventsEmitterDiagnosticsModule } from '../infrastructure/cdtpDiagno
 import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
 import { IScript, Script } from '../../internal/scripts/script';
 import { createCDTPScriptUrl, CDTPScriptUrl } from '../../internal/sources/resourceIdentifierSubtypes';
-import { MappedSourcesMapper, IMappedSourcesMapper, NoMappedSourcesMapper } from '../../internal/scripts/sourcesMapper';
+import { MappedSourcesMapper, IMappedSourcesMapper } from '../../internal/scripts/sourcesMapper';
 import { IResourceIdentifier, ResourceName, parseResourceIdentifier } from '../../internal/sources/resourceIdentifier';
 import { TYPES } from '../../dependencyInjection.ts/types';
 import { inject } from 'inversify';
@@ -25,7 +25,7 @@ import * as _ from 'lodash';
 import { SourceMap } from '../../../sourceMaps/sourceMap';
 import { BasePathTransformer } from '../../../transformers/basePathTransformer';
 import { BaseSourceMapTransformer } from '../../../transformers/baseSourceMapTransformer';
-import { isNotEmpty, isNotNull } from '../../utils/typedOperators';
+import { isNotEmpty } from '../../utils/typedOperators';
 import { CDTPExecutionContextEventsProvider } from './cdtpExecutionContextEventsProvider';
 
 /**
@@ -181,10 +181,7 @@ abstract class ScriptCreator {
     }
 
     private sourceMapper(script: IScript, sourceMap: SourceMap | null): IMappedSourcesMapper {
-        const sourceMapper = isNotNull(sourceMap)
-            ? new MappedSourcesMapper(script, sourceMap)
-            : new NoMappedSourcesMapper(script);
-        return sourceMapper;
+        return MappedSourcesMapper.tryParsing(script, sourceMap);
     }
 
     protected scriptRange(runtimeSource: ILoadedSource<CDTPScriptUrl>) {

--- a/src/chrome/internal/breakpoints/features/bpAtNotLoadedScriptViaHeuristicSetter.ts
+++ b/src/chrome/internal/breakpoints/features/bpAtNotLoadedScriptViaHeuristicSetter.ts
@@ -54,7 +54,7 @@ export class BPAtNotLoadedScriptViaHeuristicSetter {
         const sourceMap = await this._sourceMapTransformer.getSourceMapFromAuthoredPath(sourceIdentifier);
         if (sourceMap !== null) {
             const script = new SourceWithSourceMap(sourceMap);
-            const sourceMapper = new MappedSourcesMapper(script, sourceMap);
+            const sourceMapper = MappedSourcesMapper.tryParsing(script, sourceMap);
             const mappedLocation = sourceMapper.getPositionInScript(requestedBP.location);
             return new LocationInUrl(<IResourceIdentifier<CDTPScriptUrl>>sourceMap.generatedPath, mappedLocation.enclosingRange.range.start);
         }
@@ -70,6 +70,9 @@ export class BPAtNotLoadedScriptViaHeuristicSetter {
  * that will correctly help map typescript files to javascript files for non .html files.
  */
 export class SourceWithSourceMap implements IHasSourceMappingInformation {
+    public readonly runtimeSource = new NoLoadedSourceAvailable();
+    public readonly developmentSource = new NoLoadedSourceAvailable();
+
     public constructor(private readonly _sourceMap: SourceMap) { }
 
     public get mappedSources(): IdentifiedLoadedSource<string>[] {

--- a/src/chrome/internal/locations/mappedTokensInScript.ts
+++ b/src/chrome/internal/locations/mappedTokensInScript.ts
@@ -1,5 +1,5 @@
 import { RangeInResource, Range } from './rangeInScript';
-import { LocationInScript } from './location';
+import { LocationInScript, Location } from './location';
 import { printArray } from '../../collections/printing';
 import { IHasSourceMappingInformation } from '../scripts/IHasSourceMappingInformation';
 import { IScript } from '../scripts/script';
@@ -23,8 +23,8 @@ export class MappedTokensInScript<T extends IHasSourceMappingInformation = IHasS
         }
     }
 
-    public static characterAt(characterLocation: LocationInScript): IMappedTokensInScript<IScript> {
-        return new MappedTokensInScript(characterLocation.script, [Range.at(characterLocation.position)]);
+    public static characterAt<T extends IHasSourceMappingInformation>(characterLocation: Location<T>): IMappedTokensInScript<T> {
+        return new MappedTokensInScript<T>(characterLocation.resource, [Range.at(characterLocation.position)]);
     }
 
     public static untilNextLine(characterLocation: LocationInScript): IMappedTokensInScript<IScript> {

--- a/src/chrome/internal/scripts/IHasSourceMappingInformation.ts
+++ b/src/chrome/internal/scripts/IHasSourceMappingInformation.ts
@@ -1,7 +1,10 @@
 import { IdentifiedLoadedSource } from '../sources/identifiedLoadedSource';
 import { Position } from '../locations/location';
+import { ILoadedSource } from '../../..';
 
 export interface IHasSourceMappingInformation {
     readonly mappedSources: IdentifiedLoadedSource[]; // Sources before compilation
     readonly startPositionInSource: Position;
+    readonly runtimeSource: ILoadedSource;
+    readonly developmentSource: ILoadedSource;
 }


### PR DESCRIPTION
Reading a source-map with "sources": [] was throwing an unhandled exception.
Now we just ignore a source-map that fails to be parsed

src/telemetry.ts: Added method to report telemetry on an error

All the other changes were to get the code to compile after starting to use the MappedSourcesMapper.tryParsing method.

test: https://github.com/microsoft/vscode-chrome-debug/pull/869