### PR TITLE
Make localization work for v2, and send locale independent error ids

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -75,7 +75,7 @@
             "request": "launch",
             "protocol": "inspector",
             "env": {
-                "BREAK_WHILE_DEBUGGING": "true"
+                "BREAK_WHILE_DEBUGGING": "true",
             },
 
             // These paths are only valid for my particular setup! You need to replace them with your own.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1959,8 +1959,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1981,14 +1980,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2003,20 +2000,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2133,8 +2127,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2146,7 +2139,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2161,7 +2153,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2169,14 +2160,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2195,7 +2184,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2276,8 +2264,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2289,7 +2276,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2375,8 +2361,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2412,7 +2397,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2432,7 +2416,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2476,14 +2459,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/chrome/cdtpDebuggee/features/cdtpPauseOnExceptionsConfigurer.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpPauseOnExceptionsConfigurer.ts
@@ -4,12 +4,13 @@
 
 import * as nls from 'vscode-nls';
 let localize = nls.loadMessageBundle();
+import { LocalizedError, registerGetLocalize } from '../../utils/localizedError';
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 import { Protocol as CDTP } from 'devtools-protocol';
 import { IPauseOnExceptionsStrategy, PauseOnAllExceptions, PauseOnUnhandledExceptions, DoNotPauseOnAnyExceptions } from '../../internal/exceptions/strategies';
 import { inject, injectable } from 'inversify';
 import { TYPES } from '../../dependencyInjection.ts/types';
-import { LocalizedError } from '../../utils/localizedError';
 
 export interface IPauseOnExceptionsConfigurer {
     setPauseOnExceptions(strategy: IPauseOnExceptionsStrategy): Promise<void>;

--- a/src/chrome/cdtpDebuggee/features/cdtpPauseOnExceptionsConfigurer.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpPauseOnExceptionsConfigurer.ts
@@ -9,6 +9,7 @@ import { Protocol as CDTP } from 'devtools-protocol';
 import { IPauseOnExceptionsStrategy, PauseOnAllExceptions, PauseOnUnhandledExceptions, DoNotPauseOnAnyExceptions } from '../../internal/exceptions/strategies';
 import { inject, injectable } from 'inversify';
 import { TYPES } from '../../dependencyInjection.ts/types';
+import { LocalizedError } from '../../utils/localizedError';
 
 export interface IPauseOnExceptionsConfigurer {
     setPauseOnExceptions(strategy: IPauseOnExceptionsStrategy): Promise<void>;
@@ -35,7 +36,7 @@ export class CDTPPauseOnExceptionsConfigurer implements IPauseOnExceptionsConfig
         } else if (strategy instanceof DoNotPauseOnAnyExceptions) {
             state = 'none';
         } else {
-            throw new Error(localize('error.pauseOnException.unknownStrategy', "Can't pause on exception using an unknown strategy {0}", strategy.toString()));
+            throw new LocalizedError(localize('error.pauseOnException.unknownStrategy', "Can't pause on exception using an unknown strategy {0}", strategy.toString()));
         }
 
         return this.api.setPauseOnExceptions({ state });

--- a/src/chrome/cdtpDebuggee/features/cdtpPauseOnExceptionsConfigurer.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpPauseOnExceptionsConfigurer.ts
@@ -4,7 +4,7 @@
 
 import * as nls from 'vscode-nls';
 let localize = nls.loadMessageBundle();
-import { LocalizedError, registerGetLocalize } from '../../utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../../utils/localization';
 registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 import { Protocol as CDTP } from 'devtools-protocol';

--- a/src/chrome/cdtpDebuggee/features/cdtpPauseOnExceptionsConfigurer.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpPauseOnExceptionsConfigurer.ts
@@ -36,7 +36,7 @@ export class CDTPPauseOnExceptionsConfigurer implements IPauseOnExceptionsConfig
         } else if (strategy instanceof DoNotPauseOnAnyExceptions) {
             state = 'none';
         } else {
-            throw new LocalizedError(localize('error.pauseOnException.unknownStrategy', "Can't pause on exception using an unknown strategy {0}", strategy.toString()));
+            throw new LocalizedError('error.pauseOnException.unknownStrategy', localize('error.pauseOnException.unknownStrategy', "Can't pause on exception using an unknown strategy {0}", strategy.toString()));
         }
 
         return this.api.setPauseOnExceptions({ state });

--- a/src/chrome/chromeConnection.ts
+++ b/src/chrome/chromeConnection.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
 
 import * as WebSocket from 'ws';
 
@@ -26,7 +25,10 @@ import { IAttachRequestArgs } from '../debugAdapterInterfaces';
 import { ITelemetryPropertyCollector } from '../telemetry';
 import { isDefined } from './utils/typedOperators';
 import { InternalError } from './utils/internalError';
-import { LocalizedError } from './utils/localizedError';
+import { LocalizedError, registerGetLocalize } from './utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 export interface ITarget {
     description: string;

--- a/src/chrome/chromeConnection.ts
+++ b/src/chrome/chromeConnection.ts
@@ -25,7 +25,7 @@ import { IAttachRequestArgs } from '../debugAdapterInterfaces';
 import { ITelemetryPropertyCollector } from '../telemetry';
 import { isDefined } from './utils/typedOperators';
 import { InternalError } from './utils/internalError';
-import { LocalizedError, registerGetLocalize } from './utils/localizedError';
+import { LocalizedError, registerGetLocalize } from './utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/chromeConnection.ts
+++ b/src/chrome/chromeConnection.ts
@@ -148,7 +148,7 @@ export class ChromeConnection implements IObservableEvents<IStepStartedEventsEmi
             await this.attach(attachArgs.address, attachArgs.port, attachArgs.url, attachArgs.timeout, attachArgs.extraCRDPChannelPort);
         }
         else {
-            throw new LocalizedError(localize('error.connection.unrecognizedScenarioType', 'Unrecognized scenario type. Expected either ScenarioType.Launch ({0}) or ScenarioType.Attach ({1}) but got: {2} ', ScenarioType.Launch, ScenarioType.Attach, this._configuration.scenarioType));
+            throw new LocalizedError('error.connection.unrecognizedScenarioType', localize('error.connection.unrecognizedScenarioType', 'Unrecognized scenario type. Expected either ScenarioType.Launch ({0}) or ScenarioType.Attach ({1}) but got: {2} ', ScenarioType.Launch, ScenarioType.Attach, this._configuration.scenarioType));
         }
     }
 

--- a/src/chrome/chromeConnection.ts
+++ b/src/chrome/chromeConnection.ts
@@ -26,6 +26,7 @@ import { IAttachRequestArgs } from '../debugAdapterInterfaces';
 import { ITelemetryPropertyCollector } from '../telemetry';
 import { isDefined } from './utils/typedOperators';
 import { InternalError } from './utils/internalError';
