### PR TITLE
Fix startup telemetry to match v1

### DIFF
--- a/src/chrome/cdtpDebuggee/cdtpDIContainer.ts
+++ b/src/chrome/cdtpDebuggee/cdtpDIContainer.ts
@@ -27,6 +27,7 @@ import { ValidatedMap } from '../collections/validatedMap';
 import { TYPES } from '../dependencyInjection.ts/types';
 import { interfaces } from 'inversify';
 import { DependencyInjection } from '../dependencyInjection.ts/di';
+import { CDTPNetworkCacheConfigurer } from './features/cdtpNetworkCacheConfigurer';
 
 const exportedIdentifierToClassMapping = new ValidatedMap<symbol, interfaces.Newable<any>>([
     [TYPES.IDebuggeeExecutionController, CDTPDebuggeeExecutionController],
@@ -52,6 +53,7 @@ const exportedIdentifierToClassMapping = new ValidatedMap<symbol, interfaces.New
     [TYPES.IDomainsEnabler, CDTPDomainsEnabler],
     [TYPES.IRuntimeStarter, CDTPRuntimeStarter],
     [TYPES.IPausedOverlayConfigurer, CDTPPausedOverlayConfigurer],
+    [TYPES.INetworkCacheConfiguration, CDTPNetworkCacheConfigurer],
     [TYPES.ISchemaProvider, CDTPSchemaProvider],
 ]);
 

--- a/src/chrome/cdtpDebuggee/features/cdtpNetworkCacheConfigurer.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpNetworkCacheConfigurer.ts
@@ -3,24 +3,28 @@
  *--------------------------------------------------------*/
 
 import { Protocol as CDTP } from 'devtools-protocol';
+import { injectable, inject } from 'inversify';
+import { TYPES } from '../../dependencyInjection.ts/types';
 
 export interface INetworkCacheConfigurer {
     setCacheDisabled(params: CDTP.Network.SetCacheDisabledRequest): Promise<void>;
 }
 
+@injectable()
 export class CDTPNetworkCacheConfigurer implements INetworkCacheConfigurer {
-    constructor(protected api: CDTP.NetworkApi) {
-    }
+    private _api: CDTP.NetworkApi = this._protocolApi.Network;
+
+    constructor(@inject(TYPES.CDTPClient) private readonly _protocolApi: CDTP.ProtocolApi) {}
 
     public enable(parameters: CDTP.Network.EnableRequest): Promise<void> {
-        return this.api.enable(parameters);
+        return this._api.enable(parameters);
     }
 
     public disable(): Promise<void> {
-        return this.api.disable();
+        return this._api.disable();
     }
 
     public setCacheDisabled(params: CDTP.Network.SetCacheDisabledRequest): Promise<void> {
-        return this.api.setCacheDisabled(params);
+        return this._api.setCacheDisabled(params);
     }
 }

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -23,7 +23,6 @@ import { stackTraceWithoutLogpointFrame } from './internalSourceBreakpoint';
 import * as errors from '../errors';
 import * as utils from '../utils';
 import { telemetry } from '../telemetry';
-import { StepProgressEventsEmitter } from '../executionTimingsReporter';
 
 import { LineColTransformer } from '../transformers/lineNumberTransformer';
 import { BasePathTransformer } from '../transformers/basePathTransformer';
