### PR TITLE
Add more granularity to the telemetry

### DIFF
--- a/src/chrome/internal/sources/features/notifyClientOfLoadedSources.ts
+++ b/src/chrome/internal/sources/features/notifyClientOfLoadedSources.ts
@@ -80,4 +80,8 @@ export class NotifyClientOfLoadedSources implements IServiceComponent {
 
         return this._eventsToClientReporter.sendSourceWasLoaded({ reason: loadedSourceEventReason, source: source });
     }
+
+    public toString(): string {
+        return 'NotifyClientOfLoadedSources';
+    }
 }


### PR DESCRIPTION
Added more granularity to the ConfigureDebuggingSession telemetry:
            "Attach.ConfigureDebuggingSession.onClose": "[0.106019]",
            "Attach.ConfigureDebuggingSession.enableDomains": "[92.349376]",
            "Attach.ConfigureDebuggingSession.super.install": "[23.430073]",
            "Attach.ConfigureDebuggingSession.daLogic.install": "[1.135201]",
            "Attach.ConfigureDebuggingSession.pathTransfofmer.install": "[1.192679]",
            "Attach.ConfigureDebuggingSession.supportedDomains.install": "[2.247911]",
            "Attach.ConfigureDebuggingSession.serviceComponents.install": "[0.046724]",
            "Attach.ConfigureDebuggingSession.NotifyClientOfLoadedSources.install": "[0.117193]",
            "Attach.ConfigureDebuggingSession.ShowOverlayWhenPaused.install": "[0.091422]",
            "Attach.ConfigureDebuggingSession.ReportVersionInformation.install": "[1.776623]",
            "Attach.ConfigureDebuggingSession.runIfWaitingForDebugger": "[22.296548]",