+import { LocalizedError } from './utils/localizedError';
 
 export interface ITarget {
     description: string;
@@ -147,7 +148,7 @@ export class ChromeConnection implements IObservableEvents<IStepStartedEventsEmi
             await this.attach(attachArgs.address, attachArgs.port, attachArgs.url, attachArgs.timeout, attachArgs.extraCRDPChannelPort);
         }
         else {
-            throw new Error(localize('error.connection.unrecognizedScenarioType', 'Unrecognized scenario type. Expected either ScenarioType.Launch ({0}) or ScenarioType.Attach ({1}) but got: {2} ', ScenarioType.Launch, ScenarioType.Attach, this._configuration.scenarioType));
+            throw new LocalizedError(localize('error.connection.unrecognizedScenarioType', 'Unrecognized scenario type. Expected either ScenarioType.Launch ({0}) or ScenarioType.Attach ({1}) but got: {2} ', ScenarioType.Launch, ScenarioType.Attach, this._configuration.scenarioType));
         }
     }
 

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -56,7 +56,7 @@ import { isTrue, isNotNull, isNotEmpty, isUndefined, isDefined, hasElements, isE
 import * as _ from 'lodash';
 import { CurrentStackTraceProvider } from './internal/stackTraces/currentStackTraceProvider';
 import { InternalError } from './utils/internalError';
-import { registerGetLocalize } from './utils/localizedError';
+import { registerGetLocalize } from './utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -56,8 +56,10 @@ import { isTrue, isNotNull, isNotEmpty, isUndefined, isDefined, hasElements, isE
 import * as _ from 'lodash';
 import { CurrentStackTraceProvider } from './internal/stackTraces/currentStackTraceProvider';
 import { InternalError } from './utils/internalError';
+import { registerGetLocalize } from './utils/localizedError';
 
 let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 interface IPropCount {
     indexedVariables: number | undefined;
@@ -668,7 +670,7 @@ export class ChromeDebugLogic {
         if (isDefined(evalResponse.exceptionDetails)) {
             let resultValue = variable.value;
             if (isNotEmpty(resultValue) && (resultValue.startsWith('ReferenceError: ') || resultValue.startsWith('TypeError: ')) && args.context !== 'repl') {
-                resultValue = errors.evalNotAvailableMsg;
+                resultValue = errors.evalNotAvailableMsg();
             }
 
             return utils.errP(resultValue);

--- a/src/chrome/chromeDebugSession.ts
+++ b/src/chrome/chromeDebugSession.ts
@@ -20,7 +20,9 @@ import * as _ from 'lodash';
 
 import * as nls from 'vscode-nls';
 import { InternalError } from './utils/internalError';
-const localize = nls.loadMessageBundle();
+import { registerGetLocalize } from './utils/localizedError';
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 export interface IChromeDebugAdapterOpts {
     extensibilityPoints: IExtensibilityPoints;

--- a/src/chrome/chromeDebugSession.ts
+++ b/src/chrome/chromeDebugSession.ts
@@ -20,7 +20,7 @@ import * as _ from 'lodash';
 
 import * as nls from 'vscode-nls';
 import { InternalError } from './utils/internalError';
-import { registerGetLocalize } from './utils/localizedError';
+import { registerGetLocalize } from './utils/localization';
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());
 

--- a/src/chrome/chromeTargetDiscoveryStrategy.ts
+++ b/src/chrome/chromeTargetDiscoveryStrategy.ts
@@ -16,6 +16,7 @@ import { injectable, inject } from 'inversify';
 import { TYPES } from './dependencyInjection.ts/types';
 import { ILogger } from './internal/services/logging';
 import { isNotEmpty, isDefined, hasMatches } from './utils/typedOperators';
+import { LocalizedError } from './utils/localizedError';
 const localize = nls.loadMessageBundle();
 
 export class TargetVersions {
@@ -163,13 +164,13 @@ export class ChromeTargetDiscovery implements ITargetDiscoveryStrategy, IObserva
             filteredTargets;
 
         if (filteredTargets.length === 0) {
-            throw new Error(localize('attach.noMatchingTarget', "Can't find a valid target that matches: {0}. Available pages: {1}", targetUrl, JSON.stringify(targets.map(target => target.url))));
+            throw new LocalizedError(localize('attach.noMatchingTarget', "Can't find a valid target that matches: {0}. Available pages: {1}", targetUrl, JSON.stringify(targets.map(target => target.url))));
         }
 
         // If all possible targets appear to be attached to have some other devtool attached, then fail
         const targetsWithWSURLs = filteredTargets.filter(target => isNotEmpty(target.webSocketDebuggerUrl));
         if (targetsWithWSURLs.length === 0) {
-            throw new Error(localize('attach.devToolsAttached', "Can't attach to this target that may have Chrome DevTools attached: {0}", filteredTargets[0].url));
+            throw new LocalizedError(localize('attach.devToolsAttached', "Can't attach to this target that may have Chrome DevTools attached: {0}", filteredTargets[0].url));
         }
 
         return targetsWithWSURLs;

--- a/src/chrome/chromeTargetDiscoveryStrategy.ts
+++ b/src/chrome/chromeTargetDiscoveryStrategy.ts
@@ -16,8 +16,9 @@ import { injectable, inject } from 'inversify';
 import { TYPES } from './dependencyInjection.ts/types';
 import { ILogger } from './internal/services/logging';
 import { isNotEmpty, isDefined, hasMatches } from './utils/typedOperators';
-import { LocalizedError } from './utils/localizedError';
-const localize = nls.loadMessageBundle();
+import { LocalizedError, registerGetLocalize } from './utils/localizedError';
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 export class TargetVersions {
     constructor(public readonly protocol: Version, public readonly browser: Version) {}

--- a/src/chrome/chromeTargetDiscoveryStrategy.ts
+++ b/src/chrome/chromeTargetDiscoveryStrategy.ts
@@ -61,7 +61,7 @@ export class ChromeTargetDiscovery implements ITargetDiscoveryStrategy, IObserva
         this.telemetry.reportEvent('targetCount', { numTargets: targets.length });
 
         if (targets.length === 0) {
-            return utils.errP(localize('attach.responseButNoTargets', 'Got a response from the target app, but no target pages found'));
+            return utils.errP(localize('attach.responseButNoTargets', 'Got a response from the target app, but no target pages found'), 'attach.responseButNoTargets');
         }
 
         return this._getMatchingTargets(targets, targetFilter, targetUrl);
@@ -128,7 +128,7 @@ export class ChromeTargetDiscovery implements ITargetDiscoveryStrategy, IObserva
 
         const jsonResponse = await checkDiscoveryEndpoint(`http://${address}:${port}/json/list`)
             .catch(() => checkDiscoveryEndpoint(`http://${address}:${port}/json`))
-            .catch(e => utils.errP(localize('attach.cannotConnect', 'Cannot connect to the target: {0}', e.message)));
+            .catch(e => utils.errP(localize('attach.cannotConnect', 'Cannot connect to the target: {0}', e.message), 'attach.cannotConnect'));
 
         /* __GDPR__FRAGMENT__
            "StepNames" : {
@@ -146,10 +146,10 @@ export class ChromeTargetDiscovery implements ITargetDiscoveryStrategy, IObserva
                         return target;
                     });
             } else {
-                return utils.errP(localize('attach.invalidResponseArray', 'Response from the target seems invalid: {0}', jsonResponse));
+                return utils.errP(localize('attach.invalidResponseArray', 'Response from the target seems invalid: {0}', jsonResponse), 'attach.invalidResponseArray');
             }
         } catch (e) {
-            return utils.errP(localize('attach.invalidResponse', 'Response from the target seems invalid. Error: {0}. Response: {1}', e.message, jsonResponse));
+            return utils.errP(localize('attach.invalidResponse', 'Response from the target seems invalid. Error: {0}. Response: {1}', e.message, jsonResponse), 'attach.invalidResponse');
         }
     }
 
@@ -164,13 +164,13 @@ export class ChromeTargetDiscovery implements ITargetDiscoveryStrategy, IObserva
             filteredTargets;
 
         if (filteredTargets.length === 0) {
-            throw new LocalizedError(localize('attach.noMatchingTarget', "Can't find a valid target that matches: {0}. Available pages: {1}", targetUrl, JSON.stringify(targets.map(target => target.url))));
+            throw new LocalizedError('attach.noMatchingTarget', localize('attach.noMatchingTarget', "Can't find a valid target that matches: {0}. Available pages: {1}", targetUrl, JSON.stringify(targets.map(target => target.url))));
         }
 
         // If all possible targets appear to be attached to have some other devtool attached, then fail
         const targetsWithWSURLs = filteredTargets.filter(target => isNotEmpty(target.webSocketDebuggerUrl));
         if (targetsWithWSURLs.length === 0) {
-            throw new LocalizedError(localize('attach.devToolsAttached', "Can't attach to this target that may have Chrome DevTools attached: {0}", filteredTargets[0].url));
+            throw new LocalizedError('attach.devToolsAttached', localize('attach.devToolsAttached', "Can't attach to this target that may have Chrome DevTools attached: {0}", filteredTargets[0].url));
         }
 
         return targetsWithWSURLs;

--- a/src/chrome/chromeTargetDiscoveryStrategy.ts
+++ b/src/chrome/chromeTargetDiscoveryStrategy.ts
@@ -16,7 +16,7 @@ import { injectable, inject } from 'inversify';
 import { TYPES } from './dependencyInjection.ts/types';
 import { ILogger } from './internal/services/logging';
 import { isNotEmpty, isDefined, hasMatches } from './utils/typedOperators';
-import { LocalizedError, registerGetLocalize } from './utils/localizedError';
+import { LocalizedError, registerGetLocalize } from './utils/localization';
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());
 

--- a/src/chrome/chromeUtils.ts
+++ b/src/chrome/chromeUtils.ts
@@ -19,7 +19,9 @@ import { notEmpty } from '../validation';
 
 import * as nls from 'vscode-nls';
 import { InternalError } from './utils/internalError';
-const localize = nls.loadMessageBundle();
+import { registerGetLocalize } from './utils/localizedError';
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 /**
  * Takes the path component of a target url (starting with '/') and applies pathMapping

--- a/src/chrome/chromeUtils.ts
+++ b/src/chrome/chromeUtils.ts
@@ -19,7 +19,7 @@ import { notEmpty } from '../validation';
 
 import * as nls from 'vscode-nls';
 import { InternalError } from './utils/internalError';
-import { registerGetLocalize } from './utils/localizedError';
+import { registerGetLocalize } from './utils/localization';
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());
 

--- a/src/chrome/client/chromeDebugAdapter/requestProcessor.ts
+++ b/src/chrome/client/chromeDebugAdapter/requestProcessor.ts
@@ -10,6 +10,7 @@ import { CommandText } from '../requests';
 import { RequestHandler, ICommandHandlerDeclarer } from '../../internal/features/components';
 import { printArray } from '../../collections/printing';
 import { DoNotLog } from '../../logging/decorators';
+import { LocalizedError } from '../../utils/localizedError';
 
 export class RequestProcessor {
     private readonly _requestNameToHandler = new ValidatedMap<CommandText, RequestHandler>();
@@ -22,7 +23,7 @@ export class RequestProcessor {
         if (requestHandler !== undefined) {
             return requestHandler.call('Process request has no this', args);
         } else {
-            throw new Error(localize('error.requestProcessor.unexpectedRequest', 'Unexpected request: The request: {0} with arguments: {1} is not expected while in state: {2}', requestName, JSON.stringify(args), this._stateDescription));
+            throw new LocalizedError(localize('error.requestProcessor.unexpectedRequest', 'Unexpected request: The request: {0} with arguments: {1} is not expected while in state: {2}', requestName, JSON.stringify(args), this._stateDescription));
         }
     }
 

--- a/src/chrome/client/chromeDebugAdapter/requestProcessor.ts
+++ b/src/chrome/client/chromeDebugAdapter/requestProcessor.ts
@@ -3,14 +3,16 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
 
 import { ValidatedMap } from '../../collections/validatedMap';
 import { CommandText } from '../requests';
 import { RequestHandler, ICommandHandlerDeclarer } from '../../internal/features/components';
 import { printArray } from '../../collections/printing';
 import { DoNotLog } from '../../logging/decorators';
-import { LocalizedError } from '../../utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../../utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 export class RequestProcessor {
     private readonly _requestNameToHandler = new ValidatedMap<CommandText, RequestHandler>();

--- a/src/chrome/client/chromeDebugAdapter/requestProcessor.ts
+++ b/src/chrome/client/chromeDebugAdapter/requestProcessor.ts
@@ -9,7 +9,7 @@ import { CommandText } from '../requests';
 import { RequestHandler, ICommandHandlerDeclarer } from '../../internal/features/components';
 import { printArray } from '../../collections/printing';
 import { DoNotLog } from '../../logging/decorators';
-import { LocalizedError, registerGetLocalize } from '../../utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../../utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/client/chromeDebugAdapter/requestProcessor.ts
+++ b/src/chrome/client/chromeDebugAdapter/requestProcessor.ts
@@ -23,7 +23,7 @@ export class RequestProcessor {
         if (requestHandler !== undefined) {
             return requestHandler.call('Process request has no this', args);
         } else {
-            throw new LocalizedError(localize('error.requestProcessor.unexpectedRequest', 'Unexpected request: The request: {0} with arguments: {1} is not expected while in state: {2}', requestName, JSON.stringify(args), this._stateDescription));
+            throw new LocalizedError('error.requestProcessor.unexpectedRequest', localize('error.requestProcessor.unexpectedRequest', 'Unexpected request: The request: {0} with arguments: {1} is not expected while in state: {2}', requestName, JSON.stringify(args), this._stateDescription));
         }
     }
 

--- a/src/chrome/client/chromeDebugAdapter/uninitializedCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/uninitializedCDA.ts
@@ -12,7 +12,7 @@ import { TYPES } from '../../dependencyInjection.ts/types';
 import { inject, injectable } from 'inversify';
 import { isNotEmpty } from '../../utils/typedOperators';
 import { ISession } from '../session';
-import { registerGetLocalize, configureLocale } from '../../utils/localizedError';
+import { registerGetLocalize, configureLocale } from '../../utils/localization';
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());
 

--- a/src/chrome/client/chromeDebugAdapter/uninitializedCDA.ts
+++ b/src/chrome/client/chromeDebugAdapter/uninitializedCDA.ts
@@ -12,7 +12,9 @@ import { TYPES } from '../../dependencyInjection.ts/types';
 import { inject, injectable } from 'inversify';
 import { isNotEmpty } from '../../utils/typedOperators';
 import { ISession } from '../session';
-let localize = nls.loadMessageBundle(); // Initialize to an unlocalized version until we know which locale to use
+import { registerGetLocalize, configureLocale } from '../../utils/localizedError';
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 @injectable()
 export class UninitializedCDA extends BaseCDAState {
@@ -26,7 +28,7 @@ export class UninitializedCDA extends BaseCDAState {
 
     public async initialize(args: IInitializeRequestArgs, _telemetryPropertyCollector?: ITelemetryPropertyCollector): Promise<{ capabilities: DebugProtocol.Capabilities, newState: IDebugAdapterState }> {
         if (isNotEmpty(args.locale)) {
-                localize = nls.config({ locale: args.locale })(); // Replace with the proper locale
+                configureLocale(args.locale);
         }
 
         const exceptionBreakpointFilters = [

--- a/src/chrome/internal/breakpoints/bpActionWhenHit.ts
+++ b/src/chrome/internal/breakpoints/bpActionWhenHit.ts
@@ -5,7 +5,9 @@
 import { IEquivalenceComparable } from '../../utils/equivalence';
 
 import * as nls from 'vscode-nls';
+import { registerGetLocalize } from '../../utils/localizedError';
 let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 /**
  * These classes represents the different actions that a breakpoint can take when hit

--- a/src/chrome/internal/breakpoints/bpActionWhenHit.ts
+++ b/src/chrome/internal/breakpoints/bpActionWhenHit.ts
@@ -5,7 +5,7 @@
 import { IEquivalenceComparable } from '../../utils/equivalence';
 
 import * as nls from 'vscode-nls';
-import { registerGetLocalize } from '../../utils/localizedError';
+import { registerGetLocalize } from '../../utils/localization';
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());
 

--- a/src/chrome/internal/breakpoints/bpRecipe.ts
+++ b/src/chrome/internal/breakpoints/bpRecipe.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
 
 import { ISource } from '../sources/source';
 import { Location, ScriptOrSourceOrURLOrURLRegexp } from '../locations/location';
@@ -15,6 +14,10 @@ import { URLRegexp } from '../locations/subtypes';
 import { IEquivalenceComparable } from '../../utils/equivalence';
 import { BPRecipeInLoadedSource, BPRecipeInScript, BPRecipeInUrl, BPRecipeInUrlRegexp } from './baseMappedBPRecipe';
 import { BPRecipeInSource } from './bpRecipeInSource';
+import { registerGetLocalize } from '../../utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 /**
  * IBPRecipe represents the instruction/recipe to set a breakpoint with some particular properties. Assuming that IBPRecipe ends up creating an actual

--- a/src/chrome/internal/breakpoints/bpRecipe.ts
+++ b/src/chrome/internal/breakpoints/bpRecipe.ts
@@ -14,7 +14,7 @@ import { URLRegexp } from '../locations/subtypes';
 import { IEquivalenceComparable } from '../../utils/equivalence';
 import { BPRecipeInLoadedSource, BPRecipeInScript, BPRecipeInUrl, BPRecipeInUrlRegexp } from './baseMappedBPRecipe';
 import { BPRecipeInSource } from './bpRecipeInSource';
-import { registerGetLocalize } from '../../utils/localizedError';
+import { registerGetLocalize } from '../../utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/internal/breakpoints/bpRecipeStatus.ts
+++ b/src/chrome/internal/breakpoints/bpRecipeStatus.ts
@@ -10,7 +10,7 @@ import { breakWhileDebugging } from '../../../validation';
 
 import * as nls from 'vscode-nls';
 import { InternalError } from '../../utils/internalError';
-import { registerGetLocalize } from '../../utils/localizedError';
+import { registerGetLocalize } from '../../utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/internal/breakpoints/bpRecipeStatus.ts
+++ b/src/chrome/internal/breakpoints/bpRecipeStatus.ts
@@ -10,7 +10,10 @@ import { breakWhileDebugging } from '../../../validation';
 
 import * as nls from 'vscode-nls';
 import { InternalError } from '../../utils/internalError';
-const localize = nls.loadMessageBundle();
+import { registerGetLocalize } from '../../utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 /** These interface and classes represent the status of a BP Recipe (Is it bound or not?) */
 export const ImplementsBPRecipeStatus = Symbol();

--- a/src/chrome/internal/breakpoints/bpRecipeStatusForRuntimeLocation.ts
+++ b/src/chrome/internal/breakpoints/bpRecipeStatusForRuntimeLocation.ts
@@ -8,7 +8,7 @@ import { LocationInLoadedSource } from '../locations/location';
 import { InternalError } from '../../utils/internalError';
 
 import * as nls from 'vscode-nls';
-import { registerGetLocalize } from '../../utils/localizedError';
+import { registerGetLocalize } from '../../utils/localization';
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());
 

--- a/src/chrome/internal/breakpoints/bpRecipeStatusForRuntimeLocation.ts
+++ b/src/chrome/internal/breakpoints/bpRecipeStatusForRuntimeLocation.ts
@@ -8,7 +8,9 @@ import { LocationInLoadedSource } from '../locations/location';
 import { InternalError } from '../../utils/internalError';
 
 import * as nls from 'vscode-nls';
+import { registerGetLocalize } from '../../utils/localizedError';
 let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 const ImplementsBPRecipeSingleLocationStatus = Symbol();
 export interface IBPRecipeSingleLocationStatus {

--- a/src/chrome/internal/breakpoints/breakpoint.ts
+++ b/src/chrome/internal/breakpoints/breakpoint.ts
@@ -13,7 +13,7 @@ import { ISource } from '../sources/source';
 import { IBPRecipeForRuntimeSource } from './baseMappedBPRecipe';
 import { BPRecipeInSource } from './bpRecipeInSource';
 import { IBPRecipe, BPInScriptSupportedHitActions } from './bpRecipe';
-import { registerGetLocalize } from '../../utils/localizedError';
+import { registerGetLocalize } from '../../utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/internal/breakpoints/breakpoint.ts
+++ b/src/chrome/internal/breakpoints/breakpoint.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
 
 import { LocationInScript, LocationInLoadedSource } from '../locations/location';
 import { IScript } from '../scripts/script';
@@ -14,6 +13,10 @@ import { ISource } from '../sources/source';
 import { IBPRecipeForRuntimeSource } from './baseMappedBPRecipe';
 import { BPRecipeInSource } from './bpRecipeInSource';
 import { IBPRecipe, BPInScriptSupportedHitActions } from './bpRecipe';
+import { registerGetLocalize } from '../../utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 export type BPPossibleResources = IScript | ISource | URLRegexp | IResourceIdentifier<CDTPScriptUrl>;
 export type ActualLocation<TResource extends BPPossibleResources> =

--- a/src/chrome/internal/breakpoints/features/hitCountConditionParser.ts
+++ b/src/chrome/internal/breakpoints/features/hitCountConditionParser.ts
@@ -24,7 +24,7 @@ export class HitCountConditionParser {
             const shouldPause: HitCountConditionFunction = <any>new Function('numHits', this.javaScriptCodeToEvaluateCondition(patternMatches));
             return shouldPause;
         } else {
-            throw new LocalizedError(localize('error.hitCountParser.unrecognizedCondition', "Didn't recognize <{0}> as a valid hit count condition", this._hitCountCondition));
+            throw new LocalizedError('error.hitCountParser.unrecognizedCondition', localize('error.hitCountParser.unrecognizedCondition', "Didn't recognize <{0}> as a valid hit count condition", this._hitCountCondition));
         }
     }
 

--- a/src/chrome/internal/breakpoints/features/hitCountConditionParser.ts
+++ b/src/chrome/internal/breakpoints/features/hitCountConditionParser.ts
@@ -3,11 +3,13 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
 
 import { hasMatches } from '../../../utils/typedOperators';
 import * as _ from 'lodash';
-import { LocalizedError } from '../../../utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../../../utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 export type HitCountConditionFunction = (numHits: number) => boolean;
 

--- a/src/chrome/internal/breakpoints/features/hitCountConditionParser.ts
+++ b/src/chrome/internal/breakpoints/features/hitCountConditionParser.ts
@@ -7,6 +7,7 @@ let localize = nls.loadMessageBundle();
 
 import { hasMatches } from '../../../utils/typedOperators';
 import * as _ from 'lodash';
+import { LocalizedError } from '../../../utils/localizedError';
 
 export type HitCountConditionFunction = (numHits: number) => boolean;
 
@@ -23,7 +24,7 @@ export class HitCountConditionParser {
             const shouldPause: HitCountConditionFunction = <any>new Function('numHits', this.javaScriptCodeToEvaluateCondition(patternMatches));
             return shouldPause;
         } else {
-            throw new Error(localize('error.hitCountParser.unrecognizedCondition', "Didn't recognize <{0}> as a valid hit count condition", this._hitCountCondition));
+            throw new LocalizedError(localize('error.hitCountParser.unrecognizedCondition', "Didn't recognize <{0}> as a valid hit count condition", this._hitCountCondition));
         }
     }
 

--- a/src/chrome/internal/breakpoints/features/hitCountConditionParser.ts
+++ b/src/chrome/internal/breakpoints/features/hitCountConditionParser.ts
@@ -6,7 +6,7 @@ import * as nls from 'vscode-nls';
 
 import { hasMatches } from '../../../utils/typedOperators';
 import * as _ from 'lodash';
-import { LocalizedError, registerGetLocalize } from '../../../utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../../../utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/internal/breakpoints/features/setBreakpointsRequestHandler.ts
+++ b/src/chrome/internal/breakpoints/features/setBreakpointsRequestHandler.ts
@@ -2,7 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
- import * as nls from 'vscode-nls';
+import * as nls from 'vscode-nls';
 let localize = nls.loadMessageBundle();
 
 import { injectable, inject } from 'inversify';
@@ -29,6 +29,7 @@ import { BPRecipeStatusChanged } from '../registries/bpRecipeStatusCalculator';
 import { isDefined, isNotEmpty } from '../../../utils/typedOperators';
 import { ISourceToClientConverter } from '../../../client/sourceToClientConverter';
 import { InternalError } from '../../../utils/internalError';
+import { LocalizedError } from '../../../utils/localizedError';
 
 @injectable()
 export class SetBreakpointsRequestHandler implements ICommandHandlerDeclarer {
@@ -94,7 +95,7 @@ export class SetBreakpointsRequestHandler implements ICommandHandlerDeclarer {
                     + ` 'hitCondition' (${actionWhenHit.hitCondition}) or 'logMessage' (${actionWhenHit.logMessage})`);
             }
         } else { // howManyDefined >= 2
-            throw new Error(localize('error.setBreakpoints.cantHaveTwoActions', "Expected a single one of 'condition' ({0}), 'hitCondition' ({1}) and 'logMessage' ({2}) to be defined, yet multiple were defined.", actionWhenHit.condition, actionWhenHit.hitCondition, actionWhenHit.logMessage));
+            throw new LocalizedError(localize('error.setBreakpoints.cantHaveTwoActions', "Expected a single one of 'condition' ({0}), 'hitCondition' ({1}) and 'logMessage' ({2}) to be defined, yet multiple were defined.", actionWhenHit.condition, actionWhenHit.hitCondition, actionWhenHit.logMessage));
         }
     }
 

--- a/src/chrome/internal/breakpoints/features/setBreakpointsRequestHandler.ts
+++ b/src/chrome/internal/breakpoints/features/setBreakpointsRequestHandler.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
 
 import { injectable, inject } from 'inversify';
 import { ICommandHandlerDeclaration, CommandHandlerDeclaration, ICommandHandlerDeclarer } from '../../features/components';
@@ -29,7 +28,10 @@ import { BPRecipeStatusChanged } from '../registries/bpRecipeStatusCalculator';
 import { isDefined, isNotEmpty } from '../../../utils/typedOperators';
 import { ISourceToClientConverter } from '../../../client/sourceToClientConverter';
 import { InternalError } from '../../../utils/internalError';
-import { LocalizedError } from '../../../utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../../../utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 @injectable()
 export class SetBreakpointsRequestHandler implements ICommandHandlerDeclarer {

--- a/src/chrome/internal/breakpoints/features/setBreakpointsRequestHandler.ts
+++ b/src/chrome/internal/breakpoints/features/setBreakpointsRequestHandler.ts
@@ -28,7 +28,7 @@ import { BPRecipeStatusChanged } from '../registries/bpRecipeStatusCalculator';
 import { isDefined, isNotEmpty } from '../../../utils/typedOperators';
 import { ISourceToClientConverter } from '../../../client/sourceToClientConverter';
 import { InternalError } from '../../../utils/internalError';
-import { LocalizedError, registerGetLocalize } from '../../../utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../../../utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/internal/breakpoints/features/setBreakpointsRequestHandler.ts
+++ b/src/chrome/internal/breakpoints/features/setBreakpointsRequestHandler.ts
@@ -95,7 +95,7 @@ export class SetBreakpointsRequestHandler implements ICommandHandlerDeclarer {
                     + ` 'hitCondition' (${actionWhenHit.hitCondition}) or 'logMessage' (${actionWhenHit.logMessage})`);
             }
         } else { // howManyDefined >= 2
-            throw new LocalizedError(localize('error.setBreakpoints.cantHaveTwoActions', "Expected a single one of 'condition' ({0}), 'hitCondition' ({1}) and 'logMessage' ({2}) to be defined, yet multiple were defined.", actionWhenHit.condition, actionWhenHit.hitCondition, actionWhenHit.logMessage));
+            throw new LocalizedError('error.setBreakpoints.cantHaveTwoActions', localize('error.setBreakpoints.cantHaveTwoActions', "Expected a single one of 'condition' ({0}), 'hitCondition' ({1}) and 'logMessage' ({2}) to be defined, yet multiple were defined.", actionWhenHit.condition, actionWhenHit.hitCondition, actionWhenHit.logMessage));
         }
     }
 

