### PR TITLE
Now we can retrieve dynamic html while paused.

### DIFF
--- a/src/chrome/cdtpDebuggee/eventsProviders/cdtpExecutionContextEventsProvider.ts
+++ b/src/chrome/cdtpDebuggee/eventsProviders/cdtpExecutionContextEventsProvider.ts
@@ -10,9 +10,11 @@ import { CDTPScriptsRegistry } from '../registries/cdtpScriptsRegistry';
 import { TYPES } from '../../dependencyInjection.ts/types';
 import { CDTPDomainsEnabler } from '../infrastructure/cdtpDomainsEnabler';
 import { FrameId } from '../cdtpPrimitives';
+import { IExecutionContext } from '../../internal/scripts/executionContext';
 
 export interface IExecutionContextEventsProvider {
     onExecutionContextsCleared(listener: (args: void) => void): void;
+    onExecutionContextCreated(listener: (executionContext: IExecutionContext) => void): void;
 }
 
 @injectable()

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ import { ISourceToClientConverter } from './chrome/client/sourceToClientConverte
 import { IEventsToClientReporter } from './chrome/client/eventsToClientReporter';
 import { UserPageLaunchedError } from './chrome/client/clientLifecycleRequestsHandler';
 import { SourceContents } from './chrome/internal/sources/sourceContents';
+import { IExecutionContextEventsProvider } from './chrome/cdtpDebuggee/eventsProviders/cdtpExecutionContextEventsProvider';
 
 export {
     chromeConnection,
@@ -226,5 +227,7 @@ export {
 
     ExecutionTimingsReporter,
 
-    SourceContents
+    SourceContents,
+
+    IExecutionContextEventsProvider
 };


### PR DESCRIPTION
Export onExecutionContextCreated so we can fix the issue of retrieving dynamic html code while paused on this PR: https://github.com/microsoft/vscode-chrome-debug/pull/925