### PR TITLE
Clear scripts on reload

### DIFF
--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpExecutionContextEventsProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpExecutionContextEventsProvider.ts
@@ -11,8 +11,12 @@ import { TYPES } from '../../dependencyInjection.ts/types';
 import { CDTPDomainsEnabler } from '../infrastructure/cdtpDomainsEnabler';
 import { FrameId } from '../cdtpPrimitives';
 
+export interface IExecutionContextEventsProvider {
+    onExecutionContextsCleared(listener: (args: void) => void): void;
+}
+
 @injectable()
-export class CDTPExecutionContextEventsProvider extends CDTPEventsEmitterDiagnosticsModule<CDTP.RuntimeApi> {
+export class CDTPExecutionContextEventsProvider extends CDTPEventsEmitterDiagnosticsModule<CDTP.RuntimeApi> implements IExecutionContextEventsProvider {
     protected readonly api = this._protocolApi.Runtime;
 
     public readonly onExecutionContextsCleared = this.addApiListener('executionContextsCleared', (params: void) => params);

--- a/src/chrome/internal/sources/features/notifyClientOfLoadedSources.ts
+++ b/src/chrome/internal/sources/features/notifyClientOfLoadedSources.ts
@@ -11,6 +11,7 @@ import { ILoadedSource, ContentsLocation } from '../loadedSource';
 import { newResourceIdentifierMap } from '../resourceIdentifier';
 import { LoadedSourceEventReason } from '../../../chromeDebugAdapter';
 import { IServiceComponent } from '../../features/components';
+import { IExecutionContextEventsProvider } from '../../../cdtpDebuggee/eventsProviders/cdtpExecutionContextEventsProvider';
 
 /**
  * This class will keep the client updated of the sources that are associated with the scripts that are currently loaded in the debuggee
@@ -22,9 +23,11 @@ export class NotifyClientOfLoadedSources implements IServiceComponent {
 
     constructor(
         @inject(TYPES.IScriptParsedProvider) public readonly _cdtpOnScriptParsedEventProvider: IScriptParsedProvider,
+        @inject(TYPES.ExecutionContextEventsProvider) public readonly _executionContextEventsProvider: IExecutionContextEventsProvider,
         @inject(TYPES.IEventsToClientReporter) private readonly _eventsToClientReporter: IEventsToClientReporter) {
-        this._cdtpOnScriptParsedEventProvider.onScriptParsed(scriptParsed => this.onScriptParsed(scriptParsed));
-    }
+            this._cdtpOnScriptParsedEventProvider.onScriptParsed(scriptParsed => this.onScriptParsed(scriptParsed));
+            this._executionContextEventsProvider.onExecutionContextsCleared(() => this.onExecutionContextsCleared());
+        }
 
     public install(): this {
         return this;


### PR DESCRIPTION
We weren't clearing the list of loaded sources after reloading the webpage