--- a/src/chrome/internal/breakpoints/registries/currentBPRecipeStatusRetriever.ts
+++ b/src/chrome/internal/breakpoints/registries/currentBPRecipeStatusRetriever.ts
@@ -5,7 +5,7 @@ import { injectable } from 'inversify';
 import { LocationInLoadedSource } from '../../locations/location';
 
 import * as nls from 'vscode-nls';
-import { registerGetLocalize } from '../../../utils/localizedError';
+import { registerGetLocalize } from '../../../utils/localization';
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());
 

--- a/src/chrome/internal/breakpoints/registries/currentBPRecipeStatusRetriever.ts
+++ b/src/chrome/internal/breakpoints/registries/currentBPRecipeStatusRetriever.ts
@@ -5,7 +5,9 @@ import { injectable } from 'inversify';
 import { LocationInLoadedSource } from '../../locations/location';
 
 import * as nls from 'vscode-nls';
-const localize = nls.loadMessageBundle();
+import { registerGetLocalize } from '../../../utils/localizedError';
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 class JustCreatedBPRecipeStatus implements IBPRecipeStatus {
     [ImplementsBPRecipeStatus] = 'ImplementsBPRecipeStatus';

--- a/src/chrome/internal/features/skipFiles.ts
+++ b/src/chrome/internal/features/skipFiles.ts
@@ -23,7 +23,9 @@ import { IDebuggeePausedHandler } from './debuggeePausedHandler';
 import { isTrue, isFalse, isDefined } from '../../utils/typedOperators';
 import { DoNotLog } from '../../logging/decorators';
 import { InternalError } from '../../utils/internalError';
-const localize = nls.loadMessageBundle();
+import { registerGetLocalize } from '../../utils/localizedError';
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 export interface ISkipFilesConfiguration {
     skipFiles?: string[]; // an array of file names or glob patterns

--- a/src/chrome/internal/features/skipFiles.ts
+++ b/src/chrome/internal/features/skipFiles.ts
@@ -23,7 +23,7 @@ import { IDebuggeePausedHandler } from './debuggeePausedHandler';
 import { isTrue, isFalse, isDefined } from '../../utils/typedOperators';
 import { DoNotLog } from '../../logging/decorators';
 import { InternalError } from '../../utils/internalError';
-import { registerGetLocalize } from '../../utils/localizedError';
+import { registerGetLocalize } from '../../utils/localization';
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());
 

--- a/src/chrome/internal/features/smartStep.ts
+++ b/src/chrome/internal/features/smartStep.ts
@@ -22,7 +22,7 @@ import { printClassDescription } from '../../utils/printing';
 import * as _ from 'lodash';
 import { isNotNull } from '../../utils/typedOperators';
 import { DoNotLog } from '../../logging/decorators';
-import { registerGetLocalize } from '../../utils/localizedError';
+import { registerGetLocalize } from '../../utils/localization';
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());
 

