### PR TITLE
Don't block configurationDone

### DIFF
--- a/src/chrome/debugeeStartup/debugeeLauncher.ts
+++ b/src/chrome/debugeeStartup/debugeeLauncher.ts
@@ -33,5 +33,6 @@ export class NoDebuggeeInitializer implements IDebuggeeInitializer {
 
 export interface IDebuggeeRunner {
     run(telemetryPropertyCollector: ITelemetryPropertyCollector): Promise<void>;
+    waitUntilRunning(): Promise<void>;
     stop(): Promise<void>;
 }


### PR DESCRIPTION
We split the debuggeeRunner.run() operation into two parts: debuggeeRunner.run() and debuggeeRunner.waitUntilRunning() so configurationDone() won't wait for the Page.frameNavigated event and we'll leave Chrome open if we can't navigate to the url supplied by the user.

This will also match the behavior of v1.

(This change goes along with some corresponding changes in chrome-debug: https://github.com/microsoft/vscode-chrome-debug/pull/889 )