### PR TITLE
Do not print sourcemap url with inline source maps

### DIFF
--- a/src/chrome/chromeConnection.ts
+++ b/src/chrome/chromeConnection.ts
@@ -26,6 +26,7 @@ import { ITelemetryPropertyCollector } from '../telemetry';
 import { isDefined } from './utils/typedOperators';
 import { InternalError } from './utils/internalError';
 import { LocalizedError, registerGetLocalize } from './utils/localization';
+import * as _ from 'lodash';
 
 let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());
@@ -77,6 +78,10 @@ class LoggingSocket extends WebSocket {
                 if ((msgObj.result && msgObj.result.scriptSource)) {
                     // If this message contains the source of a script, we log everything but the source
                     msgObj.result.scriptSource = '<removed script source for logs>';
+                    logger.log('← From target: ' + JSON.stringify(msgObj));
+                } else if ((_.get(msgObj, 'params.sourceMapURL', '').startsWith('data:application/json'))) {
+                    // If this message contains a source map url, we log everything else
+                    msgObj.params.sourceMapURL = '<removed source map url for logs>';
                     logger.log('← From target: ' + JSON.stringify(msgObj));
                 } else {
                     logger.log('← From target: ' + msgStr);

--- a/src/chrome/client/eventsToClientReporter.ts
+++ b/src/chrome/client/eventsToClientReporter.ts
@@ -102,7 +102,7 @@ export class EventsToClientReporter implements IEventsToClientReporter {
 
     @DoNotLog()
     public sendCustomerContentOutput(params: ICustomerContentOutputParameters): void {
-        const event = new OutputEvent(params.output.customerContentData, params.category) as DebugProtocol.OutputEvent;
+        const event = new OutputEvent(params.output.customerContentData, params.category, { doNotLogOutput: true }) as DebugProtocol.OutputEvent;
         this._session.sendEvent(event);
     }
 


### PR DESCRIPTION
Now we won't log the sourceMapURL for inline source-maps, and we won't log the output when we are sending an output that might contain customer content.

This change depends on this PR: https://github.com/microsoft/vscode-debugadapter-node/pull/218