--- a/src/chrome/internal/features/smartStep.ts
+++ b/src/chrome/internal/features/smartStep.ts
@@ -22,7 +22,9 @@ import { printClassDescription } from '../../utils/printing';
 import * as _ from 'lodash';
 import { isNotNull } from '../../utils/typedOperators';
 import { DoNotLog } from '../../logging/decorators';
-const localize = nls.loadMessageBundle();
+import { registerGetLocalize } from '../../utils/localizedError';
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 export interface ISmartStepLogicConfiguration {
     isEnabled: boolean;

--- a/src/chrome/internal/formattedExceptionParser.ts
+++ b/src/chrome/internal/formattedExceptionParser.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
 
 import { LocationInScript, LocationInLoadedSource } from './locations/location';
 import { IResourceIdentifier, parseResourceIdentifier } from './sources/resourceIdentifier';
@@ -12,6 +11,10 @@ import { createLineNumber, createColumnNumber } from './locations/subtypes';
 import { Position } from '../internal/locations/location';
 import { CDTPScriptsRegistry } from '../cdtpDebuggee/registries/cdtpScriptsRegistry';
 import { hasMatches } from '../utils/typedOperators';
+import { registerGetLocalize } from '../utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 export interface IFormattedExceptionLineDescription {
     generateDescription(zeroBaseNumbers: boolean): string;

--- a/src/chrome/internal/formattedExceptionParser.ts
+++ b/src/chrome/internal/formattedExceptionParser.ts
@@ -11,7 +11,7 @@ import { createLineNumber, createColumnNumber } from './locations/subtypes';
 import { Position } from '../internal/locations/location';
 import { CDTPScriptsRegistry } from '../cdtpDebuggee/registries/cdtpScriptsRegistry';
 import { hasMatches } from '../utils/typedOperators';
-import { registerGetLocalize } from '../utils/localizedError';
+import { registerGetLocalize } from '../utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/internal/locations/location.ts
+++ b/src/chrome/internal/locations/location.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
 
 import * as Validation from '../../../validation';
 import { IScript, Script } from '../scripts/script';
@@ -18,6 +17,10 @@ import { IMappedTokensInScript } from './mappedTokensInScript';
 import { IHasSourceMappingInformation } from '../scripts/IHasSourceMappingInformation';
 import { SourceWithSourceMap } from '../breakpoints/features/bpAtNotLoadedScriptViaHeuristicSetter';
 import { InternalError } from '../../utils/internalError';
+import { registerGetLocalize } from '../../utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 export type integer = number;
 

--- a/src/chrome/internal/locations/location.ts
+++ b/src/chrome/internal/locations/location.ts
@@ -17,7 +17,7 @@ import { IMappedTokensInScript } from './mappedTokensInScript';
 import { IHasSourceMappingInformation } from '../scripts/IHasSourceMappingInformation';
 import { SourceWithSourceMap } from '../breakpoints/features/bpAtNotLoadedScriptViaHeuristicSetter';
 import { InternalError } from '../../utils/internalError';
-import { registerGetLocalize } from '../../utils/localizedError';
+import { registerGetLocalize } from '../../utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/internal/sources/resourceIdentifier.ts
+++ b/src/chrome/internal/sources/resourceIdentifier.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
 
 import * as path from 'path';
 import { IValidatedMap } from '../../collections/validatedMap';
@@ -13,6 +12,10 @@ import * as utils from '../../../utils';
 import { SetUsingProjection } from '../../collections/setUsingProjection';
 import { hasMatches } from '../../utils/typedOperators';
 import { InternalError } from '../../utils/internalError';
+import { registerGetLocalize } from '../../utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 /**
  * Hierarchy:

--- a/src/chrome/internal/sources/resourceIdentifier.ts
+++ b/src/chrome/internal/sources/resourceIdentifier.ts
@@ -12,7 +12,7 @@ import * as utils from '../../../utils';
 import { SetUsingProjection } from '../../collections/setUsingProjection';
 import { hasMatches } from '../../utils/typedOperators';
 import { InternalError } from '../../utils/internalError';
-import { registerGetLocalize } from '../../utils/localizedError';
+import { registerGetLocalize } from '../../utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/internal/sources/sourceTextRetriever.ts
+++ b/src/chrome/internal/sources/sourceTextRetriever.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
 
 import { ILoadedSource, ContentsLocation, SourceScriptRelationship } from './loadedSource';
 import { ValidatedMap } from '../../collections/validatedMap';
@@ -15,7 +14,10 @@ import { singleElementOfArray } from '../../collections/utilities';
 import * as utils from '../../../utils';
 import { logger } from 'vscode-debugadapter';
 import { printArray } from '../../collections/printing';
-import { LocalizedError } from '../../utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../../utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 /**
  * Retrieves the text associated with a loaded source that maps to a JavaScript script file

--- a/src/chrome/internal/sources/sourceTextRetriever.ts
+++ b/src/chrome/internal/sources/sourceTextRetriever.ts
@@ -15,6 +15,7 @@ import { singleElementOfArray } from '../../collections/utilities';
 import * as utils from '../../../utils';
 import { logger } from 'vscode-debugadapter';
 import { printArray } from '../../collections/printing';
+import { LocalizedError } from '../../utils/localizedError';
 
 /**
  * Retrieves the text associated with a loaded source that maps to a JavaScript script file
@@ -48,7 +49,7 @@ export class SourceTextRetriever {
                 return utils.readFileP(loadedSource.identifier.textRepresentation);
             } else {
                 // We'll need to figure out what is the right thing to do for SourceScriptRelationship.Unknown
-                throw new Error(localize('error.sourceText.multipleScriptsNotSupported', "Support for getting the text from dynamic sources that have multiple scripts embedded hasn't been implemented yet"));
+                throw new LocalizedError(localize('error.sourceText.multipleScriptsNotSupported', "Support for getting the text from dynamic sources that have multiple scripts embedded hasn't been implemented yet"));
             }
             this._sourceToText.set(loadedSource, text);
         }

--- a/src/chrome/internal/sources/sourceTextRetriever.ts
+++ b/src/chrome/internal/sources/sourceTextRetriever.ts
@@ -49,7 +49,7 @@ export class SourceTextRetriever {
                 return utils.readFileP(loadedSource.identifier.textRepresentation);
             } else {
                 // We'll need to figure out what is the right thing to do for SourceScriptRelationship.Unknown
-                throw new LocalizedError(localize('error.sourceText.multipleScriptsNotSupported', "Support for getting the text from dynamic sources that have multiple scripts embedded hasn't been implemented yet"));
+                throw new LocalizedError('error.sourceText.multipleScriptsNotSupported', localize('error.sourceText.multipleScriptsNotSupported', "Support for getting the text from dynamic sources that have multiple scripts embedded hasn't been implemented yet"));
             }
             this._sourceToText.set(loadedSource, text);
         }

--- a/src/chrome/internal/sources/sourceTextRetriever.ts
+++ b/src/chrome/internal/sources/sourceTextRetriever.ts
@@ -14,7 +14,7 @@ import { singleElementOfArray } from '../../collections/utilities';
 import * as utils from '../../../utils';
 import { logger } from 'vscode-debugadapter';
 import { printArray } from '../../collections/printing';
-import { LocalizedError, registerGetLocalize } from '../../utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../../utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/internal/stackTraces/currentStackTraceProvider.ts
+++ b/src/chrome/internal/stackTraces/currentStackTraceProvider.ts
@@ -12,6 +12,7 @@ import { ScriptCallFrame, CallFrameWithState } from './callFrame';
 import { CodeFlowStackTrace } from './codeFlowStackTrace';
 import { ILoadedSource } from '../sources/loadedSource';
 import { isDefined } from '../../utils/typedOperators';
+import { LocalizedError } from '../../utils/localizedError';
 
 interface ICurrentStackTraceProviderState {
     ifExceptionWasThrown(exceptionWasThrownAction: (exception: CDTP.Runtime.RemoteObject) => void, noExceptionAction: () => void): void;
@@ -57,7 +58,7 @@ class CurrentStackTraceProviderWhenPaused implements ICurrentStackTraceProviderS
     }
 
     public async onPaused(pausedEvent: PausedEvent): Promise<IActionToTakeWhenPaused> {
-        throw new Error(localize('error.stackTraceProvider.unexpectedNewPausedEvent', "It's not expected to receive a new pause event: {0} when the current stack trace provided is already in a paused state due to {1}", pausedEvent.toString(), this._currentPauseEvent.toString()));
+        throw new LocalizedError(localize('error.stackTraceProvider.unexpectedNewPausedEvent', "It's not expected to receive a new pause event: {0} when the current stack trace provided is already in a paused state due to {1}", pausedEvent.toString(), this._currentPauseEvent.toString()));
     }
 
     public onResumed(changeStateTo: (newState: ICurrentStackTraceProviderState) => void): void {
@@ -106,7 +107,7 @@ class CurrentStackTraceProviderWhenNotPaused implements ICurrentStackTraceProvid
     }
 
     private throwItIsNotPaused(): never {
-        throw new Error(localize('error.stackTraceProvider.notPaused', "Can't obtain current stack strace when the debuggee is not paused"));
+        throw new LocalizedError(localize('error.stackTraceProvider.notPaused', "Can't obtain current stack strace when the debuggee is not paused"));
     }
 }
 

--- a/src/chrome/internal/stackTraces/currentStackTraceProvider.ts
+++ b/src/chrome/internal/stackTraces/currentStackTraceProvider.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
 
 import { Protocol as CDTP } from 'devtools-protocol';
 import { PausedEvent, ICDTPDebuggeeExecutionEventsProvider } from '../../cdtpDebuggee/eventsProviders/cdtpDebuggeeExecutionEventsProvider';
@@ -12,7 +11,10 @@ import { ScriptCallFrame, CallFrameWithState } from './callFrame';
 import { CodeFlowStackTrace } from './codeFlowStackTrace';
 import { ILoadedSource } from '../sources/loadedSource';
 import { isDefined } from '../../utils/typedOperators';
-import { LocalizedError } from '../../utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../../utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 interface ICurrentStackTraceProviderState {
     ifExceptionWasThrown(exceptionWasThrownAction: (exception: CDTP.Runtime.RemoteObject) => void, noExceptionAction: () => void): void;

--- a/src/chrome/internal/stackTraces/currentStackTraceProvider.ts
+++ b/src/chrome/internal/stackTraces/currentStackTraceProvider.ts
@@ -11,7 +11,7 @@ import { ScriptCallFrame, CallFrameWithState } from './callFrame';
 import { CodeFlowStackTrace } from './codeFlowStackTrace';
 import { ILoadedSource } from '../sources/loadedSource';
 import { isDefined } from '../../utils/typedOperators';
-import { LocalizedError, registerGetLocalize } from '../../utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../../utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/internal/stackTraces/currentStackTraceProvider.ts
+++ b/src/chrome/internal/stackTraces/currentStackTraceProvider.ts
@@ -58,7 +58,7 @@ class CurrentStackTraceProviderWhenPaused implements ICurrentStackTraceProviderS
     }
 
     public async onPaused(pausedEvent: PausedEvent): Promise<IActionToTakeWhenPaused> {
-        throw new LocalizedError(localize('error.stackTraceProvider.unexpectedNewPausedEvent', "It's not expected to receive a new pause event: {0} when the current stack trace provided is already in a paused state due to {1}", pausedEvent.toString(), this._currentPauseEvent.toString()));
+        throw new LocalizedError('error.stackTraceProvider.unexpectedNewPausedEvent', localize('error.stackTraceProvider.unexpectedNewPausedEvent', "It's not expected to receive a new pause event: {0} when the current stack trace provided is already in a paused state due to {1}", pausedEvent.toString(), this._currentPauseEvent.toString()));
     }
 
     public onResumed(changeStateTo: (newState: ICurrentStackTraceProviderState) => void): void {
@@ -107,7 +107,7 @@ class CurrentStackTraceProviderWhenNotPaused implements ICurrentStackTraceProvid
     }
 
     private throwItIsNotPaused(): never {
-        throw new LocalizedError(localize('error.stackTraceProvider.notPaused', "Can't obtain current stack strace when the debuggee is not paused"));
+        throw new LocalizedError('error.stackTraceProvider.notPaused', localize('error.stackTraceProvider.notPaused', "Can't obtain current stack strace when the debuggee is not paused"));
     }
 }
 

--- a/src/chrome/internal/stackTraces/stackTracePresenter.ts
+++ b/src/chrome/internal/stackTraces/stackTracePresenter.ts
@@ -26,7 +26,7 @@ import { ICDTPDebuggeeExecutionEventsProvider } from '../../cdtpDebuggee/eventsP
 import * as _ from 'lodash';
 import { isDefined, isNotEmpty } from '../../utils/typedOperators';
 import { DoNotLog } from '../../logging/decorators';
-import { registerGetLocalize } from '../../utils/localizedError';
+import { registerGetLocalize } from '../../utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/internal/stackTraces/stackTracePresenter.ts
+++ b/src/chrome/internal/stackTraces/stackTracePresenter.ts
@@ -9,7 +9,6 @@ import { injectable, inject, multiInject } from 'inversify';
 import * as errors from '../../../errors';
 
 import * as nls from 'vscode-nls';
-const localize = nls.loadMessageBundle();
 import { CodeFlowStackTrace } from './codeFlowStackTrace';
 import { IScript } from '../scripts/script';
 import { CodeFlowFrame, ScriptCallFrame, CallFrame, CallFrameWithoutState, ICallFrameState } from './callFrame';
@@ -27,6 +26,10 @@ import { ICDTPDebuggeeExecutionEventsProvider } from '../../cdtpDebuggee/eventsP
 import * as _ from 'lodash';
 import { isDefined, isNotEmpty } from '../../utils/typedOperators';
 import { DoNotLog } from '../../logging/decorators';
+import { registerGetLocalize } from '../../utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 export interface IStackTracePresentationDetailsProvider {
     callFrameAdditionalDetails(locationInLoadedSource: LocationInLoadedSource): ICallFramePresentationDetails[];

--- a/src/chrome/internal/stepping/features/syncStepping.ts
+++ b/src/chrome/internal/stepping/features/syncStepping.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
 
 import { ScriptCallFrame, CallFrameWithState } from '../../stackTraces/callFrame';
 import { IActionToTakeWhenPaused, NoActionIsNeededForThisPause, BaseNotifyClientOfPause } from '../../features/actionToTakeWhenPaused';
@@ -17,7 +16,10 @@ import { printClassDescription, printInstanceDescription } from '../../../utils/
 import { IEventsToClientReporter } from '../../../client/eventsToClientReporter';
 import { logger } from 'vscode-debugadapter';
 import { DoNotLog } from '../../../logging/decorators';
-import { LocalizedError } from '../../../utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../../../utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 type SteppingAction = () => Promise<void>;
 

--- a/src/chrome/internal/stepping/features/syncStepping.ts
+++ b/src/chrome/internal/stepping/features/syncStepping.ts
@@ -75,7 +75,7 @@ class CurrentlyStepping implements SyncSteppingStatus {
         private readonly _eventsToClientReporter: IEventsToClientReporter) { }
 
     public startStepping(): SyncSteppingStatus {
-        throw new LocalizedError(localize('error.stepping.alreadyStepping', 'Cannot start stepping again while the program is already stepping'));
+        throw new LocalizedError('error.stepping.alreadyStepping', localize('error.stepping.alreadyStepping', 'Cannot start stepping again while the program is already stepping'));
     }
 
     public async onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
@@ -106,7 +106,7 @@ class CurrentlyPausing implements SyncSteppingStatus {
         private readonly _eventsToClientReporter: IEventsToClientReporter) { }
 
     public startStepping(): SyncSteppingStatus {
-        throw new LocalizedError(localize('error.stepping.currentlyPausing', 'Cannot start stepping while the debugger is trying to pause the program'));
+        throw new LocalizedError('error.stepping.currentlyPausing', localize('error.stepping.currentlyPausing', 'Cannot start stepping while the debugger is trying to pause the program'));
     }
 
     public async onProvideActionForWhenPaused(_paused: PausedEvent): Promise<IActionToTakeWhenPaused> {

--- a/src/chrome/internal/stepping/features/syncStepping.ts
+++ b/src/chrome/internal/stepping/features/syncStepping.ts
@@ -16,7 +16,7 @@ import { printClassDescription, printInstanceDescription } from '../../../utils/
 import { IEventsToClientReporter } from '../../../client/eventsToClientReporter';
 import { logger } from 'vscode-debugadapter';
 import { DoNotLog } from '../../../logging/decorators';
-import { LocalizedError, registerGetLocalize } from '../../../utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../../../utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/internal/stepping/features/syncStepping.ts
+++ b/src/chrome/internal/stepping/features/syncStepping.ts
@@ -17,6 +17,7 @@ import { printClassDescription, printInstanceDescription } from '../../../utils/
 import { IEventsToClientReporter } from '../../../client/eventsToClientReporter';
 import { logger } from 'vscode-debugadapter';
 import { DoNotLog } from '../../../logging/decorators';
+import { LocalizedError } from '../../../utils/localizedError';
 
 type SteppingAction = () => Promise<void>;
 
@@ -74,7 +75,7 @@ class CurrentlyStepping implements SyncSteppingStatus {
         private readonly _eventsToClientReporter: IEventsToClientReporter) { }
 
     public startStepping(): SyncSteppingStatus {
-        throw new Error(localize('error.stepping.alreadyStepping', 'Cannot start stepping again while the program is already stepping'));
+        throw new LocalizedError(localize('error.stepping.alreadyStepping', 'Cannot start stepping again while the program is already stepping'));
     }
 
     public async onProvideActionForWhenPaused(paused: PausedEvent): Promise<IActionToTakeWhenPaused> {
@@ -105,7 +106,7 @@ class CurrentlyPausing implements SyncSteppingStatus {
         private readonly _eventsToClientReporter: IEventsToClientReporter) { }
 
     public startStepping(): SyncSteppingStatus {
-        throw new Error(localize('error.stepping.currentlyPausing', 'Cannot start stepping while the debugger is trying to pause the program'));
+        throw new LocalizedError(localize('error.stepping.currentlyPausing', 'Cannot start stepping while the debugger is trying to pause the program'));
     }
 
     public async onProvideActionForWhenPaused(_paused: PausedEvent): Promise<IActionToTakeWhenPaused> {

--- a/src/chrome/internal/stepping/steppingRequestsHandler.ts
+++ b/src/chrome/internal/stepping/steppingRequestsHandler.ts
@@ -12,7 +12,7 @@ import { TYPES } from '../../dependencyInjection.ts/types';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { HandlesRegistry } from '../../client/handlesRegistry';
 import { CallFramePresentation } from '../stackTraces/callFramePresentation';
-import { LocalizedError, registerGetLocalize } from '../../utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../../utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/internal/stepping/steppingRequestsHandler.ts
+++ b/src/chrome/internal/stepping/steppingRequestsHandler.ts
@@ -28,7 +28,7 @@ export class SteppingRequestsHandler implements ICommandHandlerDeclarer {
         if (callFrame instanceof CallFramePresentation && callFrame.callFrame.hasState()) {
             return this._syncStepping.restartFrame(callFrame.callFrame.unmappedCallFrame);
         } else {
-            throw new LocalizedError(localize('error.stepping.frameLacksStateInfo', "Cannot restart to a frame that doesn't have state information"));
+            throw new LocalizedError('error.stepping.frameLacksStateInfo', localize('error.stepping.frameLacksStateInfo', "Cannot restart to a frame that doesn't have state information"));
         }
     }
 

--- a/src/chrome/internal/stepping/steppingRequestsHandler.ts
+++ b/src/chrome/internal/stepping/steppingRequestsHandler.ts
@@ -13,6 +13,7 @@ import { TYPES } from '../../dependencyInjection.ts/types';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { HandlesRegistry } from '../../client/handlesRegistry';
 import { CallFramePresentation } from '../stackTraces/callFramePresentation';
+import { LocalizedError } from '../../utils/localizedError';
 
 @injectable()
 export class SteppingRequestsHandler implements ICommandHandlerDeclarer {
@@ -27,7 +28,7 @@ export class SteppingRequestsHandler implements ICommandHandlerDeclarer {
         if (callFrame instanceof CallFramePresentation && callFrame.callFrame.hasState()) {
             return this._syncStepping.restartFrame(callFrame.callFrame.unmappedCallFrame);
         } else {
-            throw new Error(localize('error.stepping.frameLacksStateInfo', "Cannot restart to a frame that doesn't have state information"));
+            throw new LocalizedError(localize('error.stepping.frameLacksStateInfo', "Cannot restart to a frame that doesn't have state information"));
         }
     }
 

--- a/src/chrome/internal/stepping/steppingRequestsHandler.ts
+++ b/src/chrome/internal/stepping/steppingRequestsHandler.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
 
 import { ICommandHandlerDeclarer, ICommandHandlerDeclaration, CommandHandlerDeclaration } from '../features/components';
 import { AsyncStepping } from './features/asyncStepping';
@@ -13,7 +12,10 @@ import { TYPES } from '../../dependencyInjection.ts/types';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { HandlesRegistry } from '../../client/handlesRegistry';
 import { CallFramePresentation } from '../stackTraces/callFramePresentation';
-import { LocalizedError } from '../../utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../../utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 @injectable()
 export class SteppingRequestsHandler implements ICommandHandlerDeclarer {

--- a/src/chrome/internal/variables/scopesRequestHandler.ts
+++ b/src/chrome/internal/variables/scopesRequestHandler.ts
@@ -14,6 +14,7 @@ import { IScopesResponseBody } from '../../../debugAdapterInterfaces';
 import { CallFramePresentation } from '../stackTraces/callFramePresentation';
 import { IStackTracePresentationRow } from '../stackTraces/stackTracePresentationRow';
 import { HandlesRegistry } from '../../client/handlesRegistry';
+import { LocalizedError } from '../../utils/localizedError';
 
 @injectable()
 export class ScopesRequestHandler implements ICommandHandlerDeclarer {
@@ -32,7 +33,7 @@ export class ScopesRequestHandler implements ICommandHandlerDeclarer {
         if (frame instanceof CallFramePresentation && frame.callFrame.hasState()) {
             return this._chromeDebugAdapter.scopes(frame.callFrame);
         } else {
-            throw new Error(localize('error.scopes.frameLacksStateInfo', "Can't get scopes for a frame that has no associated state"));
+            throw new LocalizedError(localize('error.scopes.frameLacksStateInfo', "Can't get scopes for a frame that has no associated state"));
         }
     }
 

--- a/src/chrome/internal/variables/scopesRequestHandler.ts
+++ b/src/chrome/internal/variables/scopesRequestHandler.ts
@@ -13,7 +13,7 @@ import { IScopesResponseBody } from '../../../debugAdapterInterfaces';
 import { CallFramePresentation } from '../stackTraces/callFramePresentation';
 import { IStackTracePresentationRow } from '../stackTraces/stackTracePresentationRow';
 import { HandlesRegistry } from '../../client/handlesRegistry';
-import { LocalizedError, registerGetLocalize } from '../../utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../../utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/internal/variables/scopesRequestHandler.ts
+++ b/src/chrome/internal/variables/scopesRequestHandler.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------*/
 
  import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
 
 import { ChromeDebugLogic } from '../../chromeDebugAdapter';
 import { ICommandHandlerDeclaration, CommandHandlerDeclaration, ICommandHandlerDeclarer } from '../features/components';
@@ -14,7 +13,10 @@ import { IScopesResponseBody } from '../../../debugAdapterInterfaces';
 import { CallFramePresentation } from '../stackTraces/callFramePresentation';
 import { IStackTracePresentationRow } from '../stackTraces/stackTracePresentationRow';
 import { HandlesRegistry } from '../../client/handlesRegistry';
-import { LocalizedError } from '../../utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../../utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 @injectable()
 export class ScopesRequestHandler implements ICommandHandlerDeclarer {

--- a/src/chrome/internal/variables/scopesRequestHandler.ts
+++ b/src/chrome/internal/variables/scopesRequestHandler.ts
@@ -33,7 +33,7 @@ export class ScopesRequestHandler implements ICommandHandlerDeclarer {
         if (frame instanceof CallFramePresentation && frame.callFrame.hasState()) {
             return this._chromeDebugAdapter.scopes(frame.callFrame);
         } else {
-            throw new LocalizedError(localize('error.scopes.frameLacksStateInfo', "Can't get scopes for a frame that has no associated state"));
+            throw new LocalizedError('error.scopes.frameLacksStateInfo', localize('error.scopes.frameLacksStateInfo', "Can't get scopes for a frame that has no associated state"));
         }
     }
 

--- a/src/chrome/stoppedEvent.ts
+++ b/src/chrome/stoppedEvent.ts
@@ -10,7 +10,7 @@ import * as utils from '../utils';
 
 import * as nls from 'vscode-nls';
 import { isDefined, isNotEmpty } from './utils/typedOperators';
-import { registerGetLocalize } from './utils/localizedError';
+import { registerGetLocalize } from './utils/localization';
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());
 

--- a/src/chrome/stoppedEvent.ts
+++ b/src/chrome/stoppedEvent.ts
@@ -10,7 +10,9 @@ import * as utils from '../utils';
 
 import * as nls from 'vscode-nls';
 import { isDefined, isNotEmpty } from './utils/typedOperators';
-const localize = nls.loadMessageBundle();
+import { registerGetLocalize } from './utils/localizedError';
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 export type ReasonType = 'step' | 'breakpoint' | 'exception' | 'pause' | 'entry' | 'debugger_statement' | 'frame_entry' | 'promise_rejection';
 

--- a/src/chrome/utils/internalError.ts
+++ b/src/chrome/utils/internalError.ts
@@ -3,7 +3,10 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
+import { registerGetLocalize } from './localizedError';
+
 let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 export class InternalError extends Error {
     public constructor(public readonly errorCode: string, public readonly errorDetails: string) {

--- a/src/chrome/utils/internalError.ts
+++ b/src/chrome/utils/internalError.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-import { registerGetLocalize } from './localizedError';
+import { registerGetLocalize } from './localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/utils/localization.ts
+++ b/src/chrome/utils/localization.ts
@@ -14,6 +14,12 @@ export class LocalizedError extends Error {
 
 const getLocalizeCalls: (() => nls.LocalizeFunc)[] = [];
 
+/** Each file that calls localize = nls.loadMessageBundle() needs to call registerGetLocalize(() => localize = nls.loadMessageBundle()); too.
+ * We call localize = nls.loadMessageBundle() when the file is parsed, which in most cases is before the DAP.initializeRequest which specifies the locale we need to
+ * use in Visual Studio (In VS Code this works because it passes the locale in an environment variable).
+ * So after we get the locale from Visual Studio, we need to re-create all the localize functions in all the program to use the right locale, so we use
+ * registerGetLocalize to register all those places, and have all those locale functions recreated
+ */
 export function registerGetLocalize(getLocalizeCallback: () => nls.LocalizeFunc): void {
     getLocalizeCalls.push(getLocalizeCallback); // Add to the list to replace with the correct locale after it gets configured
 }

--- a/src/chrome/utils/localizedError.ts
+++ b/src/chrome/utils/localizedError.ts
@@ -3,40 +3,6 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-import { LocalizeInfo } from 'vscode-nls';
-import _ = require('lodash');
-
-const originalConfig = nls.config;
-let currentLocale: string | undefined = undefined;
-
-/** We replace nls.config with our own version so we can know which locale is set, and force all the localize functions to be re-created when needed.
- * This works around the need to import all the secondary files only after the locale has been already set.
- */
-(<any>nls).config = (opts?: nls.Options) => {
-    currentLocale = _.defaultTo(opts, { locale: undefined }).locale;
-    return originalConfig(opts);
-};
-
-const originalLoadMessageBundle = nls.loadMessageBundle;
-/** We replace nls.loadMessageBundle with our own custom version, which will re-created the localize function after the locale has been changed.
- * This works around the need to import all the secondary files only after the locale has been already set.
- */
-(<any>nls).loadMessageBundle = (file?: string) => {
-    let localizeForFile = originalLoadMessageBundle(file);
-    let localizeForFileLocale = currentLocale;
-    return (key: string | LocalizeInfo, message: string, ...args: (string | number | boolean | undefined | null)[]) =>
-        {
-            // Has the locale changed since we created the localize function?
-            if (localizeForFileLocale !== currentLocale) {
-                localizeForFileLocale = currentLocale;
-                // If so, re-create it so it'll use the new local (the localize caches the local, so we do need to re-create it after changing the locale)
-                localizeForFile = originalLoadMessageBundle(file);
-            }
-
-            // Call our custom localize which will store the localization key for the LocaliedErrors
-            return localizeForFile(<string>key, message, ...args);
-        };
-};
 
 /** Error class which automatically extracts the localization key of the latest call to localize (So we can easily deduplicate errors on telemetry) */
 export class LocalizedError extends Error {
@@ -44,4 +10,15 @@ export class LocalizedError extends Error {
     public constructor(public readonly errorCode: string, localizedMessage: string) {
         super(localizedMessage);
     }
+}
+
+const getLocalizeCalls: (() => nls.LocalizeFunc)[] = [];
+
+export function registerGetLocalize(getLocalizeCallback: () => nls.LocalizeFunc): void {
+    getLocalizeCalls.push(getLocalizeCallback); // Add to the list to replace with the correct locale after it gets configured
+}
+
+export function configureLocale(locale: string): void {
+    nls.config({ locale: locale });
+    getLocalizeCalls.forEach(eachCall => eachCall());
 }

--- a/src/chrome/utils/localizedError.ts
+++ b/src/chrome/utils/localizedError.ts
@@ -1,0 +1,119 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as nls from 'vscode-nls';
+import * as path from 'path';
+import { LocalizeInfo, LocalizeFunc } from 'vscode-nls';
+import _ = require('lodash');
+import { readFileSync } from 'fs';
+import { telemetry } from '../../telemetry';
+
+// Store the key of the last call to localize, so we can inject it in the next LocalizedError we create
+const defaultLastKeyOfLocalize = "last localization key couldn't be determined";
+let lastKeyOfLocalize = defaultLastKeyOfLocalize;
+
+/** We'll replace nls.loadMessageBundle to return this custom version of localize, which stores the last key used */
+function customLocalize(file: string | undefined, localize: LocalizeFunc, info: LocalizeInfo, message: string, ...args: (string | number | boolean | undefined | null)[]): string;
+function customLocalize(file: string | undefined, localize: LocalizeFunc, key: string | number, message: string, ...args: (string | number | boolean | undefined | null)[]): string;
+function customLocalize(file: string | undefined, localize: LocalizeFunc, key: string | LocalizeInfo | number, message: string, ...args: (string | number | boolean | undefined | null)[]): string {
+    lastKeyOfLocalize = extractLocalizationKey(key, file);
+
+    return localize(<string>key, message, ...args);
+}
+
+/** Format of the bundle.json file */
+interface LocalizationBundle {
+    [file: string]: { keys: (string | undefined)[] } | undefined;
+}
+
+/** We store the bundle metadata on memory to be able to extract the localization keys based on the file and message index */
+let bundle: LocalizationBundle = {};
+const bundlePath = path.resolve(__dirname, '../../../nls.metadata.json');
+const bundleFolderPath = path.dirname(bundlePath);
+try {
+    bundle = JSON.parse(readFileSync(bundlePath, 'utf8'));
+} catch (exception) {
+    telemetry.reportError('Failed to read bundle', exception);
+}
+
+/** Given the localization key, and the file, do our best effort to return the localization key (We get it from the bundle).
+ * In dev we'll normally get the localization key as a string
+ * In prod, the nls library replaces the key with a number which is the index in the bundle that has that particular message, so we need to use the file,
+ * the index, and the bundle to find the localization key
+ */
+function extractLocalizationKey(key: string | number | nls.LocalizeInfo, file: string | undefined): string {
+    if (typeof key === 'number') {
+        if (file !== undefined) {
+            const fileNormalizedPath = normalizeFilePath(file);
+            const messagesForFile = bundle[fileNormalizedPath];
+            if (messagesForFile !== undefined) {
+                const textKey = messagesForFile.keys[key];
+                if (textKey !== undefined) {
+                    return textKey;
+                }
+            }
+        }
+
+        return `${file}:${key}`;
+    } else if (typeof key === 'string') {
+        return key;
+    } else {
+        return 'getNextLastKey parameter was unexpected';
+    }
+}
+
+/** Normalize the file path to the format used in the localization bundles (Relative path, no extension, and forward slashes) */
+function normalizeFilePath(file: string): string {
+    const fileRelativePath = path.relative(bundleFolderPath, file);
+    const normalizedPath = fileRelativePath.replace(/\\/g, '/').replace(/\.js$/g, '');
+    return normalizedPath;
+}
+
+const originalConfig = nls.config;
+let currentLocale: string | undefined = undefined;
+
+/** We replace nls.config with our own version so we can know which locale is set, and force all the localize functions to be re-created when needed.
+ * This works around the need to import all the secondary files only after the locale has been already set.
+ */
+(<any>nls).config = (opts?: nls.Options) => {
+    currentLocale = _.defaultTo(opts, { locale: undefined }).locale;
+    return originalConfig(opts);
+};
+
+const originalLoadMessageBundle = nls.loadMessageBundle;
+/** We replace nls.loadMessageBundle with our own custom version, which will re-created the localize function after the locale has been changed.
+ * This works around the need to import all the secondary files only after the locale has been already set.
+ */
+(<any>nls).loadMessageBundle = (file?: string) => {
+    let localizeForFile = originalLoadMessageBundle(file);
+    let localizeForFileLocale = currentLocale;
+    return (key: string | LocalizeInfo, message: string, ...args: (string | number | boolean | undefined | null)[]) =>
+        {
+            // Has the locale changed since we created the localize function?
+            if (localizeForFileLocale !== currentLocale) {
+                localizeForFileLocale = currentLocale;
+                // If so, re-create it so it'll use the new local (the localize caches the local, so we do need to re-create it after changing the locale)
+                localizeForFile = originalLoadMessageBundle(file);
+            }
+
+            // Call our custom localize which will store the localization key for the LocaliedErrors
+            return customLocalize(file, localizeForFile, <string>key, message, ...args);
+        };
+};
+
+// Consume the key of the latest call to the localize function
+function consumeLastLocalizationKey(): string {
+    const lastKeyToReturn = lastKeyOfLocalize;
+    lastKeyOfLocalize = defaultLastKeyOfLocalize;
+    return lastKeyToReturn;
+}
+
+/** Error class which automatically extracts the localization key of the latest call to localize (So we can easily deduplicate errors on telemetry) */
+export class LocalizedError extends Error {
+    public readonly errorCode = consumeLastLocalizationKey();
+
+    public constructor(localizedMessage: string) {
+        super(localizedMessage);
+    }
+}

--- a/src/chrome/utils/localizedError.ts
+++ b/src/chrome/utils/localizedError.ts
@@ -3,72 +3,8 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-import * as path from 'path';
-import { LocalizeInfo, LocalizeFunc } from 'vscode-nls';
+import { LocalizeInfo } from 'vscode-nls';
 import _ = require('lodash');
-import { readFileSync } from 'fs';
-import { telemetry } from '../../telemetry';
-
-// Store the key of the last call to localize, so we can inject it in the next LocalizedError we create
-const defaultLastKeyOfLocalize = "last localization key couldn't be determined";
-let lastKeyOfLocalize = defaultLastKeyOfLocalize;
-
-/** We'll replace nls.loadMessageBundle to return this custom version of localize, which stores the last key used */
-function customLocalize(file: string | undefined, localize: LocalizeFunc, info: LocalizeInfo, message: string, ...args: (string | number | boolean | undefined | null)[]): string;
-function customLocalize(file: string | undefined, localize: LocalizeFunc, key: string | number, message: string, ...args: (string | number | boolean | undefined | null)[]): string;
-function customLocalize(file: string | undefined, localize: LocalizeFunc, key: string | LocalizeInfo | number, message: string, ...args: (string | number | boolean | undefined | null)[]): string {
-    lastKeyOfLocalize = extractLocalizationKey(key, file);
-
-    return localize(<string>key, message, ...args);
-}
-
-/** Format of the bundle.json file */
-interface LocalizationBundle {
-    [file: string]: { keys: (string | undefined)[] } | undefined;
-}
-
-/** We store the bundle metadata on memory to be able to extract the localization keys based on the file and message index */
-let bundle: LocalizationBundle = {};
-const bundlePath = path.resolve(__dirname, '../../../nls.metadata.json');
-const bundleFolderPath = path.dirname(bundlePath);
-try {
-    bundle = JSON.parse(readFileSync(bundlePath, 'utf8'));
-} catch (exception) {
-    telemetry.reportError('Failed to read bundle', exception);
-}
-
-/** Given the localization key, and the file, do our best effort to return the localization key (We get it from the bundle).
- * In dev we'll normally get the localization key as a string
- * In prod, the nls library replaces the key with a number which is the index in the bundle that has that particular message, so we need to use the file,
- * the index, and the bundle to find the localization key
- */
-function extractLocalizationKey(key: string | number | nls.LocalizeInfo, file: string | undefined): string {
-    if (typeof key === 'number') {
-        if (file !== undefined) {
-            const fileNormalizedPath = normalizeFilePath(file);
-            const messagesForFile = bundle[fileNormalizedPath];
-            if (messagesForFile !== undefined) {
-                const textKey = messagesForFile.keys[key];
-                if (textKey !== undefined) {
-                    return textKey;
-                }
-            }
-        }
-
-        return `${file}:${key}`;
-    } else if (typeof key === 'string') {
-        return key;
-    } else {
-        return 'getNextLastKey parameter was unexpected';
-    }
-}
-
-/** Normalize the file path to the format used in the localization bundles (Relative path, no extension, and forward slashes) */
-function normalizeFilePath(file: string): string {
-    const fileRelativePath = path.relative(bundleFolderPath, file);
-    const normalizedPath = fileRelativePath.replace(/\\/g, '/').replace(/\.js$/g, '');
-    return normalizedPath;
-}
 
 const originalConfig = nls.config;
 let currentLocale: string | undefined = undefined;
@@ -98,22 +34,14 @@ const originalLoadMessageBundle = nls.loadMessageBundle;
             }
 
             // Call our custom localize which will store the localization key for the LocaliedErrors
-            return customLocalize(file, localizeForFile, <string>key, message, ...args);
+            return localizeForFile(<string>key, message, ...args);
         };
 };
 
-// Consume the key of the latest call to the localize function
-function consumeLastLocalizationKey(): string {
-    const lastKeyToReturn = lastKeyOfLocalize;
-    lastKeyOfLocalize = defaultLastKeyOfLocalize;
-    return lastKeyToReturn;
-}
-
 /** Error class which automatically extracts the localization key of the latest call to localize (So we can easily deduplicate errors on telemetry) */
 export class LocalizedError extends Error {
-    public readonly errorCode = consumeLastLocalizationKey();
 
-    public constructor(localizedMessage: string) {
+    public constructor(public readonly errorCode: string, localizedMessage: string) {
         super(localizedMessage);
     }
 }

--- a/src/chrome/variables.ts
+++ b/src/chrome/variables.ts
@@ -15,7 +15,7 @@ import { CDTPNonPrimitiveRemoteObject, validateNonPrimitiveRemoteObject } from '
 import { isDefined, isUndefined, hasMatches, isNotEmpty, isTrue } from './utils/typedOperators';
 import * as _ from 'lodash';
 import { InternalError } from './utils/internalError';
-import { registerGetLocalize } from './utils/localizedError';
+import { registerGetLocalize } from './utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/chrome/variables.ts
+++ b/src/chrome/variables.ts
@@ -31,7 +31,7 @@ export abstract class BaseVariableContainer implements IVariableContainer {
     }
 
     public setValue(_adapter: ChromeDebugLogic, _name: string, _value: string): Promise<string> {
-        return utils.errP(localize('error.variables.cantSetVarOfThisType', 'setValue not supported by this variable type'));
+        return utils.errP(localize('error.variables.cantSetVarOfThisType', 'setValue not supported by this variable type'), 'error.variables.cantSetVarOfThisType');
     }
 }
 
@@ -49,7 +49,7 @@ export class LoggedObjects implements IVariableContainer {
     }
 
     public setValue(_adapter: ChromeDebugLogic, _name: string, _value: string): Promise<string> {
-        return utils.errP(localize('error.loggedObjects.cantSetVarOfThisType', 'setValue not supported by this variable type'));
+        return utils.errP(localize('error.loggedObjects.cantSetVarOfThisType', 'setValue not supported by this variable type'), 'error.loggedObjects.cantSetVarOfThisType');
     }
 }
 

--- a/src/chrome/variables.ts
+++ b/src/chrome/variables.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
 
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { Handles } from 'vscode-debugadapter';
@@ -16,6 +15,10 @@ import { CDTPNonPrimitiveRemoteObject, validateNonPrimitiveRemoteObject } from '
 import { isDefined, isUndefined, hasMatches, isNotEmpty, isTrue } from './utils/typedOperators';
 import * as _ from 'lodash';
 import { InternalError } from './utils/internalError';
+import { registerGetLocalize } from './utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 export interface IVariableContainer {
     expand(adapter: ChromeDebugLogic, filter?: string, start?: number, count?: number): Promise<DebugProtocol.Variable[]>;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -5,14 +5,14 @@
 import { DebugProtocol } from 'vscode-debugprotocol';
 
 import * as nls from 'vscode-nls';
-const localize = nls.loadMessageBundle();
 
 import { InternalError } from './chrome/utils/internalError';
+import { registerGetLocalize } from './chrome/utils/localizedError';
 
-export const evalNotAvailableMsg = localize('eval.not.available', 'not available');
-export const runtimeNotConnectedMsg = localize('not.connected', 'not connected to runtime');
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
-export const noRestartFrame = localize('restartFrame.cannot', "Can't restart frame");
+export const evalNotAvailableMsg = () => localize('eval.not.available', 'not available');
 
 export class ErrorWithMessage extends Error implements DebugProtocol.Message {
     public id: number;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -7,7 +7,7 @@ import { DebugProtocol } from 'vscode-debugprotocol';
 import * as nls from 'vscode-nls';
 
 import { InternalError } from './chrome/utils/internalError';
-import { registerGetLocalize } from './chrome/utils/localizedError';
+import { registerGetLocalize } from './chrome/utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/sourceMaps/sourceMap.ts
+++ b/src/sourceMaps/sourceMap.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
 
 import { SourceMapConsumer, MappedPosition, NullablePosition, RawSourceMap } from 'source-map';
 import * as path from 'path';
@@ -21,7 +20,10 @@ import { Range } from '../chrome/internal/locations/rangeInScript';
 import { SetUsingProjection } from '../chrome/collections/setUsingProjection';
 import { isNotEmpty, isDefined, isNull } from '../chrome/utils/typedOperators';
 import { wrapWithMethodLogger } from '../chrome/logging/methodsCalledLogger';
-import { LocalizedError } from '../chrome/utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../chrome/utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 export type MappedPosition = MappedPosition;
 

--- a/src/sourceMaps/sourceMap.ts
+++ b/src/sourceMaps/sourceMap.ts
@@ -21,6 +21,7 @@ import { Range } from '../chrome/internal/locations/rangeInScript';
 import { SetUsingProjection } from '../chrome/collections/setUsingProjection';
 import { isNotEmpty, isDefined, isNull } from '../chrome/utils/typedOperators';
 import { wrapWithMethodLogger } from '../chrome/logging/methodsCalledLogger';
+import { LocalizedError } from '../chrome/utils/localizedError';
 
 export type MappedPosition = MappedPosition;
 
@@ -227,7 +228,7 @@ export class SourceMap {
                 source: parseResourceIdentifier(this._generatedPath)
             };
         } else {
-            throw new Error(localize('error.sourceMap.cantFindGeneratedPosition', "Couldn't find generated position in source-map for {0}", JSON.stringify(lookupArgs)));
+            throw new LocalizedError(localize('error.sourceMap.cantFindGeneratedPosition', "Couldn't find generated position in source-map for {0}", JSON.stringify(lookupArgs)));
         }
     }
 

