### PR TITLE
Now we don't send sourceReference if we can't retrieve the source

### DIFF
--- a/src/chrome/cdtpDebuggee/cdtpDIContainer.ts
+++ b/src/chrome/cdtpDebuggee/cdtpDIContainer.ts
@@ -28,8 +28,9 @@ import { TYPES } from '../dependencyInjection.ts/types';
 import { interfaces } from 'inversify';
 import { DependencyInjection } from '../dependencyInjection.ts/di';
 import { CDTPNetworkCacheConfigurer } from './features/cdtpNetworkCacheConfigurer';
+import { getSourceTextRetrievability } from '../internal/sources/sourceTextRetriever';
 
-const exportedIdentifierToClassMapping = new ValidatedMap<symbol, interfaces.Newable<any>>([
+const exportedIdentifierToClassMapping = new ValidatedMap<symbol, interfaces.Newable<any> | Function>([
     [TYPES.IDebuggeeExecutionController, CDTPDebuggeeExecutionController],
     [TYPES.IDebuggeeStateInspector, CDTPDebuggeeStateInspector],
     [TYPES.IUpdateDebuggeeState, CDTPDebuggeeStateSetter],
@@ -40,6 +41,7 @@ const exportedIdentifierToClassMapping = new ValidatedMap<symbol, interfaces.New
     [TYPES.IDOMInstrumentationBreakpointsSetter, CDTPDOMInstrumentationBreakpointsSetter],
     [TYPES.IAsyncDebuggingConfiguration, CDTPAsyncDebuggingConfigurer],
     [TYPES.IScriptSources, CDTPScriptSourcesRetriever],
+    [TYPES.GetSourceTextRetrievability, getSourceTextRetrievability],
     [TYPES.CDTPScriptsRegistry, CDTPScriptsRegistry],
     [TYPES.IPauseOnExceptions, CDTPPauseOnExceptionsConfigurer],
     [TYPES.IBreakpointFeaturesSupport, CDTPBreakpointFeaturesSupport],

--- a/src/chrome/dependencyInjection.ts/bind.ts
+++ b/src/chrome/dependencyInjection.ts/bind.ts
@@ -43,6 +43,7 @@ import { CompletionsRequestHandler } from '../internal/completions/completionsRe
 import { SourceToClientConverter } from '../client/sourceToClientConverter';
 import { NotifyClientOfLoadedSources } from '../internal/sources/features/notifyClientOfLoadedSources';
 import { logger } from 'vscode-debugadapter';
+import { SourceTextRetriever } from '../internal/sources/sourceTextRetriever';
 
 // TODO: This file needs a lot of work. We need to improve/simplify all this code when possible
 interface IHasContainerName {
@@ -55,6 +56,7 @@ export function bindAll(loggingConfiguration: MethodsCalledLoggerConfiguration, 
     bind(loggingConfiguration, di, TYPES.IEventsToClientReporter, EventsToClientReporter, callback);
     bind(loggingConfiguration, di, TYPES.ChromeDebugLogic, ChromeDebugLogic, callback);
     bind(loggingConfiguration, di, TYPES.ISourcesRetriever, SourcesRetriever, callback);
+    bind(loggingConfiguration, di, TYPES.ISourceTextRetriever, SourceTextRetriever, callback);
     bind(loggingConfiguration, di, TYPES.SourceToClientConverter, SourceToClientConverter, callback);
 
     bind(loggingConfiguration, di, TYPES.StackTracesLogic, StackTracePresenter, callback);
@@ -105,7 +107,10 @@ export function createWrapWithLoggerActivator<T extends object>(configuration: M
     serviceIdentifier: interfaces.ServiceIdentifier<T>,
     callback?: ComponentCustomizationCallback): (context: interfaces.Context, injectable: T) => T {
     return (_context: interfaces.Context, injectable: T) => {
-        (<IHasContainerName>injectable).__containerName = configuration.containerName;
+        if (!(typeof injectable === 'number')) {
+            (<IHasContainerName>injectable).__containerName = configuration.containerName;
+        }
+
         const objectWithLogging = wrapWithLogging(configuration, injectable, `${configuration.containerName}.${getName(serviceIdentifier)}`);
         const possibleOverwrittenComponent = isDefined(callback)
             ? callback(serviceIdentifier, objectWithLogging, identifier => _context.container.get(identifier))

--- a/src/chrome/dependencyInjection.ts/types.ts
+++ b/src/chrome/dependencyInjection.ts/types.ts
@@ -3,6 +3,7 @@
  *--------------------------------------------------------*/
 
 import 'reflect-metadata';
+import { interfaces } from 'inversify';
 
 // TODO: Add all necesary types so we can use inversifyjs to create our components
 const TYPES = {
@@ -25,6 +26,8 @@ const TYPES = {
     IDebuggeeLauncher: Symbol.for('IDebuggeeLauncher'),
     ChromeDebugLogic: Symbol.for('ChromeDebugLogic'),
     ISourcesRetriever: Symbol.for('ISourcesRetriever'),
+    ISourceTextRetriever: Symbol.for('ISourceTextRetriever'),
+    GetSourceTextRetrievability: Symbol.for('GetSourceTextRetrievability'),
     CDTPScriptsRegistry: Symbol.for('CDTPScriptsRegistry'),
     ClientToInternal: Symbol.for('ClientToInternal'),
     InternalToClient: Symbol.for('InternalToClient'),
@@ -79,5 +82,11 @@ const TYPES = {
     IClientCapabilities: Symbol.for('IClientCapabilities'),
     IServiceComponent: Symbol.for('IServiceComponent'),
 };
+
+const valueComponents = new Set<interfaces.ServiceIdentifier<unknown>>([TYPES.GetSourceTextRetrievability]);
+
+export function isValueComponent(componentIdentifier: interfaces.ServiceIdentifier<unknown>): boolean {
+    return valueComponents.has(componentIdentifier);
+}
 
 export { TYPES };

--- a/src/chrome/internal/scripts/IHasSourceMappingInformation.ts
+++ b/src/chrome/internal/scripts/IHasSourceMappingInformation.ts
@@ -1,6 +1,6 @@
 import { IdentifiedLoadedSource } from '../sources/identifiedLoadedSource';
 import { Position } from '../locations/location';
-import { ILoadedSource } from '../../..';
+import { ILoadedSource } from '../sources/loadedSource';
 
 export interface IHasSourceMappingInformation {
     readonly mappedSources: IdentifiedLoadedSource[]; // Sources before compilation

--- a/src/chrome/internal/sources/sourceTextRetriever.ts
+++ b/src/chrome/internal/sources/sourceTextRetriever.ts
@@ -20,15 +20,39 @@ let localize = nls.loadMessageBundle();
 registerGetLocalize(() => localize = nls.loadMessageBundle());
 import { SourceContents } from './sourceContents';
 
+export interface IPossiblyRetrievableText {
+    isRetrievable: boolean;
+
+    retrieve(): Promise<SourceContents>;
+}
+
+export class RetrievableText implements IPossiblyRetrievableText {
+    public readonly isRetrievable = true;
+
+    public constructor(public readonly retrieve: () => Promise<SourceContents>) { }
+}
+
+export class NonRetrievableText implements IPossiblyRetrievableText {
+    public readonly isRetrievable = false;
+
+    public constructor(public readonly retrieve: () => never) { }
+}
+
+export interface ISourceTextRetriever {
+    text(source: ILoadedSource): Promise<SourceContents>;
+    retrievability(source: ILoadedSource): IPossiblyRetrievableText;
+}
+
 /**
  * Retrieves the text associated with a loaded source that maps to a JavaScript script file
  * (If the loaded source maps to an .html file or something different than a single script, a different class/API will need to be used)
  */
 @injectable()
-export class SourceTextRetriever {
+export class SourceTextRetriever implements ISourceTextRetriever {
     private _sourceToText = new ValidatedMap<ILoadedSource, Promise<SourceContents>>();
 
-    constructor(@inject(TYPES.IScriptSources) private readonly _scriptSources: IScriptSourcesRetriever) { }
+    constructor(@inject(TYPES.IScriptSources) private readonly _scriptSources: IScriptSourcesRetriever,
+        @inject(TYPES.GetSourceTextRetrievability) private readonly _retrievability: GetSourceTextRetrievability) {}
 
     // We want this method to add an entry to the map this._sourceToText atomically, so if we get 2 simultaneous calls,
     // the second call will return the promise/result of the first call
@@ -36,31 +60,51 @@ export class SourceTextRetriever {
         let text = this._sourceToText.tryGetting(loadedSource);
 
         if (text === undefined) {
-            const scripts = loadedSource.scriptMapper().scripts;
-            if (loadedSource.sourceScriptRelationship === SourceScriptRelationship.SourceIsSingleScript && scripts.length === 1) {
-                text = this._scriptSources.getScriptSource(singleElementOfArray(scripts));
-            } else if (loadedSource.sourceScriptRelationship === SourceScriptRelationship.SourceIsSingleScript && scripts.length >= 2) {
-                /**
-                 * We have two scripts associated with this source. At the moment we don't have any further support for this scenario
-                 * so we just return the source of the first script. This won't be ideal if for some reason the source of both scripts
-                 * isn't the same.
-                 */
-                logger.warn(`${loadedSource} is associated with several ${printArray('scripts', scripts)} returning the source arbitrarily of the first one`);
-                text = this._scriptSources.getScriptSource(scripts[0]);
-            } else if (loadedSource.contentsLocation === ContentsLocation.PersistentStorage) {
-                // If this is a file, we don't want to cache it, so we return the contents immediately
-                return utils.readFileP(loadedSource.identifier.textRepresentation);
-            } else {
-                // We'll need to figure out what is the right thing to do for SourceScriptRelationship.Unknown
-                throw new LocalizedError('error.sourceText.multipleScriptsNotSupported', localize('error.sourceText.multipleScriptsNotSupported', "Support for getting the text from dynamic sources that have multiple scripts embedded hasn't been implemented yet"));
-            }
+            const sourceRetrievability = this._retrievability(this._scriptSources, loadedSource);
+            text = sourceRetrievability.retrieve();
             this._sourceToText.set(loadedSource, text);
         }
 
         return text;
     }
 
+    public retrievability(source: ILoadedSource): IPossiblyRetrievableText {
+        return this._retrievability(this._scriptSources, source);
+    }
+
     public toString(): string {
         return `Sources text logic\n${printIterable('sources in cache', this._sourceToText.keys())}`;
+    }
+}
+
+export type GetSourceTextRetrievability = (scriptSources: IScriptSourcesRetriever, loadedSource: ILoadedSource) => IPossiblyRetrievableText;
+
+// We use the retrievability instead of the text method to figure out if a loadedSource that we'll send to the client
+// is retrievable, and thus, if it should include a sourceReference in it or not
+export function getSourceTextRetrievability(scriptSources: IScriptSourcesRetriever, loadedSource: ILoadedSource): IPossiblyRetrievableText {
+    const scripts = loadedSource.scriptMapper().scripts;
+    if (loadedSource.sourceScriptRelationship === SourceScriptRelationship.SourceIsSingleScript && scripts.length === 1) {
+        const singleScript = singleElementOfArray(scripts);
+        return new RetrievableText(() => scriptSources.getScriptSource(singleScript));
+    } else if (loadedSource.sourceScriptRelationship === SourceScriptRelationship.SourceIsSingleScript && scripts.length >= 2) {
+        /**
+         * We have two or more scripts associated with this source. At the moment we don't have any further support for this scenario
+         * so we just return the source of the first script. This won't be ideal if for some reason the source of both scripts
+         * isn't the same.
+         */
+        logger.warn(`${loadedSource} is associated with several ${printArray('scripts', scripts)} returning arbitrarily the source of the first one`);
+        const singleScript = scripts[0];
+        return new RetrievableText(() => scriptSources.getScriptSource(singleScript));
+    } else if (loadedSource.contentsLocation === ContentsLocation.PersistentStorage) {
+        // If this is a file, we don't want to cache it, so we return the contents immediately
+        return new RetrievableText(() => utils.readFileP(loadedSource.identifier.textRepresentation));
+    } else {
+        logger.error(`Unexpected source relationship: ${loadedSource} sourceScriptRelationship = ${loadedSource.sourceScriptRelationship}. #scripts = ${scripts.length}`);
+
+        // We'll need to figure out what is the right thing to do for SourceScriptRelationship.Unknown
+        return new NonRetrievableText(() => {
+            throw new LocalizedError('error.sourceText.multipleScriptsNotSupported', localize('error.sourceText.multipleScriptsNotSupported',
+                "Support for getting the text from dynamic sources that have multiple scripts embedded hasn't been implemented yet"));
+        });
     }
 }

--- a/src/chrome/internal/sources/sourceTextRetriever.ts
+++ b/src/chrome/internal/sources/sourceTextRetriever.ts
@@ -92,9 +92,11 @@ export function getSourceTextRetrievability(scriptSources: IScriptSourcesRetriev
          * so we just return the source of the first script. This won't be ideal if for some reason the source of both scripts
          * isn't the same.
          */
-        logger.warn(`${loadedSource} is associated with several ${printArray('scripts', scripts)} returning arbitrarily the source of the first one`);
-        const singleScript = scripts[0];
-        return new RetrievableText(() => scriptSources.getScriptSource(singleScript));
+        return new RetrievableText(() => {
+            logger.warn(`${loadedSource} is associated with several ${printArray('scripts', scripts)} returning arbitrarily the source of the first one`);
+            const singleScript = scripts[0];
+                return scriptSources.getScriptSource(singleScript);
+        });
     } else if (loadedSource.contentsLocation === ContentsLocation.PersistentStorage) {
         // If this is a file, we don't want to cache it, so we return the contents immediately
         return new RetrievableText(() => utils.readFileP(loadedSource.identifier.textRepresentation));

--- a/src/chrome/internal/sources/sourcesRetriever.ts
+++ b/src/chrome/internal/sources/sourcesRetriever.ts
@@ -2,25 +2,27 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { SourceTextRetriever } from './sourceTextRetriever';
+import { IPossiblyRetrievableText, ISourceTextRetriever } from './sourceTextRetriever';
 import { LoadedSourcesTreeRetriever } from './loadedSourcesTreeRetriever';
-import { ILoadedSourceTreeNode } from './loadedSource';
+import { ILoadedSourceTreeNode, ILoadedSource } from './loadedSource';
 import { ISource } from './source';
 import { IScript } from '../scripts/script';
-import { injectable } from 'inversify';
+import { injectable, inject } from 'inversify';
 import { InternalError } from '../../utils/internalError';
 import { SourceContents } from './sourceContents';
+import { TYPES } from '../../dependencyInjection.ts/types';
 
 export interface ISourcesRetriever {
     loadedSourcesTrees(): Promise<ILoadedSourceTreeNode[]>;
     loadedSourcesTreeForScript(script: IScript): ILoadedSourceTreeNode;
     text(source: ISource): Promise<SourceContents>;
+    retrievability(loadedSource: ILoadedSource): IPossiblyRetrievableText;
 }
 
 @injectable()
 export class SourcesRetriever implements ISourcesRetriever {
     constructor(
-        private readonly _sourceTextRetriever: SourceTextRetriever,
+        @inject(TYPES.ISourceTextRetriever) private readonly _sourceTextRetriever: ISourceTextRetriever,
         private readonly _sourceTreeNodeLogic: LoadedSourcesTreeRetriever) {
     }
 
@@ -38,6 +40,10 @@ export class SourcesRetriever implements ISourcesRetriever {
             identifier => {
                 throw new InternalError('error.source.cantResolve', `Couldn't resolve the source with the path: ${identifier.textRepresentation}`);
             });
+    }
+
+    public retrievability(loadedSource: ILoadedSource): IPossiblyRetrievableText {
+        return this._sourceTextRetriever.retrievability(loadedSource);
     }
 
     public toString(): string {

--- a/src/chrome/logging/methodsCalledLogger.ts
+++ b/src/chrome/logging/methodsCalledLogger.ts
@@ -61,6 +61,10 @@ export class MethodsCalledLogger<T extends object> {
     }
 
     public wrapped(): T {
+        if (typeof this._objectToWrap === 'number') {
+            return this._objectToWrap;
+        }
+
         const handler = {
             get: <K extends keyof T>(target: T, propertyKey: K, receiver: any) => {
                 const originalPropertyValue = target[propertyKey];

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ import { IDebuggeeRuntimeVersionProvider, CDTPComponentsVersions } from './chrom
 import { IBrowserNavigator } from './chrome/cdtpDebuggee/features/cdtpBrowserNavigator';
 import { ISourcesRetriever } from './chrome/internal/sources/sourcesRetriever';
 import { ISource } from './chrome/internal/sources/source';
-import { ILoadedSourceTreeNode, SourceScriptRelationship, ILoadedSource } from './chrome/internal/sources/loadedSource';
+import { ILoadedSourceTreeNode, SourceScriptRelationship, ILoadedSource, ContentsLocation } from './chrome/internal/sources/loadedSource';
 import { IScript } from './chrome/internal/scripts/script';
 import * as utilities from './chrome/collections/utilities';
 import { CDTPDomainsEnabler } from './chrome/cdtpDebuggee/infrastructure/cdtpDomainsEnabler';
@@ -77,6 +77,8 @@ import { IEventsToClientReporter } from './chrome/client/eventsToClientReporter'
 import { UserPageLaunchedError } from './chrome/client/clientLifecycleRequestsHandler';
 import { SourceContents } from './chrome/internal/sources/sourceContents';
 import { IExecutionContextEventsProvider } from './chrome/cdtpDebuggee/eventsProviders/cdtpExecutionContextEventsProvider';
+import { IPossiblyRetrievableText, RetrievableText, NonRetrievableText, ISourceTextRetriever, GetSourceTextRetrievability } from './chrome/internal/sources/sourceTextRetriever';
+import { IScriptSourcesRetriever } from './chrome/cdtpDebuggee/features/cdtpScriptSourcesRetriever';
 
 export {
     chromeConnection,
@@ -232,6 +234,20 @@ export {
     ICommandHandlerDeclaration,
 
     CommandHandlerDeclaration,
-  
-    IExecutionContextEventsProvider
+
+    IExecutionContextEventsProvider,
+
+    IPossiblyRetrievableText,
+
+    RetrievableText,
+
+    NonRetrievableText,
+
+    ContentsLocation,
+
+    ISourceTextRetriever,
+
+    GetSourceTextRetrievability,
+
+    IScriptSourcesRetriever,
 };

--- a/src/sourceMaps/sourceMapUtils.ts
+++ b/src/sourceMaps/sourceMapUtils.ts
@@ -9,8 +9,7 @@ import { logger } from 'vscode-debugadapter';
 import * as chromeUtils from '../chrome/chromeUtils';
 import * as utils from '../utils';
 import { ISourceMapPathOverrides, IPathMapping } from '../debugAdapterInterfaces';
-import { IResourceIdentifier } from '..';
-import { parseResourceIdentifier } from '../chrome/internal/sources/resourceIdentifier';
+import { parseResourceIdentifier, IResourceIdentifier } from '../chrome/internal/sources/resourceIdentifier';
 import { isNotEmpty, hasNoMatches, isEmpty, defaultWhenEmpty } from '../chrome/utils/typedOperators';
 import * as _ from 'lodash';
 

--- a/src/transformers/baseSourceMapTransformer.ts
+++ b/src/transformers/baseSourceMapTransformer.ts
@@ -12,12 +12,11 @@ import { logger } from 'vscode-debugadapter';
 import { ILoadedSource } from '../chrome/internal/sources/loadedSource';
 import { TYPES } from '../chrome/dependencyInjection.ts/types';
 import { inject, injectable } from 'inversify';
-import { IResourceIdentifier } from '..';
 import { LocationInLoadedSource } from '../chrome/internal/locations/location';
 import { CDTPScriptsRegistry } from '../chrome/cdtpDebuggee/registries/cdtpScriptsRegistry';
 import { isTrue, isDefined, isNotNull, isNull, isUndefined } from '../chrome/utils/typedOperators';
 import * as _ from 'lodash';
-import { parseResourceIdentifier, newResourceIdentifierSet } from '../chrome/internal/sources/resourceIdentifier';
+import { parseResourceIdentifier, newResourceIdentifierSet, IResourceIdentifier } from '../chrome/internal/sources/resourceIdentifier';
 import { DoNotLog } from '../chrome/logging/decorators';
 import { SourceMapUrl } from '../sourceMaps/sourceMapUrl';
 


### PR DESCRIPTION
Before this change we were sending sourceReference for sources we couldn't find the source for. This PR addresses that issue.
As an experiment, we implemented this change by inserting a function instead of a class like we normally do. We added some support to be able to do that.

* src/chrome/cdtpDebuggee/cdtpDIContainer.ts:
  - Exported getSourceTextRetrievability so it can be customized by chrome-debug

* src/chrome/client/sourceToClientConverter.ts:
  - Only include sourceReferences for sources we can actually get the source for...

* src/chrome/dependencyInjection.ts/bind.ts:
  - Don't modify injectables that are numbers

* src/chrome/dependencyInjection.ts/di.ts:
  - Add support for injecting functions instead of classes
  - Pass _componentCustomizationCallback to find places where we should've been passing it already

* src/chrome/dependencyInjection.ts/types.ts:
  - Add isValueComponent to identify if an identifier is a class or a value

* src/chrome/internal/sources/sourceTextRetriever.ts:
  - Refactor the text logic to create the getSourceTextRetrievability functions

* src/chrome/logging/methodsCalledLogger.ts:
  - Don't try to wrap numbers in a proxy

This change won't compile with a required change in chrome-debug: 
https://github.com/microsoft/vscode-chrome-debug/pull/930