### PR TITLE
Added PossiblyCustomerContent<T> class to prevent logging customer content inadvertently

### DIFF
--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpOnScriptParsedEventProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpOnScriptParsedEventProvider.ts
@@ -28,6 +28,7 @@ import { BaseSourceMapTransformer } from '../../../transformers/baseSourceMapTra
 import { isNotEmpty } from '../../utils/typedOperators';
 import { CDTPExecutionContextEventsProvider } from './cdtpExecutionContextEventsProvider';
 import { DebuggerInternalSourceUrlPrefix } from '../features/cdtpDebugeeStateInspector';
+import { SourceMapUrl } from '../../../sourceMaps/sourceMapUrl';
 
 /**
  * A new JavaScript Script has been parsed by the debuggee and it's about to be executed
@@ -42,7 +43,7 @@ export interface IScriptParsedEvent {
     readonly executionContext: IExecutionContext;
     readonly executionContextAuxData?: any;
     readonly isLiveEdit?: boolean;
-    readonly sourceMapURL?: string;
+    readonly sourceMapURL?: SourceMapUrl;
     readonly hasSourceURL?: boolean;
     readonly isModule?: boolean;
     readonly length?: integer;
@@ -58,7 +59,7 @@ export class ScriptParsedEvent implements IScriptParsedEvent {
     public readonly executionContext: IExecutionContext;
     public readonly executionContextAuxData?: any;
     public readonly isLiveEdit?: boolean;
-    public readonly sourceMapURL?: string;
+    public readonly sourceMapURL?: SourceMapUrl;
     public readonly hasSourceURL?: boolean;
     public readonly isModule?: boolean;
     public readonly length?: integer;
@@ -143,13 +144,17 @@ export class CDTPOnScriptParsedEventProvider extends CDTPEventsEmitterDiagnostic
                 executionContext: executionContext,
                 executionContextAuxData: params.executionContextAuxData,
                 isLiveEdit: params.isLiveEdit,
-                sourceMapURL: params.sourceMapURL,
+                sourceMapURL: sourceMapURL(params),
                 hasSourceURL: params.hasSourceURL,
                 isModule: params.isModule,
                 length: params.length,
                 script: await this._scriptsRegistry.getScriptByCdtpId(params.scriptId)
             });
     }
+}
+
+function sourceMapURL(params: CDTP.Debugger.ScriptParsedEvent): SourceMapUrl | undefined {
+    return SourceMapUrl.maybeUndefined(params.sourceMapURL);
 }
 
 abstract class ScriptCreator {
@@ -183,7 +188,7 @@ abstract class ScriptCreator {
     }
 
     private sourceMap(): Promise<SourceMap | null> {
-        return this._sourceMapTransformer.scriptParsed(this.runtimeSourcePath.canonicalized, this._scriptParsedEvent.sourceMapURL);
+        return this._sourceMapTransformer.scriptParsed(this.runtimeSourcePath.canonicalized, sourceMapURL(this._scriptParsedEvent));
     }
 
     protected abstract createScript(executionContext: IExecutionContext, sourceMapperProvider: (script: IScript) => IMappedSourcesMapper,

--- a/src/chrome/cdtpDebuggee/features/cdtpScriptSourcesRetriever.ts
+++ b/src/chrome/cdtpDebuggee/features/cdtpScriptSourcesRetriever.ts
@@ -7,9 +7,10 @@ import { IScript } from '../../internal/scripts/script';
 import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
 import { inject, injectable } from 'inversify';
 import { TYPES } from '../../dependencyInjection.ts/types';
+import { SourceContents } from '../../internal/sources/sourceContents';
 
 export interface IScriptSourcesRetriever {
-    getScriptSource(script: IScript): Promise<string>;
+    getScriptSource(script: IScript): Promise<SourceContents>;
 }
 
 @injectable()
@@ -22,7 +23,8 @@ export class CDTPScriptSourcesRetriever implements IScriptSourcesRetriever {
         @inject(TYPES.CDTPScriptsRegistry) private readonly _scriptsRegistry: CDTPScriptsRegistry) {
     }
 
-    public async getScriptSource(script: IScript): Promise<string> {
-        return (await this.api.getScriptSource({ scriptId: this._scriptsRegistry.getCdtpId(script) })).scriptSource;
+    public async getScriptSource(script: IScript): Promise<SourceContents> {
+        const scriptSource = (await this.api.getScriptSource({ scriptId: this._scriptsRegistry.getCdtpId(script) })).scriptSource;
+        return SourceContents.customerContent(scriptSource);
     }
 }

--- a/src/chrome/internal/sources/features/dotScriptsCommand.ts
+++ b/src/chrome/internal/sources/features/dotScriptsCommand.ts
@@ -12,6 +12,7 @@ import { CDTPScriptsRegistry } from '../../../cdtpDebuggee/registries/cdtpScript
 import { IScriptSourcesRetriever } from '../../../cdtpDebuggee/features/cdtpScriptSourcesRetriever';
 import { parseResourceIdentifier } from '../resourceIdentifier';
 import { isNotEmpty } from '../../../utils/typedOperators';
+import { SourceContents } from '../sourceContents';
 
 @injectable()
 export class DotScriptCommand {
@@ -25,29 +26,21 @@ export class DotScriptCommand {
      * Handle the .scripts command, which can be used as `.scripts` to return a list of all script details,
      * or `.scripts <url>` to show the contents of the given script.
      */