--- a/src/sourceMaps/sourceMap.ts
+++ b/src/sourceMaps/sourceMap.ts
@@ -20,7 +20,7 @@ import { Range } from '../chrome/internal/locations/rangeInScript';
 import { SetUsingProjection } from '../chrome/collections/setUsingProjection';
 import { isNotEmpty, isDefined, isNull } from '../chrome/utils/typedOperators';
 import { wrapWithMethodLogger } from '../chrome/logging/methodsCalledLogger';
-import { LocalizedError, registerGetLocalize } from '../chrome/utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../chrome/utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/sourceMaps/sourceMap.ts
+++ b/src/sourceMaps/sourceMap.ts
@@ -228,7 +228,7 @@ export class SourceMap {
                 source: parseResourceIdentifier(this._generatedPath)
             };
         } else {
-            throw new LocalizedError(localize('error.sourceMap.cantFindGeneratedPosition', "Couldn't find generated position in source-map for {0}", JSON.stringify(lookupArgs)));
+            throw new LocalizedError('error.sourceMap.cantFindGeneratedPosition', localize('error.sourceMap.cantFindGeneratedPosition', "Couldn't find generated position in source-map for {0}", JSON.stringify(lookupArgs)));
         }
     }
 

--- a/src/transformers/baseSourceMapTransformer.ts
+++ b/src/transformers/baseSourceMapTransformer.ts
@@ -18,6 +18,7 @@ import { CDTPScriptsRegistry } from '../chrome/cdtpDebuggee/registries/cdtpScrip
 import { isTrue, isDefined, isEmpty, isNotNull, isNull, isUndefined } from '../chrome/utils/typedOperators';
 import * as _ from 'lodash';
 import { parseResourceIdentifier, newResourceIdentifierSet } from '../chrome/internal/sources/resourceIdentifier';
