### PR TITLE
Add a new step at the end of the steps for telemetry

### DIFF
--- a/src/chrome/client/chromeDebugAdapter/connectedCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/connectedCDA.ts
@@ -103,6 +103,7 @@ export class ConnectedCDA extends BaseCDAState {
         this._session.sendEvent(new InitializedEvent());
         this.events.emitStepCompleted('NotifyInitialized');
 
+        this.events.emitStepStarted('Attach.ConfigureDebuggingSession.waitForUserContentToLoad');
         return this;
     }
 


### PR DESCRIPTION
The last steps includes all the time until the user content actually loads. Given that this tends to be a significant amount of time, having it own steps makes sense