### PR TITLE
Update to vscode-debugadapter with don't print source fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6880,18 +6880,18 @@
       }
     },
     "vscode-debugadapter": {
-      "version": "1.33.0-pre.2",
-      "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.33.0-pre.2.tgz",
-      "integrity": "sha512-H5J1YTjsuiBmdnjl/zvrSTNClfcoz/i4tWDoxvW4FEE3jEfhW2npapiwJkLuzVFnv7tlU0iiJzqhv2iYwBFZoA==",
+      "version": "1.36.1",
+      "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.36.1.tgz",
+      "integrity": "sha512-9mFiqno0h8p7zTxYM06VdE3f6DnenqxhDWB/WG6ca7aKIY/kzFFkvohsfRtgDl9iPR17a4a/GgB/mruPKe1T/A==",
       "requires": {
         "mkdirp": "^0.5.1",
-        "vscode-debugprotocol": "1.32.0"
+        "vscode-debugprotocol": "1.36.0"
       },
       "dependencies": {
         "vscode-debugprotocol": {
-          "version": "1.32.0",
-          "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.32.0.tgz",
-          "integrity": "sha512-x3+HV+BkLqfl1ZuDJEILAv1sT5mDceuPThDXD12hwXAEjAdfc6MLQFvaoVPuO6C6gb+lHQTd0R9FNkCflEJHbA=="
+          "version": "1.36.0",
+          "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.36.0.tgz",
+          "integrity": "sha512-F0MfcUkF88TfNf4iQbcmC+K9rA+zsrQpEz1XpTKidy5sMq8sYsJGUadYDGmmktfjRX+S/ebjHgM+YV/2qm6lVQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "reflect-metadata": "^0.1.13",
     "semver": "^5.6.0",
     "source-map": "^0.7.3",
-    "vscode-debugadapter": "^1.33.0-pre.2",
+    "vscode-debugadapter": "^1.36.1",
     "vscode-debugprotocol": "^1.32.0",
     "vscode-nls": "^4.0.0",
     "vscode-uri": "^1.0.6",


### PR DESCRIPTION
Update to vscode-debugadapter with don't print source fix