### PR TITLE
Adding support for launching with port = 0

### DIFF
--- a/src/chrome/chromeConnection.ts
+++ b/src/chrome/chromeConnection.ts
@@ -95,7 +95,7 @@ export interface IChromeError {
  * Connects to a target supporting the Chrome Debug Protocol and sends and receives messages
  */
 export class ChromeConnection implements IObservableEvents<IStepStartedEventsEmitter> {
-    private static ATTACH_TIMEOUT = 10000; // ms
+    protected static ATTACH_TIMEOUT = 10000; // ms
 
     private _socket: WebSocket;
     private _crdpSocketMultiplexor: CRDPMultiplexor;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -151,3 +151,21 @@ export function noStoredException(): DebugProtocol.Message {
         sendTelemetry: true
     });
 }
+
+export function failedToReadPortFromUserDataDir(dataDirPath: string, err: Error) {
+    return new ErrorWithMessage({
+        id: 2033,
+        format: localize('failed.to.read.port', 'Failed to read file {dataDirPath}, {error}'),
+        variables: { dataDirPath, error: err.message },
+        sendTelemetry: true
+    });
+}
+
+export function activePortFileContentsInvalid(dataDirPath: string, dataDirContents: string) {
+    return new ErrorWithMessage({
+        id: 2034,
+        format: localize('port.file.contents.invalid', 'File at location: "{dataDirPath}" did not contain valid port data, contents were: {dataDirContents}'),
+        variables: { dataDirPath, dataDirContents },
+        sendTelemetry: true
+    });
+}

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -107,7 +107,8 @@ export function pathResolve(...segments: string[]): string {
 }
 
 export function registerMockReadFile(...entries: { absPath: string; data: string }[]): void {
-    const fsMock = Mock.ofInstance(fs, MockBehavior.Strict);
+    const fsMock = Mock.ofInstance(fs, MockBehavior.Loose);
+    fsMock.callBase = true; // use real fs if we didn't mock the call
     mockery.registerMock('fs', fsMock.object);
 
     entries.forEach(entry => {


### PR DESCRIPTION
In order to fix some of the timeout issues we have in VS, we want to be able to support launching with --remote-debugging-port=0 on Chrome, which will then allow Chrome to select the debugging port, and let us know through the DevToolsActivePort file in the user-data-dir.