### PR TITLE
Ignore debugger internal sources

### DIFF
--- a/src/chrome/cdtpDebuggee/features/cdtpDebugeeStateInspector.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpDebugeeStateInspector.ts
@@ -29,6 +29,8 @@ export interface IDebuggeeStateInspector {
     evaluateOnCallFrame(params: IEvaluateOnCallFrameRequest): Promise<CDTP.Debugger.EvaluateOnCallFrameResponse>;
 }
 
+export const DebuggerInternalSourceUrlPrefix = '<debugger-internal>';
+
 export class AddSourceUriToExpession {
     private nextEvaluateScriptId = 0;
 
@@ -38,7 +40,7 @@ export class AddSourceUriToExpession {
         const sourceUrlPrefix = '\n//# sourceURL=';
 
         if (expression.indexOf(sourceUrlPrefix) < 0) {
-            expression += `${sourceUrlPrefix}<debugger-internal>/${this._prefix}/id=${this.nextEvaluateScriptId++}`;
+            expression += `${sourceUrlPrefix}${DebuggerInternalSourceUrlPrefix}/${this._prefix}/id=${this.nextEvaluateScriptId++}`;
         }
 
         return expression;


### PR DESCRIPTION
When we enable ReportVersionInformation we evaluate navigator.userAgent on the debuggee which creates a script which makes our loaded tests fail because we get unexpected loaded sources.
We shouldn't send loaded sources for the internal scripts used by the debug adapter