-    public handleScriptsCommand(scriptsRest: string): Promise<void> {
-        let outputStringP: Promise<string>;
+    public async handleScriptsCommand(scriptsRest: string): Promise<void> {
+        let outputStringP: SourceContents;
         if (isNotEmpty(scriptsRest)) {
             // `.scripts <url>` was used, look up the script by url
             const requestedScript = this._scriptsRegistry.getScriptsByPath(parseResourceIdentifier(scriptsRest));
             if (requestedScript.length > 0) {
-                outputStringP = this._scriptSources.getScriptSource(requestedScript[0])
-                    .then(result => {
-                        const maxLength = 1e5;
-                        return result.length > maxLength ?
-                            result.substr(0, maxLength) + '[⋯]' :
-                            result;
-                    });
+                outputStringP = (await this._scriptSources.getScriptSource(requestedScript[0])).truncated();
             } else {
-                outputStringP = Promise.resolve(`No runtime script with url: ${scriptsRest}\n`);
+                outputStringP =  SourceContents.nonCustomerContent(`No runtime script with url: ${scriptsRest}\n`);
             }
         } else {
-            outputStringP = this.getAllScriptsString();
+            outputStringP = SourceContents.nonCustomerContent(await this.getAllScriptsString());
         }
 
-        return outputStringP.then(scriptsStr => {
-            this._eventsToClientReporter.sendOutput({ output: scriptsStr, category: 'stdout' });
-        });
+        this._eventsToClientReporter.sendCustomerContentOutput({ output: await outputStringP.contents, category: 'stdout' });
     }
 
     private async getAllScriptsString(): Promise<string> {

--- a/src/chrome/internal/sources/sourceContents.ts
+++ b/src/chrome/internal/sources/sourceContents.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+ import { PossiblyCustomerContent, CustomerContent, NonCustomerContent } from '../../logging/gdpr';
+
+export class SourceContents {
+    public constructor(public readonly contents: PossiblyCustomerContent<string>) {}
+
+    public static customerContent(contents: string): SourceContents {
+        return new SourceContents(new CustomerContent(contents));
+    }
+
+    public static nonCustomerContent(contents: string): SourceContents {
+        return new SourceContents(new NonCustomerContent(contents));
+    }
+
+    public get customerContentData(): string {
+        return this.contents.customerContentData;
+    }
+
+    public truncated(): SourceContents {
+        const maxLength = 1e5;
+        return this.customerContentData.length > maxLength
+            ? SourceContents.customerContent(this.customerContentData.substr(0, maxLength) + '[⋯]')
+            : this;
+    }
+}

--- a/src/chrome/internal/sources/sourceRequestHandler.ts
+++ b/src/chrome/internal/sources/sourceRequestHandler.ts
@@ -17,6 +17,7 @@ import { SourceResolver } from './sourceResolver';
 import { isDefined } from '../../utils/typedOperators';
 import { TYPES } from '../../dependencyInjection.ts/types';
 import { InternalError } from '../../utils/internalError';
+import { DoNotLog } from '../../logging/decorators';
 
 @injectable()
 export class SourceRequestHandler implements ICommandHandlerDeclarer {
@@ -39,12 +40,13 @@ export class SourceRequestHandler implements ICommandHandlerDeclarer {
         return { sources: await asyncMap(await this._sourcesRetriever.loadedSourcesTrees(), st => this.toSourceTree(st)) };
     }
 
+    @DoNotLog()
     public async source(args: DebugProtocol.SourceArguments, _telemetryPropertyCollector?: ITelemetryPropertyCollector, _requestSeq?: number): Promise<ISourceResponseBody> {
         if (isDefined(args.source)) {
             const source = this._clientSourceParser.toSource(args.source);
             const sourceText = await this._sourcesRetriever.text(source);
             return {
-                content: sourceText,
+                content: sourceText.customerContentData,
                 mimeType: 'text/javascript'
             };
         } else {

--- a/src/chrome/internal/sources/sourcesRetriever.ts
+++ b/src/chrome/internal/sources/sourcesRetriever.ts
@@ -9,11 +9,12 @@ import { ISource } from './source';
 import { IScript } from '../scripts/script';
 import { injectable } from 'inversify';
 import { InternalError } from '../../utils/internalError';
+import { SourceContents } from './sourceContents';
 
 export interface ISourcesRetriever {
     loadedSourcesTrees(): Promise<ILoadedSourceTreeNode[]>;
     loadedSourcesTreeForScript(script: IScript): ILoadedSourceTreeNode;
-    text(source: ISource): Promise<string>;
+    text(source: ISource): Promise<SourceContents>;
 }
 
 @injectable()
@@ -31,7 +32,7 @@ export class SourcesRetriever implements ISourcesRetriever {
         return this._sourceTreeNodeLogic.getLoadedSourcesTreeForScript(script);
     }
 
-    public async text(source: ISource): Promise<string> {
+    public async text(source: ISource): Promise<SourceContents> {
         return await source.tryResolving(
             async loadedSource => await this._sourceTextRetriever.text(loadedSource),
             identifier => {

--- a/src/chrome/logging/gdpr.ts
+++ b/src/chrome/logging/gdpr.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+/** Used to store data that can potentially be customer content. If it is, we should never log it or send it over telemetry */
+ export interface PossiblyCustomerContent<T> {
+    customerContentData: T;
+
+    /** Transform the data. If it is customer data, the result will sill be customer data */
+    transform<U>(transformFunction: (customerContentData: T) => U): PossiblyCustomerContent<U>;
+}
+
+/** Used to protect CustomerContent data so we don't inadvertently log it or send it as telemetry */
+export class CustomerContent<T> implements PossiblyCustomerContent<T> {
+    public constructor(data: T) {
+        Object.defineProperty(this, 'customerContentData', {
+            get: () => data
+        });
+    }
+
+    public static maybeNull<T>(data: T | null): PossiblyCustomerContent<T> | null {
+        return data !== null
+            ? new CustomerContent(data)
+            : null;
+    }
+
+    public static maybeUndefined<T>(data: T | undefined): PossiblyCustomerContent<T> | undefined {
+        return data !== undefined
+            ? new CustomerContent(data)
+            : undefined;
+    }
+
+    public static fromAsync<T>(promisedData: Promise<T>): Promise<PossiblyCustomerContent<T>> {
+        return promisedData.then(data => new CustomerContent(data));
+    }
+
+    public transform<U>(transformFunction: (customerContentData: T) => U): PossiblyCustomerContent<U> {
+        return new CustomerContent(transformFunction(this.customerContentData));
+    }
+
+    public toString(): string {
+        return `CustomerContent`;
+    }
+}
+
+export interface CustomerContent<T> {
+    customerContentData: T; // class CustomerContent<T> has this member, and it's created on the constructor
+}
+
+export class NonCustomerContent<T> implements PossiblyCustomerContent<T> {
+    public constructor(public customerContentData: T) {}
+
+    public transform<U>(transformFunction: (customerContentData: T) => U): PossiblyCustomerContent<U> {
+        return new NonCustomerContent(transformFunction(this.customerContentData));
+    }
+}

--- a/src/sourceMaps/sourceMap.ts
+++ b/src/sourceMaps/sourceMap.ts
@@ -21,6 +21,7 @@ import { SetUsingProjection } from '../chrome/collections/setUsingProjection';
 import { isNotEmpty, isDefined, isNull } from '../chrome/utils/typedOperators';
 import { wrapWithMethodLogger } from '../chrome/logging/methodsCalledLogger';
 import { LocalizedError, registerGetLocalize } from '../chrome/utils/localization';
+import { SourceMapContents } from './sourceMapContents';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());
@@ -112,9 +113,9 @@ export class SourceMap {
      * generatedPath: an absolute local path or a URL
      * json: sourcemap contents as string
      */
-    public static async create(generatedPath: string, json: string, pathMapping?: IPathMapping,
+    public static async create(generatedPath: string, json: SourceMapContents, pathMapping?: IPathMapping,
         sourceMapPathOverrides?: utils.IStringDictionary<string>, isVSClient = false): Promise<SourceMap> {
-        const sourceMap: RawSourceMap = JSON.parse(json);
+        const sourceMap = json.parsed();
         logger.log(`SourceMap: creating for ${generatedPath}`);
         logger.log(`SourceMap: sourceRoot: ${sourceMap.sourceRoot}`);
         if (isNotEmpty(sourceMap.sourceRoot) && sourceMap.sourceRoot.toLowerCase() === '/source/') {

--- a/src/sourceMaps/sourceMapContents.ts
+++ b/src/sourceMaps/sourceMapContents.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+ import { PossiblyCustomerContent, CustomerContent } from '../chrome/logging/gdpr';
+import { RawSourceMap } from 'source-map';
+
+export class SourceMapContents {
+    private readonly _data: PossiblyCustomerContent<string>;
+
+    public constructor(data: string) {
+        this._data = new CustomerContent(data);
+    }
+
+    public parsed(): RawSourceMap {
+        const sourceMap: RawSourceMap = JSON.parse(this._data.customerContentData); // The only customer data propery is the sourcesContent property
+        delete sourceMap.sourcesContent; // We don't use sourcesContent. We delete it so that sourcesContent won't have any more customer data and it'll be safe to log, etc...
+        return sourceMap;
+    }
+}

--- a/src/sourceMaps/sourceMapUrl.ts
+++ b/src/sourceMaps/sourceMapUrl.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+ import { PossiblyCustomerContent, CustomerContent, NonCustomerContent } from '../chrome/logging/gdpr';
+import { logger } from 'vscode-debugadapter';
+import { SourceMapContents } from './sourceMapContents';
+
+export class SourceMapUrl {
+    private readonly _url: PossiblyCustomerContent<string>;
+    public readonly isInlineSourceMap: boolean;
+
+    public constructor(url: string) {
+        this.isInlineSourceMap = url.indexOf('data:application/json') >= 0;
+        this._url = this.isInlineSourceMap ? new CustomerContent(url) : new NonCustomerContent(url);
+    }
+
+    public static maybeUndefined(url: string | undefined): SourceMapUrl | undefined {
+        if (url) {
+            return new SourceMapUrl(url);
+        } else {
+            return undefined; // Convert '' to undefined
+        }
+    }
+
+    public get customerContentData(): string {
+        return this._url.customerContentData;
+    }
+
+    /**
+     * Parses sourcemap contents from inlined base64-encoded data
+     */
+    public inlineSourceMapContents(): SourceMapContents | null {
+        const firstCommaPos = this.customerContentData.indexOf(',');
+        if (firstCommaPos < 0) {
+            logger.log(`SourceMaps.getInlineSourceMapContents: Inline sourcemap is malformed.`);
+            return null;
+        }
+
+        const header = this.customerContentData.substr(0, firstCommaPos);
+        const data = this.customerContentData.substr(firstCommaPos + 1);
+
+        try {
+            if (header.indexOf(';base64') !== -1) {
+                const buffer = new Buffer(data, 'base64');
+                return new SourceMapContents(buffer.toString());
+            } else {
+                // URI encoded.
+                return new SourceMapContents(decodeURI(data));
+            }
+        } catch (e) {
+            logger.error(`SourceMaps.getInlineSourceMapContents: exception while processing data uri (${e.stack})`);
+        }
+
+        return null;
+    }
+}

--- a/src/sourceMaps/sourceMaps.ts
+++ b/src/sourceMaps/sourceMaps.ts
@@ -10,6 +10,7 @@ import { createLineNumber, createColumnNumber } from '../chrome/internal/locatio
 import { parseResourceIdentifier, IResourceIdentifier, newResourceIdentifierMap } from '../chrome/internal/sources/resourceIdentifier';
 import { CDTPScriptsRegistry } from '../chrome/cdtpDebuggee/registries/cdtpScriptsRegistry';
 import { isNotNull } from '../chrome/utils/typedOperators';
+import { SourceMapUrl } from './sourceMapUrl';
 
 export class SourceMaps {
     // Maps absolute paths to generated/authored source files to their corresponding SourceMap object
@@ -75,7 +76,7 @@ export class SourceMaps {
     /**
      * Given a new path to a new script file, finds and loads the sourcemap for that file
      */
-    public async processNewSourceMap(pathToGenerated: string, sourceMapURL: string, isVSClient = false): Promise<SourceMap | null> {
+    public async processNewSourceMap(pathToGenerated: string, sourceMapURL: SourceMapUrl, isVSClient = false): Promise<SourceMap | null> {
         const pathToGeneratedIdentifier = parseResourceIdentifier(pathToGenerated);
         const maybeSourceMap = this._generatedPathToSourceMap.tryGetting(pathToGeneratedIdentifier);
 

--- a/src/transformers/baseSourceMapTransformer.ts
+++ b/src/transformers/baseSourceMapTransformer.ts
@@ -15,10 +15,11 @@ import { inject, injectable } from 'inversify';
 import { IResourceIdentifier } from '..';
 import { LocationInLoadedSource } from '../chrome/internal/locations/location';
 import { CDTPScriptsRegistry } from '../chrome/cdtpDebuggee/registries/cdtpScriptsRegistry';
-import { isTrue, isDefined, isEmpty, isNotNull, isNull, isUndefined } from '../chrome/utils/typedOperators';
+import { isTrue, isDefined, isNotNull, isNull, isUndefined } from '../chrome/utils/typedOperators';
 import * as _ from 'lodash';
 import { parseResourceIdentifier, newResourceIdentifierSet } from '../chrome/internal/sources/resourceIdentifier';
 import { DoNotLog } from '../chrome/logging/decorators';
+import { SourceMapUrl } from '../sourceMaps/sourceMapUrl';
 
 export interface ISourceLocation {
     source: ILoadedSource;
@@ -75,11 +76,11 @@ export class BaseSourceMapTransformer {
     }
 
     @DoNotLog()
-    public async scriptParsed(pathToGenerated: string, sourceMapURL: string | undefined): Promise<SourceMap | null> {
+    public async scriptParsed(pathToGenerated: string, sourceMapURL: SourceMapUrl | undefined): Promise<SourceMap | null> {
         if (isDefined(this._sourceMaps)) {
             this._allRuntimeScriptPaths.addAndReplaceIfExists(parseResourceIdentifier(pathToGenerated));
 
-            if (isEmpty(sourceMapURL)) {
+            if (sourceMapURL === undefined) {
                 // We've seen some cases where Node.js doesn't return the SourceMapURL when the file has one. We use our
                 // cache in case we were able to read it with the EagerSourceMapReader
                 return _.defaultTo(this._sourceMaps.tryGettingSourceMapFromGeneratedPath(pathToGenerated), null);

--- a/src/transformers/eagerSourceMapTransformer.ts
+++ b/src/transformers/eagerSourceMapTransformer.ts
@@ -13,6 +13,8 @@ import { injectable, inject } from 'inversify';
 import { CDTPScriptsRegistry } from '../chrome/cdtpDebuggee/registries/cdtpScriptsRegistry';
 import { TYPES } from '../chrome/dependencyInjection.ts/types';
 import { isDefined, isNotEmpty, isNotNull, hasMatches } from '../chrome/utils/typedOperators';
+import { PossiblyCustomerContent } from '../chrome/logging/gdpr';
+import { SourceMapUrl } from '../sourceMaps/sourceMapUrl';
 
 /**
  * Load SourceMaps on launch. Requires reading the file and parsing out the sourceMappingURL, because
@@ -74,11 +76,7 @@ export class EagerSourceMapTransformer extends BaseSourceMapTransformer {
      * Try to find the 'sourceMappingURL' in content or the file with the given path.
      * Returns null if no source map url is found or if an error occured.
      */
-    private findSourceMapUrlInFile(pathToGenerated: string, content?: string): Promise<string | null> {
-        if (isNotEmpty(content)) {
-            return Promise.resolve(this.findSourceMapUrl(content));
-        }
-
+    private findSourceMapUrlInFile(pathToGenerated: string): Promise<SourceMapUrl | null> {
         return utils.readFileP(pathToGenerated)
             .then(fileContents => this.findSourceMapUrl(fileContents));
     }
@@ -88,13 +86,13 @@ export class EagerSourceMapTransformer extends BaseSourceMapTransformer {
      * Relative file paths are converted into absolute paths.
      * Returns null if no source map url is found.
      */
-    private findSourceMapUrl(contents: string): string | null {
-        const lines = contents.split('\n');
+    private findSourceMapUrl(contents: PossiblyCustomerContent<string>): SourceMapUrl | null {
+        const lines = contents.customerContentData.split('\n');
         for (let l = lines.length - 1; l >= Math.max(lines.length - 10, 0); l--) {    // only search for url in the last 10 lines
             const line = lines[l].trim();
             const matches = EagerSourceMapTransformer.SOURCE_MAPPING_MATCHER.exec(line);
             if (hasMatches(matches) && matches.length === 2) {
-                return matches[1].trim();
+                return new SourceMapUrl(matches[1].trim());
             }
         }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,7 @@ import { isDefined, hasMatches, hasNoMatches, isNotEmpty, isTrue, isEmpty } from
 import * as _ from 'lodash';
 import { InternalError } from './chrome/utils/internalError';
 import { LocalizedError } from './chrome/utils/localization';
+import { PossiblyCustomerContent, CustomerContent } from './chrome/logging/gdpr';
 
 export interface IStringDictionary<T> {
     [name: string]: T;
@@ -333,8 +334,8 @@ export function fsReadDirP(path: string): Promise<string[]> {
     return promisify(fs.readdir)(path);
 }
 
-export function readFileP(path: string, encoding = 'utf8'): Promise<string> {
-    return promisify(fs.readFile)(path, encoding);
+export function readFileP(path: string, encoding = 'utf8'): Promise<PossiblyCustomerContent<string>> {
+    return CustomerContent.fromAsync(promisify(fs.readFile)(path, encoding));
 }
 
 export async function writeFileP(filePath: string, data: string): Promise<void> {

--- a/test/v2/gdpr.test.ts
+++ b/test/v2/gdpr.test.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+ import { CustomerContent } from '../../src/chrome/logging/gdpr';
+import * as assert from 'assert';
+import * as util from 'util';
+
+suite('PII', () => {
+    const someCustomerContent = 'Customer content';
+    const piiObject = new CustomerContent(someCustomerContent);
+
+    function assertDoesNotContainPII(strignified: string) {
+        assert.equal(strignified.indexOf(someCustomerContent), -1);
+    }
+
+    test(`JSON.stringify doesn't reveal PII`, () => {
+        assertDoesNotContainPII(JSON.stringify(piiObject));
+    });
+
+    test(`util.inspect doesn't reveal PII`, () => {
+        assertDoesNotContainPII(util.inspect(piiObject));
+    });
+
+    test(`getPIIData retrieves PII`, () => {
+        assert.equal(piiObject.customerContentData, someCustomerContent);
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
         "src/**/*.ts",
         "test/testDebug/**/*.ts",
         "test-DoNot-/**/*.ts",
+        "test/v2/**/*.ts",
         "node_modules/@types/**/*.ts"
     ]
 }


### PR DESCRIPTION
Updated the code to store customer content in the CustomerContent class. The most important part of this change is that JSON.stringify(new CustomerContent()) won't contain the customer CustomerContent

Replaced several uses of string for a specifically designed class. Also moved into those classes some code that processed the possibly customer data:
    * SourceMapUrl
    * SourceContents
    * SourceMapContents 
   