### PR TITLE
Show paused overlay when pausing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -86,13 +86,21 @@
             "internalConsoleOptions": "openOnSessionStart",
             "smartStep": true,
             "skipFiles": [
+                "<node_internals>/**",
                 "async_hooks.js",
+                "transformedListenerRegistry.ts",
+                "loggingDebugSession.ts",
+                "debugSession.ts",
+                "messages.ts",
+                "protocol.ts",
+                "decorators.ts",
+                "logger.ts",
                 "methodsCalledLogger.ts",
                 "next_tick.js",
                 "inspector_async_hook.js",
                 "printObjectDescription.js",
                 "lodash.js",
-                "listeners.ts",
+                "listeners.ts"
             ]
         },
         {

--- a/src/chrome/client/chromeDebugAdapter/connectedCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/connectedCDA.ts
@@ -18,6 +18,7 @@ import { TerminatingCDAProvider } from './terminatingCDA';
 import { BasePathTransformer } from '../../../transformers/basePathTransformer';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { IDebuggeeInitializer, TerminatingReason } from '../../debugeeStartup/debugeeLauncher';
+import { ISupportedDomains } from '../../internal/domains/supportedDomains';
 
 export type ConnectedCDAProvider = (protocolApi: CDTP.ProtocolApi) => ConnectedCDA;
 
@@ -38,6 +39,7 @@ export class ConnectedCDA extends BaseCDAState {
         @multiInject(TYPES.IServiceComponent) private readonly _serviceComponents: IServiceComponent[],
         @inject(TYPES.BasePathTransformer) private readonly _basePathTransformer: BasePathTransformer,
         @multiInject(TYPES.ICommandHandlerDeclarer) requestHandlerDeclarers: ICommandHandlerDeclarer[],
+        @inject(TYPES.ISupportedDomains) private readonly _supportedDomains: ISupportedDomains,
     ) {
         super(requestHandlerDeclarers, {
             'initialize': () => { throw new Error('The debug adapter is already initialized. Calling initialize again is not supported.'); },
@@ -72,6 +74,7 @@ export class ConnectedCDA extends BaseCDAState {
         await super.install(); // Some of the components make CDTP calls on their install methods. We need to call this after enabling domings, to prevent a component hanging this method
         await this._chromeDebugAdapterLogic.install();
         await this._basePathTransformer.install();
+        await this._supportedDomains.install();
 
         for (const serviceComponent of this._serviceComponents) {
             await serviceComponent.install();

--- a/src/chrome/internal/domains/supportedDomains.ts
+++ b/src/chrome/internal/domains/supportedDomains.ts
@@ -9,12 +9,12 @@ import { injectable, inject } from 'inversify';
 import { TYPES } from '../../dependencyInjection.ts/types';
 import { CDTPSchemaProvider } from '../../cdtpDebuggee/features/cdtpSchemaProvider';
 
-export interface ISupportedDomains {
+export interface ISupportedDomains extends IInstallableComponent {
     isSupported(domainName: string): boolean;
 }
 
 @injectable()
-export class SupportedDomains implements IInstallableComponent, ISupportedDomains {
+export class SupportedDomains implements ISupportedDomains {
     private readonly _domains = new Map<string, CDTP.Schema.Domain>();
 
     constructor(@inject(TYPES.ISchemaProvider) private readonly _cdtpSchemaProvider: CDTPSchemaProvider) { }


### PR DESCRIPTION
The paused overlay wasn't being shown because we didn't install SupportedDomains so the list of domains was empty, and the code assumed that the Overlay domain didn't exist.

test: https://github.com/microsoft/vscode-chrome-debug/pull/885