### PR TITLE
Now the BPs fail independently on setBreakpoints

### DIFF
--- a/src/chrome/cdtpDebuggee/features/cdtpDebuggeeBreakpointsSetter.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpDebuggeeBreakpointsSetter.ts
@@ -20,20 +20,36 @@ import { IScript } from '../../internal/scripts/script';
 import { IURL, IResourceIdentifier } from '../../internal/sources/resourceIdentifier';
 import { CDTPScriptUrl } from '../../internal/sources/resourceIdentifierSubtypes';
 import { URLRegexp } from '../../internal/locations/subtypes';
-import { MappableBreakpoint, ActualLocation } from '../../internal/breakpoints/breakpoint';
+import { MappableBreakpoint, ActualLocation, BreakpointInSource } from '../../internal/breakpoints/breakpoint';
 import { BPRecipeInScript, BPRecipeInUrl, BPRecipeInUrlRegexp, IBPRecipeForRuntimeSource } from '../../internal/breakpoints/baseMappedBPRecipe';
-import { ConditionalPause } from '../../internal/breakpoints/bpActionWhenHit';
+import { ConditionalPause, PauseOnHitCount } from '../../internal/breakpoints/bpActionWhenHit';
 import { singleElementOfArray } from '../../collections/utilities';
+import { BPRecipeInSource } from '../../internal/breakpoints/bpRecipeInSource';
 
 export enum Synchronicity {
     Sync,
     Async
 }
 
