### PR TITLE
Log VS Code protocol as info level

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-chrome-debug-core",
   "displayName": "vscode-chrome-debug-core",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "A library for building VS Code debug adapters for targets that support the Chrome Remote Debug Protocol",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We were most some To client: and From client: logs messages on the "info" level.
We want to keep them.

We modify the logger.verbose to keep only those messages