### PR TITLE
Preseve script urls as supplied by CRDP

### DIFF
--- a/src/chrome/internal/sources/resourceIdentifier.ts
+++ b/src/chrome/internal/sources/resourceIdentifier.ts
@@ -84,9 +84,9 @@ export interface IURL<TString extends string = string> extends IResourceLocation
 export class LocalFileURL<TString extends string = string> extends IsEquivalentCommonLogic implements IURL<TString> {
     private _localResourcePath: ILocalFilePath;
 
-    constructor(fileUrl: TString) {
+    constructor(private readonly _fileUrl: TString) {
         super();
-        let filePath = decodeURIComponent(fileUrl.replace(/^file:\/\/\//, ''));
+        let filePath = decodeURIComponent(_fileUrl.replace(/^file:\/\/\//, ''));
         this._localResourcePath = parseLocalResourcePath(filePath);
     }
 
@@ -95,7 +95,7 @@ export class LocalFileURL<TString extends string = string> extends IsEquivalentC
     }
 
     public get textRepresentation(): TString {
-        return <TString>utils.pathToFileURL(this._localResourcePath.textRepresentation);
+        return this._fileUrl; // We preserve the exact representation that was given to us. If we unescape a character, CRDP will consider it to be a different url
     }
 
     public get filePathRepresentation(): string {


### PR DESCRIPTION
If we launch a url like file:///c%3A/myproject/index.html and then we try to set a breakpoint with a regexp on file:///c:/myproject/app.js it doesn't work. We need to build the regexp with file:///c%3A/myproject/index.html for CRDP to match it properly. We achieve that by keeping the exact script url provided by CRDP instead of normalizing it.

test: https://github.com/microsoft/vscode-chrome-debug/pull/883