### PR TITLE
Now we correctly support failed scripts

### DIFF
--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider.ts
@@ -65,8 +65,6 @@ export class CDTPDebuggeeExecutionEventsProvider extends CDTPEventsEmitterDiagno
 
     public readonly onResumed = this.addApiListener('resumed', (params: void) => params);
 
-    public readonly onScriptFailedToParse = this.addApiListener('scriptFailedToParse', (params: CDTP.Debugger.ScriptFailedToParseEvent) => params);
-
     constructor(
         @inject(TYPES.CDTPClient) private readonly _protocolApi: CDTP.ProtocolApi,
         @inject(TYPES.CDTPScriptsRegistry) private _scriptsRegistry: CDTPScriptsRegistry,


### PR DESCRIPTION
When a script is invalid, we get a Runtime.onExceptionThrown with a scriptId referencing the invalid script (and an unhandled exception).
With this change, we treat correct and erroneous script the same way, so we can find them both by script id.

If we find a scenario where we need to differentiate between these two, we'll have to update the code to treat them differently.

test: https://github.com/microsoft/vscode-chrome-debug/pull/884