### PR TITLE
Improved the startup error messages and other fixes

### DIFF
--- a/src/chrome/cdtpDebuggee/registries/cdtpScriptsRegistry.ts
+++ b/src/chrome/cdtpDebuggee/registries/cdtpScriptsRegistry.ts
@@ -23,7 +23,7 @@ const WAIT_FOR_SCRIPT_PARSED_INTERVAL_IN_MS = 100;
  */
 @injectable()
 export class CDTPScriptsRegistry {
-    private readonly _idToExecutionContext = new ValidatedMap<CDTP.Runtime.ExecutionContextId, ExecutionContext>();
+    private _idToExecutionContext = new ValidatedMap<CDTP.Runtime.ExecutionContextId, ExecutionContext>();
     private _scripts = new CDTPCurrentGeneration();
 
     public registerExecutionContext(executionContextId: CDTP.Runtime.ExecutionContextId, frameId: FrameId): IExecutionContext {
@@ -72,6 +72,9 @@ export class CDTPScriptsRegistry {
         // If Users start seeing those kind of issues, we'll need to figure out what enhancements we need to do to handle those cases
         // Also see: loadedSourcesRegistry.ts
         this._scripts = new CDTPCurrentGeneration();
+
+        // The same execution context id can be used after a cleared message
+        this._idToExecutionContext = new ValidatedMap<CDTP.Runtime.ExecutionContextId, ExecutionContext>();
     }
 
     public toString(): string {

--- a/src/chrome/chromeUtils.ts
+++ b/src/chrome/chromeUtils.ts
@@ -16,7 +16,6 @@ import { IResourceIdentifier } from './internal/sources/resourceIdentifier';
 import { isNotEmpty, isEmpty, isDefined, hasMatches, isUndefined, defaultWhenEmpty } from './utils/typedOperators';
 import * as _ from 'lodash';
 import { notEmpty } from '../validation';
-import isNull = require('lodash/isNull');
 
 /**
  * Takes the path component of a target url (starting with '/') and applies pathMapping
@@ -110,8 +109,8 @@ export function targetUrlToClientPath(aUrl: string, pathMapping: IPathMapping | 
     }
 
     // Search the filesystem under the webRoot for the file that best matches the given url
-    let pathName = url.parse(canonicalUrl).pathname; // This can be null
-    if (isNull(pathName) || isEmpty(pathName) || pathName === '/') {
+    let pathName = <string | undefined | null>url.parse(canonicalUrl).pathname; // This can be null even though the typing says otherwise
+    if (pathName === null || isEmpty(pathName) || pathName === '/') {
         return '';
     }
 

--- a/src/chrome/chromeUtils.ts
+++ b/src/chrome/chromeUtils.ts
@@ -16,6 +16,7 @@ import { IResourceIdentifier } from './internal/sources/resourceIdentifier';
 import { isNotEmpty, isEmpty, isDefined, hasMatches, isUndefined, defaultWhenEmpty } from './utils/typedOperators';
 import * as _ from 'lodash';
 import { notEmpty } from '../validation';
+import isNull = require('lodash/isNull');
 
 /**
  * Takes the path component of a target url (starting with '/') and applies pathMapping
@@ -109,8 +110,8 @@ export function targetUrlToClientPath(aUrl: string, pathMapping: IPathMapping | 
     }
 
     // Search the filesystem under the webRoot for the file that best matches the given url
-    let pathName = url.parse(canonicalUrl).pathname;
-    if (isEmpty(pathName) || pathName === '/') {
+    let pathName = url.parse(canonicalUrl).pathname; // This can be null
+    if (isNull(pathName) || isEmpty(pathName) || pathName === '/') {
         return '';
     }
 

--- a/src/chrome/client/chromeDebugAdapter/baseCDAState.ts
+++ b/src/chrome/client/chromeDebugAdapter/baseCDAState.ts
@@ -21,7 +21,7 @@ export abstract class BaseCDAState implements IDebugAdapterState {
         const allDeclarers = requestHandlerDeclarers.concat({
             getCommandHandlerDeclarations: () => CommandHandlerDeclaration.fromLiteralObject(requestHandlerMappingsWithDefault)
         });
-        this._requestProcessor = new RequestProcessor(allDeclarers);
+        this._requestProcessor = new RequestProcessor(`${this}`, allDeclarers);
     }
 
     public async install(): Promise<this> {

--- a/src/chrome/client/chromeDebugAdapter/baseCDAState.ts
+++ b/src/chrome/client/chromeDebugAdapter/baseCDAState.ts
@@ -21,7 +21,7 @@ export abstract class BaseCDAState implements IDebugAdapterState {
         const allDeclarers = requestHandlerDeclarers.concat({
             getCommandHandlerDeclarations: () => CommandHandlerDeclaration.fromLiteralObject(requestHandlerMappingsWithDefault)
         });
-        this._requestProcessor = new RequestProcessor(`${this}`, allDeclarers);
+        this._requestProcessor = new RequestProcessor(this.toString(), allDeclarers);
     }
 
     public async install(): Promise<this> {

--- a/src/chrome/client/chromeDebugAdapter/connectedCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/connectedCDA.ts
@@ -94,4 +94,8 @@ export class ConnectedCDA extends BaseCDAState {
         await terminatingCDA.install();
         await this._chromeDebugAdapter.terminate(terminatingCDA);
     }
+
+    public toString(): string {
+        return `Connected to the debuggee`;
+    }
 }

--- a/src/chrome/client/chromeDebugAdapter/connectingCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/connectingCDA.ts
@@ -29,4 +29,8 @@ export class ConnectingCDA extends BaseCDAState {
         await newState.install();
         return newState;
     }
+
+    public toString(): string {
+        return `Connecting to the debuggee`;
+    }
 }

--- a/src/chrome/client/chromeDebugAdapter/requestProcessor.ts
+++ b/src/chrome/client/chromeDebugAdapter/requestProcessor.ts
@@ -6,14 +6,14 @@ import { printArray } from '../../collections/printing';
 export class RequestProcessor {
     private readonly _requestNameToHandler = new ValidatedMap<CommandText, RequestHandler>();
 
-    public constructor(private readonly _requestHandlerDeclarers: ICommandHandlerDeclarer[]) { }
+    public constructor(private readonly _stateDescription: string, private readonly _requestHandlerDeclarers: ICommandHandlerDeclarer[]) { }
 
     public async processRequest(requestName: CommandText, args: unknown): Promise<unknown> {
         const requestHandler = this._requestNameToHandler.tryGetting(requestName);
         if (requestHandler !== undefined) {
             return requestHandler.call('Process request has no this', args);
         } else {
-            throw new Error(`The request processor is not configured to handle request: ${requestName} with arguments: ${JSON.stringify(args)}`);
+            throw new Error(`Unexpected request: The request: ${requestName} with arguments: ${JSON.stringify(args)} is not expected while in state: ${this._stateDescription}`);
         }
     }
 

--- a/src/chrome/client/chromeDebugAdapter/terminatedCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/terminatedCDA.ts
@@ -12,4 +12,8 @@ export class TerminatedCDA extends BaseCDAState {
     constructor(@inject(TYPES.ISession) protected readonly _session: ISession) {
         super([], {});
     }
+
+    public toString(): string {
+        return `Terminated the debug session`;
+    }
 }

--- a/src/chrome/client/chromeDebugAdapter/terminatingCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/terminatingCDA.ts
@@ -71,4 +71,8 @@ export class TerminatingCDA extends BaseCDAState {
         // TODO: Figure out when we shouldn't send a TerminatedEvent if (isTrue((<ILaunchRequestArgs>this._configuration.args).noDebug)) { }
         this._session.sendEvent(new TerminatedEvent(restart));
     }
+
+    public toString(): string {
+        return `Terminating the debug session`;
+    }
 }

--- a/src/chrome/client/chromeDebugAdapter/uninitializedCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/uninitializedCDA.ts
@@ -69,4 +69,8 @@ export class UninitializedCDA extends BaseCDAState {
         const newState = this._unconnectedCDAProvider(args);
         return { capabilities, newState };
     }
+
+    public toString(): string {
+        return `Waiting for the debug session to be initialized`;
+    }
 }


### PR DESCRIPTION
cdtpScriptsRegistry.ts: After we clear the execution contexts, CRDP sometimes reuse ids...
chromeUtils.ts: url.parse(canonicalUrl).pathname can be null

Also improve the error messages we show if we cannot find the url that the user requested in Chrome