+import { DoNotLog } from '../chrome/logging/decorators';
 
 export interface ISourceLocation {
     source: ILoadedSource;
@@ -73,6 +74,7 @@ export class BaseSourceMapTransformer {
         this._allRuntimeScriptPaths =  newResourceIdentifierSet<string>();
     }
 
+    @DoNotLog()
     public async scriptParsed(pathToGenerated: string, sourceMapURL: string | undefined): Promise<SourceMap | null> {
         if (isDefined(this._sourceMaps)) {
             this._allRuntimeScriptPaths.addAndReplaceIfExists(parseResourceIdentifier(pathToGenerated));

--- a/src/transformers/fallbackToClientPathTransformer.ts
+++ b/src/transformers/fallbackToClientPathTransformer.ts
@@ -13,7 +13,7 @@ import { IConnectedCDAConfiguration } from '../chrome/client/chromeDebugAdapter/
 import { inject } from 'inversify';
 import { TYPES } from '../chrome/dependencyInjection.ts/types';
 import { isNotEmpty } from '../chrome/utils/typedOperators';
-import { LocalizedError, registerGetLocalize } from '../chrome/utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../chrome/utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/transformers/fallbackToClientPathTransformer.ts
+++ b/src/transformers/fallbackToClientPathTransformer.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------*/
 
 import * as nls from 'vscode-nls';
-let localize = nls.loadMessageBundle();
 
 import { logger } from 'vscode-debugadapter';
 
@@ -14,7 +13,10 @@ import { IConnectedCDAConfiguration } from '../chrome/client/chromeDebugAdapter/
 import { inject } from 'inversify';
 import { TYPES } from '../chrome/dependencyInjection.ts/types';
 import { isNotEmpty } from '../chrome/utils/typedOperators';
-import { LocalizedError } from '../chrome/utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../chrome/utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 /**
  * Converts a local path from Code to a path on the target. Uses the UrlPathTransforme logic and fallbacks to asking the client if neccesary

--- a/src/transformers/fallbackToClientPathTransformer.ts
+++ b/src/transformers/fallbackToClientPathTransformer.ts
@@ -52,7 +52,7 @@ export class FallbackToClientPathTransformer extends UrlPathTransformer {
                     logger.log(`The client responded that the url "${url}" maps to the file path "${filePath}"`);
                     resolve(filePath !== null ? parseResourceIdentifier(filePath) : url);
                 } else {
-                    reject(new LocalizedError(localize('error.fallbackToClientPathTransformer.mappingFailed', "The client responded that the url \"{0}\" couldn't be mapped to a file path due to: {1}", url.textRepresentation, response.message)));
+                    reject(new LocalizedError('error.fallbackToClientPathTransformer.mappingFailed', localize('error.fallbackToClientPathTransformer.mappingFailed', "The client responded that the url \"{0}\" couldn't be mapped to a file path due to: {1}", url.textRepresentation, response.message)));
                 }
             });
         });