@@ -109,8 +108,6 @@ export class ChromeDebugLogic {
     private _currentLogMessage = Promise.resolve();
     privaRejectExceptionFilterEnabled = false;
 
-    public readonly events: StepProgressEventsEmitter;
-
     private readonly _chromeConnection: ChromeConnection;
     private readonly _sourceMapTransformer: BaseSourceMapTransformer;
     public _promiseRejectExceptionFilterEnabled = false;
@@ -140,7 +137,6 @@ export class ChromeDebugLogic {
         telemetry.setupEventHandler(e => session.sendEvent(e));
         this._session = session;
         this._chromeConnection = chromeConnection;
-        this.events = new StepProgressEventsEmitter(isDefined(this._chromeConnection.events) ? [this._chromeConnection.events] : []);
 
         this._variableHandles = new variables.VariableHandles();
 

--- a/src/chrome/chromeTargetDiscoveryStrategy.ts
+++ b/src/chrome/chromeTargetDiscoveryStrategy.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------*/
 
 import * as utils from '../utils';
-import { IStepStartedEventsEmitter, StepProgressEventsEmitter, IObservableEvents } from '../executionTimingsReporter';
+import { IStepStartedEventsEmitter, StepProgressEventsEmitter, IObservableEvents, ExecutionTimingsReporter } from '../executionTimingsReporter';
 
 import * as chromeUtils from './chromeUtils';
 
@@ -28,7 +28,12 @@ export class ChromeTargetDiscovery implements ITargetDiscoveryStrategy, IObserva
 
     public constructor(
         @inject(TYPES.ILogger) private logger: ILogger,
-        @inject(TYPES.ITelemetryReporter) private readonly telemetry: ITelemetryReporter) {}
+        @inject(TYPES.ITelemetryReporter) private readonly telemetry: ITelemetryReporter,
+        @inject(TYPES.ExecutionTimingsReporter) reporter?: ExecutionTimingsReporter) { // The extension uses null here
+            if (isDefined(reporter)) {
+                reporter.subscribeTo(this.events);
+            }
+        }
 
     async getTarget(address: string, port: number, targetFilter?: ITargetFilter, targetUrl?: string): Promise<ITarget> {
         const targets = await this.getAllTargets(address, port, targetFilter, targetUrl);

--- a/src/chrome/client/chromeDebugAdapter/cdaDIContainerCreator.ts
+++ b/src/chrome/client/chromeDebugAdapter/cdaDIContainerCreator.ts
@@ -28,6 +28,7 @@ export function createDIContainer(chromeDebugAdapter: ChromeDebugAdapter, rawDeb
     const diContainer = new DependencyInjection('ChromeDebugAdapter', debugSessionOptions.extensibilityPoints.componentCustomizationCallback);
 
     return diContainer
+    .configureValue(TYPES.ExecutionTimingsReporter, rawDebugSession.reporter)
     .configureValue(TYPES.ISession, session)
     .configureValue(TYPES.ITelemetryReporter, telemetry)
     .configureValue(TYPES.ChromeDebugAdapter, chromeDebugAdapter)

--- a/src/chrome/client/chromeDebugAdapter/connectingCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/connectingCDA.ts
@@ -10,17 +10,22 @@ import { ConnectedCDA, ConnectedCDAProvider } from './connectedCDA';
 import { ConnectedCDAConfiguration } from './cdaConfiguration';
 import { ITelemetryPropertyCollector } from '../../../telemetry';
 import { ISession } from '../session';
+import { ExecutionTimingsReporter, StepProgressEventsEmitter } from '../../../executionTimingsReporter';
 
 export type ConnectingCDAProvider = (configuration: ConnectedCDAConfiguration) => ConnectingCDA;
 
 @injectable()
 export class ConnectingCDA extends BaseCDAState {
+    private readonly events = new StepProgressEventsEmitter();
+
     constructor(
         @inject(TYPES.ISession) protected readonly _session: ISession,
         @inject(TYPES.ConnectedCDAProvider) private readonly _connectedCDAProvider: ConnectedCDAProvider,
+        @inject(TYPES.ExecutionTimingsReporter) reporter: ExecutionTimingsReporter,
         @inject(TYPES.ChromeConnection) private readonly _chromeConnection: ChromeConnection,
     ) {
         super([], {});
+        reporter.subscribeTo(this.events);
     }
 
     public async connect(telemetryPropertyCollector: ITelemetryPropertyCollector): Promise<ConnectedCDA> {

--- a/src/chrome/client/chromeDebugAdapter/unconnectedCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/unconnectedCDA.ts
@@ -41,6 +41,8 @@ export class UnconnectedCDA implements IDebugAdapterState {
                 return this.launch(<ILaunchRequestArgs>args, telemetryPropertyCollector);
             case 'attach':
                 return this.attach(<IAttachRequestArgs>args, telemetryPropertyCollector);
+            case 'disconnect':
+                throw new Error(`The debug adapter is already disconnected`);
             default:
                 throw new Error(`The unconnected debug adapter is not prepared to respond to the request ${requestName}`);
         }

--- a/src/chrome/client/clientLifecycleRequestsHandler.ts
+++ b/src/chrome/client/clientLifecycleRequestsHandler.ts
@@ -3,10 +3,16 @@ import { inject, injectable } from 'inversify';
 import { TYPES } from '../dependencyInjection.ts/types';
 import { ChromeDebugLogic } from '../chromeDebugAdapter';
 import { IDebuggeeRunner } from '../debugeeStartup/debugeeLauncher';
-import { StepProgressEventsEmitter } from '../../executionTimingsReporter';
+import { StepProgressEventsEmitter, ExecutionTimingsReporter } from '../../executionTimingsReporter';
 import { ICommandHandlerDeclarer, ICommandHandlerDeclaration, CommandHandlerDeclaration } from '../internal/features/components';
 import { ConnectedCDAConfiguration } from './chromeDebugAdapter/cdaConfiguration';
-import { ScenarioType } from '../..';
+import { ScenarioType } from './chromeDebugAdapter/unconnectedCDA';
+
+export class UserPageLaunchedError extends Error {
+    public constructor(public readonly reason: string, message: string) {
+        super(message);
+    }
+}
 
 @injectable()
 export class ClientLifecycleRequestsHandler implements ICommandHandlerDeclarer {
@@ -16,7 +22,9 @@ export class ClientLifecycleRequestsHandler implements ICommandHandlerDeclarer {
         @inject(TYPES.ChromeDebugLogic) protected readonly _chromeDebugAdapter: ChromeDebugLogic,
         @inject(TYPES.ConnectedCDAConfiguration) protected readonly _configuration: ConnectedCDAConfiguration,
         @inject(TYPES.IDebuggeeRunner) public readonly _debuggeeRunner: IDebuggeeRunner,
+        @inject(TYPES.ExecutionTimingsReporter) reporter: ExecutionTimingsReporter,
     ) {
+        reporter.subscribeTo(this.events);
     }
 
     public getCommandHandlerDeclarations(): ICommandHandlerDeclaration[] {
@@ -28,9 +36,18 @@ export class ClientLifecycleRequestsHandler implements ICommandHandlerDeclarer {
     public async configurationDone(): Promise<void> {
         if (this._configuration.scenarioType === ScenarioType.Launch) {
             // At the moment it doesn't make sense to use the runner for attaching, so we only use it for launching
-            await this._debuggeeRunner.run(new TelemetryPropertyCollector());
-        }
+            try {
+                await this._debuggeeRunner.run(new TelemetryPropertyCollector());
+                this.events.emitMilestoneReached('RequestedNavigateToUserPage');
 
-        this.events.emitMilestoneReached('RequestedNavigateToUserPage'); // TODO DIEGO: Make sure this is reported
+                this.events.emitFinishedStartingUp(true);
+            } catch (exception) {
+                const reason = exception instanceof UserPageLaunchedError
+                    ? exception.reason
+                    : 'UnspecifiedReason';
+                    this.events.emitFinishedStartingUp(false, reason);
+                throw exception;
+            }
+        }
     }
 }

--- a/src/chrome/dependencyInjection.ts/types.ts
+++ b/src/chrome/dependencyInjection.ts/types.ts
@@ -7,6 +7,7 @@ import 'reflect-metadata';
 // TODO: Add all necesary types so we can use inversifyjs to create our components
 const TYPES = {
     ISession: Symbol.for('ISession'),
+    ExecutionTimingsReporter: Symbol.for('ExecutionTimingsReporter'),
     ITelemetryReporter: Symbol.for('ITelemetryReporter'),
     ChromeDebugAdapter: Symbol.for('ChromeDebugAdapter'),
     TerminatingReason: Symbol.for('TerminatingReason'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ import { SourceResolver } from './chrome/internal/sources/sourceResolver';
 import { ICDTPDebuggeeExecutionEventsProvider, PausedEvent } from './chrome/cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider';
 import { ScenarioType } from './chrome/client/chromeDebugAdapter/unconnectedCDA';
 import { ILoggingConfiguration } from './chrome/internal/services/logging';
-import { IFinishedStartingUpEventArguments, StepProgressEventsEmitter } from './executionTimingsReporter';
+import { IFinishedStartingUpEventArguments, StepProgressEventsEmitter, ExecutionTimingsReporter } from './executionTimingsReporter';
 import { ILogEventsProvider, ILogEntry } from './chrome/cdtpDebuggee/eventsProviders/cdtpLogEventsProvider';
 import { IDOMInstrumentationBreakpointsSetter } from './chrome/cdtpDebuggee/features/cdtpDOMInstrumentationBreakpointsSetter';
 import { IDebuggeePausedHandler } from './chrome/internal/features/debuggeePausedHandler';
@@ -74,6 +74,7 @@ import { CDTPScriptsRegistry } from './chrome/cdtpDebuggee/registries/cdtpScript
 import { EagerSourceMapTransformer } from './transformers/eagerSourceMapTransformer';
 import { ISourceToClientConverter } from './chrome/client/sourceToClientConverter';
 import { IEventsToClientReporter } from './chrome/client/eventsToClientReporter';
+import { UserPageLaunchedError } from './chrome/client/clientLifecycleRequestsHandler';
 
 export {
     chromeConnection,
@@ -218,5 +219,9 @@ export {
 
     IEventsToClientReporter,
 
-    TerminatingReason
+    TerminatingReason,
+
+    UserPageLaunchedError,
+
+    ExecutionTimingsReporter,
 };


### PR DESCRIPTION
- cdtpNetworkCacheConfigurer.ts & cdtpDIContainer.ts: CDTPNetworkCacheConfigurer wasn't been initialized
- unconnectedCDA.ts: Improve error for the disconnect request
- Everything else: Adapted ExecutionTimingsReporter to work with inversify. Passing the nested events to constructor of StepProgressEventsEmitter doesn't work well with the decentralized architecture of v2. Re-added some steps that I deleted while refactoring v2.

After this fix we report this:
{
        "category": "telemetry",
        "output": "report-start-up-timings",
        "data": {
            "Versions.DebugAdapter": "4.11.3",
            "Versions.DebugAdapterCore": "10.7.35",
            "Versions.Target.CRDPVersion": "1.3",
            "Versions.Target.Revision": "@cd0b15c8b6a4e70c44e27f35c37a4029bad3e3b0",
            "Versions.Target.UserAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36",
            "Versions.Target.V8": "7.5.288.23",
            "Versions.Target.Project": "Chrome",
            "Versions.Target.Version": "75.0.3770.100",
            "RequestedContentWasDetected": "true",
            "Steps": "[\"BeforeFirstStep\",\"ClientRequest/initialize\",\"ClientRequest/launch\",\"LaunchTarget.LaunchExe\",\"Attach\",\"Attach.RequestDebuggerTargetsInformation\",\"Attach.ProcessDebuggerTargetsInformation\",\"Attach.AttachToTargetDebuggerWebsocket\",\"Attach.ConfigureDebuggingSession\"]",
            "All": "1050.563829",
            "Request.ClientRequest/loadedSources.startTime": "[1562964786383]",
            "Request.ClientRequest/loadedSources.timeTakenInMilliseconds": "[4.530743]",
            "Request.ClientRequest/setBreakpoints.startTime": "[1562964786374]",
            "Request.ClientRequest/setBreakpoints.timeTakenInMilliseconds": "[17.921901]",
            "Request.ClientRequest/setExceptionBreakpoints.startTime": "[1562964786397]",
            "Request.ClientRequest/setExceptionBreakpoints.timeTakenInMilliseconds": "[3.112756]",
            "BeforeFirstStep": "[15.945812]",
            "WaitingAfter.ClientRequest/initialize": "[19.238968]",
            "ClientRequest/initialize": "[4.504762]",
            "ClientRequest/launch": "[9.599265]",
            "LaunchTarget.LaunchExe": "[127.272111]",
            "Attach": "[9.646827]",
            "Attach.RequestDebuggerTargetsInformation": "[527.857242]",
            "Attach.ProcessDebuggerTargetsInformation": "[1.054115]",
            "Attach.AttachToTargetDebuggerWebsocket": "[50.999568]",
            "WaitingAfter.NotifyInitialized": "[935.181776]",
            "WaitingAfter.ClientRequest/launch": "[935.972868]",
            "RequestedNavigateToUserPage": "[1049.547219]",
            "Attach.ConfigureDebuggingSession": "[302.82501]"
        }
    }

This change also requires this PR in chrome-debug: https://github.com/microsoft/vscode-chrome-debug/pull/887