### PR TITLE
Reduce logging

### DIFF
--- a/src/chrome/cdtpDebuggee/features/cdtpDebugeeStateInspector.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpDebugeeStateInspector.ts
@@ -8,6 +8,7 @@ import { CDTPCallFrameRegistry } from '../registries/cdtpCallFrameRegistry';
 import { injectable, inject } from 'inversify';
 import { TYPES } from '../../dependencyInjection.ts/types';
 import { ScriptCallFrame, CallFrameWithState } from '../../internal/stackTraces/callFrame';
+import { DoNotLog } from '../../logging/decorators';
 
 export interface IEvaluateOnCallFrameRequest {
     readonly frame: ScriptCallFrame<CallFrameWithState>;
@@ -57,6 +58,7 @@ export class CDTPDebuggeeStateInspector implements IDebuggeeStateInspector {
         return this.api.Runtime.callFunctionOn(params);
     }
 
+    @DoNotLog()
     public getProperties(params: CDTP.Runtime.GetPropertiesRequest): Promise<CDTP.Runtime.GetPropertiesResponse> {
         return this.api.Runtime.getProperties(params);
     }

--- a/src/chrome/chromeDebugSession.ts
+++ b/src/chrome/chromeDebugSession.ts
@@ -279,7 +279,7 @@ export class ChromeDebugSession extends LoggingDebugSession implements IObservab
                     const clonedResponse = Object.assign({}, response);
                     clonedResponse.body = Object.assign({}, response.body);
                     clonedResponse.body.content = '<removed script source for logs>';
-                    return originalLogVerbose.call(logger, `To client: ${JSON.stringify(clonedResponse)}`);
+                    return originalLogVerbose.call(logger, `To   client: ${JSON.stringify(clonedResponse)}`);
                 } else {
                     return originalLogVerbose.call(logger, textToLog);
                 }

--- a/src/chrome/client/chromeDebugAdapter/baseCDAState.ts
+++ b/src/chrome/client/chromeDebugAdapter/baseCDAState.ts
@@ -5,6 +5,7 @@ import { IDebugAdapterState } from '../../../debugAdapterInterfaces';
 import { ICommandHandlerDeclarer, CommandHandlerDeclaration, RequestHandlerMappings } from '../../internal/features/components';
 import { injectable } from 'inversify';
 import { ISession } from '../session';