--- a/src/transformers/fallbackToClientPathTransformer.ts
+++ b/src/transformers/fallbackToClientPathTransformer.ts
@@ -14,6 +14,7 @@ import { IConnectedCDAConfiguration } from '../chrome/client/chromeDebugAdapter/
 import { inject } from 'inversify';
 import { TYPES } from '../chrome/dependencyInjection.ts/types';
 import { isNotEmpty } from '../chrome/utils/typedOperators';
+import { LocalizedError } from '../chrome/utils/localizedError';
 
 /**
  * Converts a local path from Code to a path on the target. Uses the UrlPathTransforme logic and fallbacks to asking the client if neccesary
@@ -51,7 +52,7 @@ export class FallbackToClientPathTransformer extends UrlPathTransformer {
                     logger.log(`The client responded that the url "${url}" maps to the file path "${filePath}"`);
                     resolve(filePath !== null ? parseResourceIdentifier(filePath) : url);
                 } else {
-                    reject(new Error(localize('error.fallbackToClientPathTransformer.mappingFailed', "The client responded that the url \"{0}\" couldn't be mapped to a file path due to: {1}", url.textRepresentation, response.message)));
+                    reject(new LocalizedError(localize('error.fallbackToClientPathTransformer.mappingFailed', "The client responded that the url \"{0}\" couldn't be mapped to a file path due to: {1}", url.textRepresentation, response.message)));
                 }
             });
         });

--- a/src/transformers/remotePathTransformer.ts
+++ b/src/transformers/remotePathTransformer.ts
@@ -9,14 +9,16 @@ import { UrlPathTransformer } from '../transformers/urlPathTransformer';
 import * as utils from '../utils';
 import * as nls from 'vscode-nls';
 
-const localize = nls.loadMessageBundle();
 import { IResourceIdentifier, parseResourceIdentifier } from '../chrome/internal/sources/resourceIdentifier';
 import { inject } from 'inversify';
 import { TYPES } from '../chrome/dependencyInjection.ts/types';
 import { IConnectedCDAConfiguration } from '../chrome/client/chromeDebugAdapter/cdaConfiguration';
 import { isNotEmpty, hasMatches } from '../chrome/utils/typedOperators';
 import * as _ from 'lodash';
-import { LocalizedError } from '../chrome/utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../chrome/utils/localizedError';
+
+let localize = nls.loadMessageBundle();
+registerGetLocalize(() => localize = nls.loadMessageBundle());
 
 interface IRootsState {
     install(): Promise<void>;

--- a/src/transformers/remotePathTransformer.ts
+++ b/src/transformers/remotePathTransformer.ts
@@ -93,7 +93,7 @@ export class RemotePathTransformer extends UrlPathTransformer {
         const args = configuration.args;
 
         if (isNotEmpty(args.localRoot) !== isNotEmpty(args.remoteRoot)) {
-            throw new LocalizedError(localize('localRootAndRemoteRoot', 'Both localRoot and remoteRoot must be specified.'));
+            throw new LocalizedError('localRootAndRemoteRoot', localize('localRootAndRemoteRoot', 'Both localRoot and remoteRoot must be specified.'));
         }
 
         this._state = isNotEmpty(args.localRoot) && isNotEmpty(args.remoteRoot)

--- a/src/transformers/remotePathTransformer.ts
+++ b/src/transformers/remotePathTransformer.ts
@@ -15,7 +15,7 @@ import { TYPES } from '../chrome/dependencyInjection.ts/types';
 import { IConnectedCDAConfiguration } from '../chrome/client/chromeDebugAdapter/cdaConfiguration';
 import { isNotEmpty, hasMatches } from '../chrome/utils/typedOperators';
 import * as _ from 'lodash';
-import { LocalizedError, registerGetLocalize } from '../chrome/utils/localizedError';
+import { LocalizedError, registerGetLocalize } from '../chrome/utils/localization';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());

--- a/src/transformers/remotePathTransformer.ts
+++ b/src/transformers/remotePathTransformer.ts
@@ -16,6 +16,7 @@ import { TYPES } from '../chrome/dependencyInjection.ts/types';
 import { IConnectedCDAConfiguration } from '../chrome/client/chromeDebugAdapter/cdaConfiguration';
 import { isNotEmpty, hasMatches } from '../chrome/utils/typedOperators';
 import * as _ from 'lodash';
+import { LocalizedError } from '../chrome/utils/localizedError';
 
 interface IRootsState {
     install(): Promise<void>;
@@ -92,7 +93,7 @@ export class RemotePathTransformer extends UrlPathTransformer {
         const args = configuration.args;
 
         if (isNotEmpty(args.localRoot) !== isNotEmpty(args.remoteRoot)) {
-            throw new Error(localize('localRootAndRemoteRoot', 'Both localRoot and remoteRoot must be specified.'));
+            throw new LocalizedError(localize('localRootAndRemoteRoot', 'Both localRoot and remoteRoot must be specified.'));
         }
 
         this._state = isNotEmpty(args.localRoot) && isNotEmpty(args.remoteRoot)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -239,7 +239,7 @@ export function stripTrailingSlash(aPath: string): string {
  * when passing on a failure from a Promise error handler.
  * @param msg - Should be either a string or an Error
  */
