### PR TITLE
Now we don't fail if we get 2 simultaneos requests

### DIFF
--- a/src/chrome/internal/sources/sourceTextRetriever.ts
+++ b/src/chrome/internal/sources/sourceTextRetriever.ts
@@ -19,17 +19,18 @@ import { printArray } from '../../collections/printing';
  */
 @injectable()
 export class SourceTextRetriever {
-    private _sourceToText = new ValidatedMap<ILoadedSource, string>();
+    private _sourceToText = new ValidatedMap<ILoadedSource, Promise<string>>();
 
     constructor(@inject(TYPES.IScriptSources) private readonly _scriptSources: IScriptSourcesRetriever) { }
 
-    public async text(loadedSource: ILoadedSource): Promise<string> {
+    // We want this method to be sync, so if we get 2 simultaneous calls, the second call will return the promise of the first call
+    public text(loadedSource: ILoadedSource): Promise<string> {
         let text = this._sourceToText.tryGetting(loadedSource);
 
         if (text === undefined) {
             const scripts = loadedSource.scriptMapper().scripts;
             if (loadedSource.sourceScriptRelationship === SourceScriptRelationship.SourceIsSingleScript && scripts.length === 1) {
-                text = await this._scriptSources.getScriptSource(singleElementOfArray(scripts));
+                text = this._scriptSources.getScriptSource(singleElementOfArray(scripts));
             } else if (loadedSource.sourceScriptRelationship === SourceScriptRelationship.SourceIsSingleScript && scripts.length >= 2) {
                 /**
                  * We have two scripts associated with this source. At the moment we don't have any further support for this scenario
@@ -37,10 +38,10 @@ export class SourceTextRetriever {
                  * isn't the same.
                  */
                 logger.warn(`${loadedSource} is associated with several ${printArray('scripts', scripts)} returning the source arbitrarily of the first one`);
-                text = await this._scriptSources.getScriptSource(scripts[0]);
+                text = this._scriptSources.getScriptSource(scripts[0]);
             } else if (loadedSource.contentsLocation === ContentsLocation.PersistentStorage) {
                 // If this is a file, we don't want to cache it, so we return the contents immediately
-                return await utils.readFileP(loadedSource.identifier.textRepresentation);
+                return utils.readFileP(loadedSource.identifier.textRepresentation);
             } else {
                 // We'll need to figure out what is the right thing to do for SourceScriptRelationship.Unknown
                 throw new Error(`Support for getting the text from dynamic sources that have multiple scripts embedded hasn't been implemented yet`);

--- a/src/chrome/internal/sources/sourceTextRetriever.ts
+++ b/src/chrome/internal/sources/sourceTextRetriever.ts
@@ -23,7 +23,8 @@ export class SourceTextRetriever {
 
     constructor(@inject(TYPES.IScriptSources) private readonly _scriptSources: IScriptSourcesRetriever) { }
 
-    // We want this method to be sync, so if we get 2 simultaneous calls, the second call will return the promise of the first call
+    // We want this method to add an entry to the map this._sourceToText atomically, so if we get 2 simultaneous calls,
+    // the second call will return the promise/result of the first call
     public text(loadedSource: ILoadedSource): Promise<string> {
         let text = this._sourceToText.tryGetting(loadedSource);
 


### PR DESCRIPTION
Calling SourceTextRetriever.text with the same parameter twice simultaneously was failing because this._sourceToText.set was failing while trying to re-set the contents of a file.
Now we store the promise instead of the text, so the second call will return the promise created by the first one, and it won't fail.