+import { DoNotLog } from '../../logging/decorators';
 
 @injectable()
 export abstract class BaseCDAState implements IDebugAdapterState {
@@ -29,6 +30,7 @@ export abstract class BaseCDAState implements IDebugAdapterState {
         return this;
     }
 
+    @DoNotLog()
     public async processRequest(requestName: CommandText, args: unknown): Promise<unknown> {
         return await this._requestProcessor.processRequest(requestName, args);
     }

--- a/src/chrome/client/chromeDebugAdapter/requestProcessor.ts
+++ b/src/chrome/client/chromeDebugAdapter/requestProcessor.ts
@@ -2,12 +2,14 @@ import { ValidatedMap } from '../../collections/validatedMap';
 import { CommandText } from '../requests';
 import { RequestHandler, ICommandHandlerDeclarer } from '../../internal/features/components';
 import { printArray } from '../../collections/printing';
+import { DoNotLog } from '../../logging/decorators';
 
 export class RequestProcessor {
     private readonly _requestNameToHandler = new ValidatedMap<CommandText, RequestHandler>();
 
     public constructor(private readonly _requestHandlerDeclarers: ICommandHandlerDeclarer[]) { }
 
+    @DoNotLog()
     public async processRequest(requestName: CommandText, args: unknown): Promise<unknown> {
         const requestHandler = this._requestNameToHandler.tryGetting(requestName);
         if (requestHandler !== undefined) {

--- a/src/chrome/client/eventsToClientReporter.ts
+++ b/src/chrome/client/eventsToClientReporter.ts
@@ -22,6 +22,7 @@ import { BPRecipieStatusToClientConverter } from '../internal/breakpoints/featur
 import { ConnectedCDAConfiguration } from './chromeDebugAdapter/cdaConfiguration';
 import { LineColTransformer } from '../../transformers/lineNumberTransformer';
 import { isDefined } from '../utils/typedOperators';
+import { DoNotLog } from '../logging/decorators';
 
 export interface IOutputParameters {
     readonly output: string;
@@ -77,7 +78,8 @@ export class EventsToClientReporter implements IEventsToClientReporter {
         @inject(TYPES.SourceToClientConverter) private readonly _sourceToClientConverter: ISourceToClientConverter,
         @inject(TYPES.LineColTransformer) private readonly _lineColTransformer: LineColTransformer) { }
 
-    public async sendOutput(params: IOutputParameters) {
+        @DoNotLog()
+        public async sendOutput(params: IOutputParameters) {
         const event = new OutputEvent(params.output, params.category) as DebugProtocol.OutputEvent;
 
         if (isDefined(params.variablesReference)) {
@@ -91,6 +93,7 @@ export class EventsToClientReporter implements IEventsToClientReporter {
         this._session.sendEvent(event);
     }
 
+    @DoNotLog()
     public async sendSourceWasLoaded(params: ISourceWasLoadedParameters): Promise<void> {
         const clientSource = await this._sourceToClientConverter.toSource(params.source);
         const event = new LoadedSourceEvent(params.reason, <Source>clientSource); // TODO: Update source to have an optional sourceReference so we don't need to do this cast
@@ -98,6 +101,7 @@ export class EventsToClientReporter implements IEventsToClientReporter {
         this._session.sendEvent(event);
     }
 
+    @DoNotLog()
     public async sendBPStatusChanged(params: IBPStatusChangedParameters): Promise<void> {
         const breakpointStatus = await this._bpRecipieStatusToClientConverter.toExistingBreakpoint(params.bpRecipeStatus);
         const event = new BreakpointEvent(params.reason, breakpointStatus);
@@ -105,6 +109,7 @@ export class EventsToClientReporter implements IEventsToClientReporter {
         this._session.sendEvent(event);
     }
 
+    @DoNotLog()
     public async sendExceptionThrown(params: IExceptionThrownParameters): Promise<void> {
         return this.sendOutput({
             output: this._exceptionStackTracePrinter.toStackTraceString(params.exceptionStackTrace),
@@ -113,10 +118,12 @@ export class EventsToClientReporter implements IEventsToClientReporter {
         });
     }
 
+    @DoNotLog()
     public async sendDebuggeeIsStopped(params: IDebuggeeIsStoppedParameters): Promise<void> {
         return this._session.sendEvent(new StoppedEvent2(params.reason, /*threadId=*/ChromeDebugLogic.THREAD_ID, params.exception));
     }
 
+    @DoNotLog()
     public async sendDebuggeeIsResumed(): Promise<void> {
         return this._session.sendEvent(new ContinuedEvent(ChromeDebugLogic.THREAD_ID));
     }

--- a/src/chrome/client/sourceToClientConverter.ts
+++ b/src/chrome/client/sourceToClientConverter.ts
@@ -5,6 +5,7 @@ import { HandlesRegistry } from './handlesRegistry';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { LocalFileURL } from '../internal/sources/resourceIdentifier';
 import { injectable } from 'inversify';
+import { DoNotLog } from '../logging/decorators';
 
 export interface ISourceToClientConverter {
     toSource(loadedSource: ILoadedSource): Promise<DebugProtocol.Source>;
@@ -14,6 +15,7 @@ export interface ISourceToClientConverter {
 export class SourceToClientConverter implements ISourceToClientConverter {
     constructor(private readonly _handlesRegistry: HandlesRegistry) { }
 
+    @DoNotLog()
     public async toSource(loadedSource: ILoadedSource): Promise<DebugProtocol.Source> {
         const exists = await utils.existsAsync(loadedSource.identifier.canonicalized);
 

--- a/src/chrome/internal/breakpoints/features/bpRecipeAtLoadedSourceLogic.ts
+++ b/src/chrome/internal/breakpoints/features/bpRecipeAtLoadedSourceLogic.ts
@@ -25,6 +25,7 @@ import { PrivateTypes } from '../diTypes';
 import { printClassDescription } from '../../../utils/printing';
 import { SourceToScriptMapper } from '../../services/sourceToScriptMapper';
 import { OnPausedForBreakpointCallback, defaultOnPausedForBreakpointCallback } from './onPausedForBreakpointCallback';
+import { DoNotLog } from '../../../logging/decorators';
 
 @printClassDescription
 export class HitBreakpoint extends BaseNotifyClientOfPause {
@@ -75,6 +76,7 @@ export class BPRecipeAtLoadedSourceSetter implements IBPRecipeAtLoadedSourceSett
         }
     }
 
+    @DoNotLog()
     public async onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
         if (paused.hitBreakpoints.length > 0) {
             const bpRecipes = paused.hitBreakpoints.filter(bp => this._debuggeeBPRsSetForClientBPRFinder.containsBPRecipe(bp.unmappedBPRecipe));

--- a/src/chrome/internal/breakpoints/features/existingBPsForJustParsedScriptSetter.ts
+++ b/src/chrome/internal/breakpoints/features/existingBPsForJustParsedScriptSetter.ts
@@ -82,7 +82,7 @@ export class ExistingBPsForJustParsedScriptSetter {
 
     private async setBPsForScript(justParsedScript: IScript): Promise<void> {
         const defer = this.finishedSettingBPsForScriptDefer(justParsedScript);
-        await asyncMap(justParsedScript.allSources, source => this.withLogging.setBPsFromSourceIntoScript(source, justParsedScript));
+        await asyncMap(justParsedScript.allSources, source => this.setBPsFromSourceIntoScript(source, justParsedScript));
         defer.resolve();
     }
 
@@ -90,7 +90,7 @@ export class ExistingBPsForJustParsedScriptSetter {
         const bpRecipesInSource = this._bpRecipesForSourceRetriever.bpRecipesForSource(sourceWhichMayHaveBPs.identifier);
 
         for (const bpRecipe of bpRecipesInSource) {
-            await this.withLogging.setBPFromSourceIntoScriptIfNeeded(bpRecipe, justParsedScript, sourceWhichMayHaveBPs);
+            await this.setBPFromSourceIntoScriptIfNeeded(bpRecipe, justParsedScript, sourceWhichMayHaveBPs);
         }
     }
 
@@ -100,7 +100,7 @@ export class ExistingBPsForJustParsedScriptSetter {
         const runtimeLocationsWhichAlreadyHaveThisBPR = debuggeeBPRecipes.map(recipe => recipe.runtimeSourceLocation);
 
         const manyBPRecipesInScripts = await this._sourceToScriptMapper.mapBPRecipe(bpRecipeResolved, script => script === justParsedScript);
-        await this.withLogging.setBPRsInScriptIfNeeded(manyBPRecipesInScripts, runtimeLocationsWhichAlreadyHaveThisBPR);
+        await this.setBPRsInScriptIfNeeded(manyBPRecipesInScripts, runtimeLocationsWhichAlreadyHaveThisBPR);
     }
 
     private async setBPRsInScriptIfNeeded(bprInScripts: BPRecipeInScript[], runtimeLocationsWhichAlreadyHaveThisBPR: LocationInLoadedSource[]) {

--- a/src/chrome/internal/breakpoints/features/pauseScriptLoadsToSetBPs.ts
+++ b/src/chrome/internal/breakpoints/features/pauseScriptLoadsToSetBPs.ts
@@ -18,6 +18,7 @@ import { injectable, inject } from 'inversify';
 import { TYPES } from '../../../dependencyInjection.ts/types';
 import { printClassDescription } from '../../../utils/printing';
 import { PrivateTypes } from '../diTypes';
+import { DoNotLog } from '../../../logging/decorators';
 
 @printClassDescription
 export class HitStillPendingBreakpoint extends BaseNotifyClientOfPause {
@@ -82,6 +83,7 @@ export class PauseScriptLoadsToSetBPs implements IInstallableComponent {
         }
     }
 
+    @DoNotLog()
     private async onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
         if (this.isInstrumentationPause(paused)) {
             await this._existingBPsForJustParsedScriptSetter.waitUntilBPsAreSet(paused.callFrames[0].location.script);

--- a/src/chrome/internal/domains/supportedDomains.ts
+++ b/src/chrome/internal/domains/supportedDomains.ts
@@ -8,6 +8,7 @@ import { Protocol as CDTP } from 'devtools-protocol';
 import { injectable, inject } from 'inversify';
 import { TYPES } from '../../dependencyInjection.ts/types';
 import { CDTPSchemaProvider } from '../../cdtpDebuggee/features/cdtpSchemaProvider';
+import { DoNotLog } from '../../logging/decorators';
 
 export interface ISupportedDomains extends IInstallableComponent {
     isSupported(domainName: string): boolean;
@@ -19,6 +20,7 @@ export class SupportedDomains implements ISupportedDomains {
 
     constructor(@inject(TYPES.ISchemaProvider) private readonly _cdtpSchemaProvider: CDTPSchemaProvider) { }
 
+    @DoNotLog()
     public isSupported(domainName: string): boolean {
         return this._domains.has(domainName);
     }

--- a/src/chrome/internal/exceptions/pauseOnException.ts
+++ b/src/chrome/internal/exceptions/pauseOnException.ts
@@ -18,6 +18,7 @@ import { printClassDescription } from '../../utils/printing';
 import * as _ from 'lodash';
 import { isDefined } from '../../utils/typedOperators';
 import { IDebuggeeExecutionController } from '../../cdtpDebuggee/features/cdtpDebugeeExecutionController';
+import { DoNotLog } from '../../logging/decorators';
 
 type ExceptionBreakMode = 'never' | 'always' | 'unhandled' | 'userUnhandled';
 
@@ -86,6 +87,7 @@ export class PauseOnExceptionOrRejection {
         this._promiseRejectionsStrategy = promiseRejectionsStrategy;
     }
 
+    @DoNotLog()
     public async onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
         if (paused.reason === 'exception') {
             // If we are here is because we either configured the debugee to pauser on unhandled or handled exceptions

--- a/src/chrome/internal/features/skipFiles.ts
+++ b/src/chrome/internal/features/skipFiles.ts
@@ -5,7 +5,7 @@
 import * as nls from 'vscode-nls';
 import { inject, injectable } from 'inversify';
 import * as utils from '../../../utils';
-import { logger } from 'vscode-debugadapter/lib/logger';
+import { logger } from 'vscode-debugadapter';
 import { IStackTracePresentationDetailsProvider } from '../stackTraces/stackTracePresenter';
 import { newResourceIdentifierMap, IResourceIdentifier } from '../sources/resourceIdentifier';
 import { LocationInLoadedSource, LocationInScript, Position } from '../locations/location';
@@ -21,6 +21,7 @@ import { ISource } from '../sources/source';
 import { ICDTPDebuggeeExecutionEventsProvider } from '../../cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider';
 import { IDebuggeePausedHandler } from './debuggeePausedHandler';
 import { isTrue, isFalse, isDefined } from '../../utils/typedOperators';
+import { DoNotLog } from '../../logging/decorators';
 const localize = nls.loadMessageBundle();
 
 export interface ISkipFilesConfiguration {
@@ -50,6 +51,7 @@ export class SkipFilesLogic implements IStackTracePresentationDetailsProvider {
      * If the source has a saved skip status, return that, whether true or false.
      * If not, check it against the patterns list.
      */
+    @DoNotLog()
     public shouldSkipSource(sourcePath: ILoadedSource): boolean | undefined {
         const status = this.getSkipStatus(sourcePath);
         if (typeof status === 'boolean') {
@@ -63,6 +65,7 @@ export class SkipFilesLogic implements IStackTracePresentationDetailsProvider {
         return undefined;
     }
 
+    @DoNotLog()
     public callFrameAdditionalDetails(locationInLoadedSource: LocationInLoadedSource): ICallFramePresentationDetails[] {
         return isTrue(this.shouldSkipSource(locationInLoadedSource.source))
             ? [{

--- a/src/chrome/internal/features/smartStep.ts
+++ b/src/chrome/internal/features/smartStep.ts
@@ -21,6 +21,7 @@ import { IDebuggeeSteppingController } from '../../cdtpDebuggee/features/cdtpDeb
 import { printClassDescription } from '../../utils/printing';
 import * as _ from 'lodash';
 import { isNotNull } from '../../utils/typedOperators';
+import { DoNotLog } from '../../logging/decorators';
 const localize = nls.loadMessageBundle();
 
 export interface ISmartStepLogicConfiguration {
@@ -58,6 +59,7 @@ export class SmartStepLogic implements IStackTracePresentationDetailsProvider {
         this.configure();
     }
 
+    @DoNotLog()
     public isEnabled(): boolean {
         return this._isEnabled;
     }
@@ -75,6 +77,7 @@ export class SmartStepLogic implements IStackTracePresentationDetailsProvider {
         await this.stepInIfOnSkippedSource();
     }
 
+    @DoNotLog()
     public async onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
         if (this.isEnabled() && await this.shouldSkip(paused.callFrames[0])) {
             this._smartStepCount++;
@@ -110,6 +113,7 @@ export class SmartStepLogic implements IStackTracePresentationDetailsProvider {
         return false;
     }
 
+    @DoNotLog()
     public callFrameAdditionalDetails(locationInLoadedSource: LocationInLoadedSource): ICallFramePresentationDetails[] {
         return this.isEnabled() && !locationInLoadedSource.source.isMappedSource()
             ? [{

--- a/src/chrome/internal/stackTraces/stackTracePresenter.ts
+++ b/src/chrome/internal/stackTraces/stackTracePresenter.ts
@@ -26,6 +26,7 @@ import { CurrentStackTraceProvider } from './currentStackTraceProvider';
 import { ICDTPDebuggeeExecutionEventsProvider } from '../../cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider';
 import * as _ from 'lodash';
 import { isDefined, isNotEmpty } from '../../utils/typedOperators';
+import { DoNotLog } from '../../logging/decorators';
 
 export interface IStackTracePresentationDetailsProvider {
     callFrameAdditionalDetails(locationInLoadedSource: LocationInLoadedSource): ICallFramePresentationDetails[];
@@ -62,6 +63,7 @@ export class StackTracePresenter implements IInstallableComponent {
         @multiInject(TYPES.IStackTracePresentationLogicProvider) private readonly _stackTracePresentationLogicProviders: IStackTracePresentationDetailsProvider[],
         @inject(TYPES.IAsyncDebuggingConfiguration) private readonly _breakpointFeaturesSupport: IAsyncDebuggingConfigurer) { }
 
+    @DoNotLog()
     public async stackTrace(format: IStackTraceFormat, firstFrameIndex: number, framesCountOrNull: number | null): Promise<IStackTracePresentation> {
         if (!this._currentStackStraceProvider.isPaused()) {
             return Promise.reject(errors.noCallStackAvailable());

--- a/src/chrome/internal/stepping/features/asyncStepping.ts
+++ b/src/chrome/internal/stepping/features/asyncStepping.ts
@@ -11,6 +11,7 @@ import { IDebuggeeSteppingController } from '../../../cdtpDebuggee/features/cdtp
 import { IDebuggeePausedHandler } from '../../features/debuggeePausedHandler';
 import { printClassDescription } from '../../../utils/printing';
 import { isDefined } from '../../../utils/typedOperators';
+import { DoNotLog } from '../../../logging/decorators';
 
 @printClassDescription
 export class PausedBecauseAsyncCallWasScheduled extends BasePauseShouldBeAutoResumed {
@@ -28,6 +29,7 @@ export class AsyncStepping {
         this._debuggeePausedHandler.registerActionProvider(paused => this.onProvideActionForWhenPaused(paused));
     }
 
+    @DoNotLog()
     public async onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
         if (isDefined(paused.asyncCallStackTraceId)) {
             await this._debugeeStepping.pauseOnAsyncCall({ parentStackTraceId: paused.asyncCallStackTraceId });

--- a/src/chrome/internal/stepping/features/syncStepping.ts
+++ b/src/chrome/internal/stepping/features/syncStepping.ts
@@ -13,6 +13,7 @@ import { IDebuggeePausedHandler } from '../../features/debuggeePausedHandler';
 import { printClassDescription, printInstanceDescription } from '../../../utils/printing';
 import { IEventsToClientReporter } from '../../../client/eventsToClientReporter';
 import { logger } from 'vscode-debugadapter';
+import { DoNotLog } from '../../../logging/decorators';
 
 type SteppingAction = () => Promise<void>;
 
@@ -133,6 +134,7 @@ class UnknownState extends CurrentlyIdle { }
  * This class provides functionality to step thorugh the debuggee's code
  */
 @injectable()
+@printClassDescription
 export class SyncStepping {
     private _status: SyncSteppingStatus = new CurrentlyIdle(s => this.changeStatus(s), this._eventsToClientReporter);
 
@@ -162,6 +164,7 @@ export class SyncStepping {
         return this._debugeeExecutionControl.pause();
     }
 
+    @DoNotLog()
     private async onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
         const result = await this._status.onProvideActionForWhenPaused(paused);
         logger.log(`${this}.onProvideActionForWhenPaused() returns ${result}`);

--- a/src/chrome/logging/decorators.ts
+++ b/src/chrome/logging/decorators.ts
@@ -6,8 +6,9 @@ interface HasLoggingMarks {
     [DoNotLogMark]?: boolean;
 }
 
-export function shouldLog(object: HasLoggingMarks) {
-    return util.types.isProxy(object) || !object || object[DoNotLogMark] !== true;
+export function shouldLog<T extends HasLoggingMarks>(object: T, property: string | symbol | number) {
+    return property !== 'toString'
+        && (util.types.isProxy(object) || !object || object[DoNotLogMark] !== true);
 }
 
 export function DoNotLog(): (target: any, propertyKey: string, descriptor: PropertyDescriptor) => void {

--- a/src/chrome/logging/methodsCalledLogger.ts
+++ b/src/chrome/logging/methodsCalledLogger.ts
@@ -64,7 +64,7 @@ export class MethodsCalledLogger<T extends object> {
         const handler = {
             get: <K extends keyof T>(target: T, propertyKey: K, receiver: any) => {
                 const originalPropertyValue = target[propertyKey];
-                if (!shouldLog(originalPropertyValue)) {
+                if (!shouldLog(originalPropertyValue, propertyKey)) {
                     return originalPropertyValue;
                 }
 
@@ -115,8 +115,12 @@ export class MethodsCalledLogger<T extends object> {
         return MethodsCalledLogger._nextCallId++;
     }
 
+    private printMethodName(propertyKey: PropertyKey): string {
+        return `${this._objectToWrapName}.${String(propertyKey)}`;
+    }
+
     private printMethodCall(propertyKey: PropertyKey, methodCallArguments: any[]): string {
-        return `${this._objectToWrapName}.${String(propertyKey)}(${this.printArguments(methodCallArguments)})`;
+        return `${this.printMethodName(propertyKey)}(${this.printArguments(methodCallArguments)})`;
     }
 
     private printMethodResponse(outcome: Outcome, resultOrException: unknown): string {
@@ -128,17 +132,17 @@ export class MethodsCalledLogger<T extends object> {
     }
 
     private logCallStart(propertyKey: PropertyKey, methodCallArguments: any[], callId: number): void {
-        const message = `START            ${callId}: ${this.printMethodCall(propertyKey, methodCallArguments)}`;
+        const message = `START ${callId}: ${this.printMethodCall(propertyKey, methodCallArguments)}`;
         logger.verbose(message);
     }
 
-    private logSyncPartFinished(propertyKey: PropertyKey, methodCallArguments: any[], callId: number): void {
-        const message = `PROMISE-RETURNED ${callId}: ${this.printMethodCall(propertyKey, methodCallArguments)}`;
+    private logSyncPartFinished(propertyKey: PropertyKey, _methodCallArguments: any[], callId: number): void {
+        const message = `SNRET ${callId}: ${this.printMethodName(propertyKey)}`;
         logger.verbose(message);
     }
 
     private logCall(propertyKey: PropertyKey, synchronicity: Synchronicity, methodCallArguments: any[], outcome: Outcome, resultOrException: unknown, callId: number): void {
-        const endPrefix = callId ? `END              ${callId}: ` : '';
+        const endPrefix = callId ? `END   ${callId}: ` : '';
         const message = `${endPrefix}${this.printMethodCall(propertyKey, methodCallArguments)} ${this.printMethodSynchronicity(synchronicity)}  ${this.printMethodResponse(outcome, resultOrException)}`;
         logger.verbose(message);
     }

--- a/src/chrome/logging/printObjectDescription.ts
+++ b/src/chrome/logging/printObjectDescription.ts
@@ -29,7 +29,7 @@ export function printObjectDescription(objectToPrint: unknown, fallbackPrintDesc
                 } else if (objectToPrint.constructor === Object) {
                     printed = fallbackPrintDescription(objectToPrint);
                 } else {
-                    printed = `${objectToPrint}(${objectToPrint.constructor.name})`;
+                    printed = `a ${objectToPrint.constructor.name}`;
                 }
             }
         }

--- a/src/transformers/lineNumberTransformer.ts
+++ b/src/transformers/lineNumberTransformer.ts
@@ -9,6 +9,7 @@ import { inject, injectable } from 'inversify';
 import { TYPES } from '../chrome/dependencyInjection.ts/types';
 import { ConnectedCDAConfiguration } from '../chrome/client/chromeDebugAdapter/cdaConfiguration';
 import { isTrue } from '../chrome/utils/typedOperators';
+import { DoNotLog } from '../chrome/logging/decorators';
 
 /**
  * Converts from 1 based lines/cols on the client side to 0 based lines/cols on the target side
@@ -52,6 +53,7 @@ export class LineColTransformer implements IDebugTransformer {
         }
     }
 
+    @DoNotLog()
     public convertDebuggerLocationToClient(location: { line?: number; column?: number }): void {
         if (typeof location.line === 'number') {
             location.line = this.convertDebuggerLineToClient(location.line);


### PR DESCRIPTION
We stop logging several methods that seem lower priority at the moment, to try to keep our logs size in check...

cdtpDebuggeeExecutionEventsProvider.ts: Avoid triggering the failure case for -1 (It happens all the time)
printObjectDescription.ts: print "a ClassName" when an object toString prints [object object]
chromeDebugSession.ts: Now From client: and To  client: will be aligned with the START, END, SNRET lines