-export function errP(msg?: string): Promise<never> {
+export function errP(msg?: string, errorId?: string): Promise<never> {
     const isErrorLike = (thing: any): thing is Error => !!thing.message;
 
     let e: Error;
@@ -249,7 +249,7 @@ export function errP(msg?: string): Promise<never> {
         // msg is already an Error object
         e = msg;
     } else {
-        e = new LocalizedError(msg);
+        e = new LocalizedError(_.defaultTo(errorId, 'unknown.error.id'), msg);
     }
 
     return Promise.reject(e);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,7 @@ import { promisify } from 'util';
 import { isDefined, hasMatches, hasNoMatches, isNotEmpty, isTrue, isEmpty } from './chrome/utils/typedOperators';
 import * as _ from 'lodash';
 import { InternalError } from './chrome/utils/internalError';
+import { LocalizedError } from './chrome/utils/localizedError';
 
 export interface IStringDictionary<T> {
     [name: string]: T;
@@ -248,7 +249,7 @@ export function errP(msg?: string): Promise<never> {
         // msg is already an Error object
         e = msg;
     } else {
-        e = new Error(msg);
+        e = new LocalizedError(msg);
     }
 
     return Promise.reject(e);
@@ -597,9 +598,11 @@ export function fillErrorDetails(properties: IExecutionResultTelemetryProperties
     }
     if (e.id) {
         properties.exceptionId = e.id.toString();
-    }
-    if (e instanceof InternalError) {
+    } else if (e.errorCode) {
         properties.exceptionId = e.errorCode;
+    }
+
+    if (e.errorDetails) {
         properties.errorDetails = e.errorDetails;
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,7 @@ import { promisify } from 'util';
 import { isDefined, hasMatches, hasNoMatches, isNotEmpty, isTrue, isEmpty } from './chrome/utils/typedOperators';
 import * as _ from 'lodash';
 import { InternalError } from './chrome/utils/internalError';
-import { LocalizedError } from './chrome/utils/localizedError';
+import { LocalizedError } from './chrome/utils/localization';
 
 export interface IStringDictionary<T> {
     [name: string]: T;


### PR DESCRIPTION
This PR solves 2 different issues:
 - It makes localization work for v2 by re-creating the localize function after we change the locale
 - It provides a LocalizedError class where you can configure the error id for a localized error message (This will let us deduplicate errors across different locales in telemetry)

src/chrome/utils/localizedError.ts implements the solution for both of those issues