### PR TITLE
fix compile error with typescript 3.7.2

### DIFF
--- a/src/sourceMaps/sourceMap.ts
+++ b/src/sourceMaps/sourceMap.ts
@@ -2,7 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { SourceMapConsumer, MappedPosition } from 'source-map';
+import { SourceMapConsumer, MappedPosition as MappedPositionSM } from 'source-map';
 import * as path from 'path';
 
 import * as sourceMapUtils from './sourceMapUtils';
@@ -10,7 +10,7 @@ import * as utils from '../utils';
 import { logger } from 'vscode-debugadapter';
 import { IPathMapping } from '../debugAdapterInterfaces';
 
-export type MappedPosition = MappedPosition;
+export type MappedPosition = MappedPositionSM;
 
 /**
  * A pair of the original path in the sourcemap, and the full absolute path as inferred


### PR DESCRIPTION
Closes #537

This keeps the semantics of the export while fixing the compile issue seen when using TypeScript@3.7.2