+export class BPRecipeInSourceWasResolved {
+    public constructor(
+        public readonly breakpoint: BreakpointInSource,
+        public readonly actualLocationInScript: LocationInScript,
+        public readonly resolutionSynchronicity: Synchronicity) { }
+
+    public withBPRecipe(hitCountBPRecipe: BPRecipeInSource<PauseOnHitCount>) {
+        return new BPRecipeInSourceWasResolved(this.breakpoint.withBPRecipe(hitCountBPRecipe), this.actualLocationInScript, this.resolutionSynchronicity);
+    }
+}
+
 export class BPRecipeWasResolved {
     public constructor(
         public readonly breakpoint: MappableBreakpoint<CDTPSupportedResources>,
         public readonly resolutionSynchronicity: Synchronicity) { }
+
+    public withBPRecipe(bpRecipe: BPRecipeInSource): BPRecipeInSourceWasResolved {
+        return new BPRecipeInSourceWasResolved(this.breakpoint.withBPRecipe(bpRecipe), this.breakpoint.actualLocation, this.resolutionSynchronicity);
+    }
 }
 
 export interface IEventsConsumer {

--- a/src/chrome/communication/listeners.ts
+++ b/src/chrome/communication/listeners.ts
@@ -2,7 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-type Callback<Args, Result> = (args: Args) => Result;
+export type Callback<Args, Result> = (args: Args) => Result;
 
 /**
  * This class is used to manage and call a set of listeners, such as the listeners to onScriptParsed
@@ -20,5 +20,9 @@ export class Listeners<Args, Result> {
 
     public hasListeners(): boolean {
         return this._listeners.length > 0;
+    }
+
+    public toString(): string {
+        return `#Listeners = ${this._listeners.length}`;
     }
 }

--- a/src/chrome/dependencyInjection.ts/types.ts
+++ b/src/chrome/dependencyInjection.ts/types.ts
@@ -29,7 +29,6 @@ const TYPES = {
     ClientToInternal: Symbol.for('ClientToInternal'),
     InternalToClient: Symbol.for('InternalToClient'),
     StackTracesLogic: Symbol.for('StackTracesLogic'),
-    IBreakpointsUpdater: Symbol.for('IBreakpointsUpdater'),
     PauseOnExceptionOrRejection: Symbol.for('PauseOnExceptionOrRejection'),
     Stepping: Symbol.for('Stepping'),
     DotScriptCommand: Symbol.for('DotScriptCommand'),

--- a/src/chrome/internal/breakpoints/bpRecipeStatus.ts
+++ b/src/chrome/internal/breakpoints/bpRecipeStatus.ts
@@ -99,7 +99,7 @@ export class BPRecipeHasOnlyUnboundSubstatuses implements IBPRecipeStatus {
     }
 
     public isVerified(): boolean {
-        return true;
+        return false;
     }
 
     public get statusDescription(): string {

--- a/src/chrome/internal/breakpoints/diTypes.ts
+++ b/src/chrome/internal/breakpoints/diTypes.ts
@@ -7,6 +7,7 @@ export const PrivateTypes = {
     SingleBreakpointSetterWithHitCountSupport: Symbol.for('SingleBreakpointSetterWithHitCountSupport'),
     CurrentBPRecipesForSourceRegistry: Symbol.for('CurrentBPRecipesForSourceRegistry'),
     CurrentBPRecipeStatusRetriever: Symbol.for('CurrentBPRecipeStatusRetriever'),
+    IBreakpointsUpdater: Symbol.for('IBreakpointsUpdater'),
     BPRecipeStatusCalculator: Symbol.for('BPRecipeStatusCalculator'),
     PauseScriptLoadsToSetBPs: Symbol.for('PauseScriptLoadsToSetBPs'),
     ExistingBPsForJustParsedScriptSetter: Symbol.for('ExistingBPsForJustParsedScriptSetter'),

--- a/src/chrome/internal/breakpoints/features/breakpointsEventSystem.ts
+++ b/src/chrome/internal/breakpoints/features/breakpointsEventSystem.ts
@@ -1,10 +1,8 @@
 import { CDTPBPRecipe } from '../../../cdtpDebuggee/cdtpPrimitives';
 import { BPRecipeInSource } from '../bpRecipeInSource';
-import { BPRecipeIsUnbound } from '../bpRecipeStatusForRuntimeLocation';
 import { injectable } from 'inversify';
 import { BPRecipeAtLoadedSourceSetter } from './bpRecipeAtLoadedSourceLogic';
 import { SingleBreakpointSetter } from './singleBreakpointSetter';
-import { BPRecipeWasResolved } from '../../../cdtpDebuggee/features/cdtpDebuggeeBreakpointsSetter';
 import { BPRecipeStatusChanged } from '../registries/bpRecipeStatusCalculator';
 import * as _ from 'lodash';
 
@@ -13,8 +11,6 @@ export interface IBreakpointsEventsListener {
     listenForOnClientBPRecipeRemoved(listener: (bpRecipie: BPRecipeInSource) => void): void;
     listenForOnDebuggeeBPRecipeAdded(listener: (bpRecipie: CDTPBPRecipe) => void): void;
     listenForOnDebuggeeBPRecipeRemoved(listener: (bpRecipie: CDTPBPRecipe) => void): void;
-    listenForOnBPRecipeIsResolved(listener: (bpRecipeWasResolved: BPRecipeWasResolved) => void): void;
-    listenForOnBPRecipeFailedToBind(listener: (bpRecipieIsUnbound: BPRecipeIsUnbound) => void): void;
 }
 
 /**
@@ -50,18 +46,6 @@ export class BreakpointsEventSystem implements IBreakpointsEventsListener {
     public listenForOnDebuggeeBPRecipeRemoved(listener: (bpRecipie: CDTPBPRecipe) => void): void {
         this.schedule(() => {
             this._bpRecipeAtLoadedSourceSetter!.debuggeeBPRecipeRemovedListeners.add(listener);
-        });
-    }
-
-    public listenForOnBPRecipeIsResolved(listener: (bpRecipeWasResolved: BPRecipeWasResolved) => void): void {
-        this.schedule(() => {
-            this._singleBreakpointSetter!.bpRecipeIsResolvedListeners.add(listener);
-        });
-    }
-
-    public listenForOnBPRecipeFailedToBind(listener: (bpRecipieIsUnbound: BPRecipeIsUnbound) => void): void {
-        this.schedule(() => {
-            this._bpRecipeAtLoadedSourceSetter!.bpRecipeFailedToBindListeners.add(listener);
         });
     }
 

--- a/src/chrome/internal/breakpoints/features/breakpointsUpdater.ts
+++ b/src/chrome/internal/breakpoints/features/breakpointsUpdater.ts
@@ -7,7 +7,7 @@ import { asyncMap } from '../../../collections/async';
 import { IBPRecipeStatus } from '../bpRecipeStatus';
 import { BPRsDeltaCalculatorFromStoredBPRs } from '../registries/bprsDeltaCalculatorFromStoredBPRs';
 import { IEventsToClientReporter } from '../../../client/eventsToClientReporter';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, LazyServiceIdentifer } from 'inversify';
 import { TYPES } from '../../../dependencyInjection.ts/types';
 import { BPRecipeInSource } from '../bpRecipeInSource';
 import { ITelemetryPropertyCollector } from '../../../../telemetry';
@@ -15,10 +15,13 @@ import { PrivateTypes } from '../diTypes';
 import { SingleBreakpointSetterWithHitCountSupport } from './singleBreakpointSetterWithHitCountSupport';
 import { CurrentBPRecipeStatusRetriever } from '../registries/currentBPRecipeStatusRetriever';
 import { HitBreakpoint } from './bpRecipeAtLoadedSourceLogic';
-import { BPRecipeStatusChanged } from '../registries/bpRecipeStatusCalculator';
+import { BPRecipeStatusChanged, BPRecipeStatusCalculator } from '../registries/bpRecipeStatusCalculator';
 import { Synchronicity } from '../../../cdtpDebuggee/features/cdtpDebuggeeBreakpointsSetter';
 import { logger } from 'vscode-debugadapter';
 import { Listeners } from '../../../communication/listeners';
+import { BPRecipeIsUnbound } from '../bpRecipeStatusForRuntimeLocation';
+import { PauseScriptLoadsToSetBPs } from './pauseScriptLoadsToSetBPs';
+import { ConnectedCDAConfiguration } from '../../../client/chromeDebugAdapter/cdaConfiguration';
 
 /**
  * Update the breakpoint recipes for a particular source
@@ -27,13 +30,23 @@ import { Listeners } from '../../../communication/listeners';
 export class BreakpointsUpdater {
     public bpRecipeStatusChangedListeners = new Listeners<BPRecipeStatusChanged, void>();
 
+    private _isBpsWhileLoadingEnable = false;
+
     constructor(
+        @inject(new LazyServiceIdentifer(() => TYPES.ConnectedCDAConfiguration)) private readonly _configuration: ConnectedCDAConfiguration,
         @inject(TYPES.IEventsToClientReporter) private readonly _eventsToClientReporter: IEventsToClientReporter,
         @inject(PrivateTypes.CurrentBPRecipesForSourceRegistry) private readonly _clientCurrentBPRecipesRegistry: BPRsDeltaCalculatorFromStoredBPRs,
         @inject(PrivateTypes.SingleBreakpointSetterWithHitCountSupport) private readonly _singleBreakpointSetter: SingleBreakpointSetterWithHitCountSupport,
-        @inject(PrivateTypes.CurrentBPRecipeStatusRetriever) private readonly _currentBPRecipeStatusRetriever: CurrentBPRecipeStatusRetriever) {
+        @inject(PrivateTypes.CurrentBPRecipeStatusRetriever) private readonly _currentBPRecipeStatusRetriever: CurrentBPRecipeStatusRetriever,
+        @inject(new LazyServiceIdentifer(() => PrivateTypes.PauseScriptLoadsToSetBPs)) private readonly _pauseScriptLoadsToSetBPs: PauseScriptLoadsToSetBPs,
+        @inject(PrivateTypes.BPRecipeStatusCalculator) private readonly _bpRecipeStatusCalculator: BPRecipeStatusCalculator) {
+        this._bpRecipeStatusCalculator.bpRecipeStatusChangedListeners.add(bpRecipe => this.onBPRecipeStatusChanged(bpRecipe));
         this._singleBreakpointSetter.bpRecipeStatusChangedListeners.add(bpRecipe => this.onBPRecipeStatusChanged(bpRecipe));
         this._singleBreakpointSetter.setOnPausedForBreakpointCallback(async _bpRecipes => new HitBreakpoint(this._eventsToClientReporter));
+        this._singleBreakpointSetter.setBPRecipeWasResolvedCallback(bpRecipeWasResolved => {
+            this._bpRecipeStatusCalculator.bpRecipeIsResolved(bpRecipeWasResolved);
+            this._pauseScriptLoadsToSetBPs.bpRecipeIsResolved(bpRecipeWasResolved);
+        });
     }
 
     protected async onBPRecipeStatusChanged(statusChanged: BPRecipeStatusChanged): Promise<void> {
@@ -71,7 +84,16 @@ export class BreakpointsUpdater {
     }
 
     public async install(): Promise<this> {
-        await this._singleBreakpointSetter.install();
+        await this._pauseScriptLoadsToSetBPs.install();
+        await this.configure();
+        return this;
+    }
+
+    public async configure(): Promise<this> {
+        this._isBpsWhileLoadingEnable = this._configuration.args.breakOnLoadStrategy !== 'off';
+        if (this._isBpsWhileLoadingEnable) {
+            await this._pauseScriptLoadsToSetBPs.enableIfNeccesary();
+        }
         return this;
     }
 
@@ -79,6 +101,7 @@ export class BreakpointsUpdater {
         await asyncMap(bpRecipesToRemove, async existingBPToRemove => {
             await this._singleBreakpointSetter.removeBPRecipe(existingBPToRemove);
             this._currentBPRecipeStatusRetriever.clientBPRecipeWasRemoved(existingBPToRemove);
+            this._bpRecipeStatusCalculator.clientBPRecipeWasRemoved(existingBPToRemove);
         });
     }
 
@@ -86,7 +109,12 @@ export class BreakpointsUpdater {
         // DIEGO TODO: Do we need to do one breakpoint at a time to avoid issues on CDTP, or can we do them in parallel now that we use a different algorithm?
         await asyncMap(requestedBPsToAdd, async requestedBP => {
             this._currentBPRecipeStatusRetriever.clientBPRecipeIsBeingAdded(requestedBP);
-            await this._singleBreakpointSetter.addBPRecipe(requestedBP);
+            this._bpRecipeStatusCalculator.clientBPRecipeIsBeingAdded(requestedBP);
+            try {
+                await this._singleBreakpointSetter.addBPRecipe(requestedBP);
+            } catch (exception) {
+                this._bpRecipeStatusCalculator.bpRecipeFailedToBind(new BPRecipeIsUnbound(requestedBP, exception)); // We publish it so the breakpoint itself will have this information in the tooltip
+            }
         });
     }
 }

--- a/src/chrome/internal/breakpoints/features/setBreakpointsRequestHandler.ts
+++ b/src/chrome/internal/breakpoints/features/setBreakpointsRequestHandler.ts
@@ -29,6 +29,7 @@ import { isDefined, isNotEmpty } from '../../../utils/typedOperators';
 import { ISourceToClientConverter } from '../../../client/sourceToClientConverter';
 import { InternalError } from '../../../utils/internalError';
 import { LocalizedError, registerGetLocalize } from '../../../utils/localization';
+import { PrivateTypes } from '../diTypes';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());
@@ -41,7 +42,7 @@ export class SetBreakpointsRequestHandler implements ICommandHandlerDeclarer {
     private readonly _bpRecipieStatusToClientConverter = new BPRecipieStatusToClientConverter(this._handlesRegistry, this._sourceToClientConverter, this._lineColTransformer);
 
     public constructor(
-        @inject(TYPES.IBreakpointsUpdater) protected readonly _breakpointsLogic: BreakpointsUpdater,
+        @inject(PrivateTypes.IBreakpointsUpdater) protected readonly _breakpointsLogic: BreakpointsUpdater,
         private readonly _handlesRegistry: HandlesRegistry,
         @inject(TYPES.LineColTransformer) private readonly _lineColTransformer: LineColTransformer,
         @inject(TYPES.SourceToClientConverter) private readonly _sourceToClientConverter: ISourceToClientConverter,

--- a/src/chrome/internal/breakpoints/features/singleBreakpointSetterWithHitCountSupport.ts
+++ b/src/chrome/internal/breakpoints/features/singleBreakpointSetterWithHitCountSupport.ts
@@ -3,8 +3,8 @@ import { inject, injectable } from 'inversify';
 import { PrivateTypes } from '../diTypes';
 import { Listeners } from '../../../communication/listeners';
 import { BPRecipeInSource } from '../bpRecipeInSource';
-import { IBPRecipeStatus } from '../bpRecipeStatus';
-import { ISingleBreakpointSetter, SingleBreakpointSetter } from './singleBreakpointSetter';
+import { ISingleBreakpointSetter, BPRecipeInSourceWasResolvedCallback } from './singleBreakpointSetter';
+import { SingleBreakpointSetter } from './singleBreakpointSetter';
 import { BPRecipeStatusChanged } from '../registries/bpRecipeStatusCalculator';
 import { OnPausedForBreakpointCallback } from './onPausedForBreakpointCallback';
 
@@ -24,22 +24,17 @@ export class SingleBreakpointSetterWithHitCountSupport implements ISingleBreakpo
         this._hitCountBreakpointsSetter.setOnPausedForBreakpointCallback(onPausedForBreakpointCallback);
     }
 
+    public setBPRecipeWasResolvedCallback(callback: BPRecipeInSourceWasResolvedCallback): void {
+        this._singleBreakpointSetter.setBPRecipeWasResolvedCallback(callback);
+        this._hitCountBreakpointsSetter.setBPRecipeWasResolvedCallback(callback);
+    }
+
     public async addBPRecipe(requestedBP: BPRecipeInSource): Promise<void> {
         await this.getSetterForBPRecipe(requestedBP).addBPRecipe(requestedBP);
     }
 
     public async removeBPRecipe(bpRecipeToRemove: BPRecipeInSource): Promise<void> {
         await this.getSetterForBPRecipe(bpRecipeToRemove).removeBPRecipe(bpRecipeToRemove);
-    }
-
-    public statusOfBPRecipe(bpRecipe: BPRecipeInSource): IBPRecipeStatus {
-        return this.getSetterForBPRecipe(bpRecipe).statusOfBPRecipe(bpRecipe);
-    }
-
-    public async install(): Promise<this> {
-        await this._singleBreakpointSetter.install();
-        await this._hitCountBreakpointsSetter.install();
-        return this;
     }
 
     public toString(): string {

--- a/src/chrome/internal/locations/location.ts
+++ b/src/chrome/internal/locations/location.ts
@@ -71,7 +71,7 @@ export class Position implements IEquivalenceComparable {
     }
 
     public toString(): string {
-        return localize('position.description', '{0}:{1}', this.lineNumber, this.columnNumber);
+        return localize('position.description', '{0}:{1}', this.lineNumber + 1, this.columnNumber + 1);
     }
 }
 


### PR DESCRIPTION
*Summary*
The main idea behind this PR, is that we are moving the "Breakpoint Status components" from the "Single breakpoint subystem" which we have two instances, one for normal breakpoints and one for hit count breakpoints, to be outside that subsystem, so then the hit count breakpoint layer on top of the system can communicate with that and notify that a hit count breakpoint failed because the condition is invalid.


* cdtpDebuggeeBreakpointsSetter.ts: We had to translate BPRecipeWasResolved to the hit count BP Recipe. There were to choices as to how to make this change:
  1. Modify MappableBreakpoint<CDTPSupportedResources> to support hit count cdtpDebuggeeBreakpointsSetter
  2. Create a new class where we can specify breakpoint: BreakpointInSource as two properties instead of one actualLocationInScript: LocationInScript. I went with that option because it seems easier at that time and created BPRecipeInSourceWasResolved 
(We need the actualLocationInScript to check for a break-on-load hit-count breakpoint if it's on location 0,0 of a script)

* breakpoint.ts: We use withBPRecipe to map an underlying normal breakpoint to a hit count breakpoint when translating BPRecipeWasResolved to BPRecipeInSourceWasResolved

* diBindings.ts: Previously we had two parallel breakpoints system (Normal and Hit count breakpoints) and the "Breakpoint Status" was inside each of those subsystems. Because we parse the hit count condition before calling into those systems, we need to extract the "Breakpoint Status" components outside of that sub-system, so a failed condition can mark a breakpoint as "unbound" and fail independently of the other breakpoints. I moved several related classes to be outside of the single breakpoint sub-system, and they are now shared (we have a single copy) across "Normal and hit count breakpoints".

* bpRecipeAtLoadedSourceLogic.ts: Move catching the single breakpoint error to breakpointsUpdater.ts so it can catch invalid hit count conditions too

* breakpointsEventSystem.ts: This system is inside the single breakpoint subsystem, so we cannot use it from "outside" the subsystems, for transmiting "Breakpoint Status" events

* breakpointsUpdater.ts: Re-wire the "Breakpoint Status" components here, outside of the "single breakpoint subsystem"

* hitCountBreakpointsSetter.ts: Add a callback so the "single breakpoint subsystem" can notify the external breakpointsUpdater when a breakpoint status changes

* pauseScriptLoadsToSetBPs.ts: This logic doesn't need to be duplicated in the "single breakpoint subsystem", so I moved it outside, and adapted to work there

* singleBreakpointSetter.ts: Moved the "Breakpoint status" logic out of here

* singleBreakpointSetterWithHitCountSupport.ts: Add a callback so the "single breakpoint subsystem" can notify the external breakpointsUpdater when a breakpoint status changes

* bpRecipeStatusCalculator.ts: Adapted to work outside of the single breakpoint subsystem

* breakpointsSetForScriptFinder.ts: Moved outside of the subsystem as part of the pauseScriptLoadsToSetBPs.ts change

