### PR TITLE
Added additional exception handling for environments that are not support getPossibleBreakpoints requests

### DIFF
--- a/src/chrome/breakpoints.ts
+++ b/src/chrome/breakpoints.ts
@@ -333,21 +333,27 @@ export class Breakpoints {
                     { scriptId: script.scriptId, lineNumber: args.endLine, columnNumber: args.endColumn || 0 } :
                     { scriptId: script.scriptId, lineNumber: args.line + 1, columnNumber: 0 };
 
-                const possibleBpResponse = await this.chrome.Debugger.getPossibleBreakpoints({
-                    start: { scriptId: script.scriptId, lineNumber: args.line, columnNumber: args.column || 0 },
-                    end,
-                    restrictToFunction: false
-                });
-                let breakpoints = possibleBpResponse.locations.map(loc => {
-                    return <DebugProtocol.Breakpoint>{
-                        line: loc.lineNumber,
-                        column: loc.columnNumber
-                    };
-                });
-                breakpoints = this.adapter.sourceMapTransformer.setBreakpointsResponse(breakpoints, false, requestSeq);
-                const response = { breakpoints };
-                this.adapter.lineColTransformer.setBreakpointsResponse(response);
-                return response as DebugProtocol.BreakpointLocationsResponse['body'];
+                try {
+                    const possibleBpResponse = await this.chrome.Debugger.getPossibleBreakpoints({
+                        start: { scriptId: script.scriptId, lineNumber: args.line, columnNumber: args.column || 0 },
+                        end,
+                        restrictToFunction: false
+                    });
+                    let breakpoints = possibleBpResponse.locations.map(loc => {
+                        return <DebugProtocol.Breakpoint>{
+                            line: loc.lineNumber,
+                            column: loc.columnNumber
+                        };
+                    });
+                    breakpoints = this.adapter.sourceMapTransformer.setBreakpointsResponse(breakpoints, false, requestSeq);
+                    const response = { breakpoints };
+                    this.adapter.lineColTransformer.setBreakpointsResponse(response);
+                    return response as DebugProtocol.BreakpointLocationsResponse['body'];
+                } catch (e) {
+                    // getPossibleBPs not supported
+                    logger.log('breakpointsLocations failed: ' + e.message);
+                    return { breakpoints: [] };
+                }
             }
         }
 

--- a/src/chrome/breakpoints.ts
+++ b/src/chrome/breakpoints.ts
@@ -333,12 +333,12 @@ export class Breakpoints {
                     { scriptId: script.scriptId, lineNumber: args.endLine, columnNumber: args.endColumn || 0 } :
                     { scriptId: script.scriptId, lineNumber: args.line + 1, columnNumber: 0 };
 
-                try {
-                    const possibleBpResponse = await this.chrome.Debugger.getPossibleBreakpoints({
-                        start: { scriptId: script.scriptId, lineNumber: args.line, columnNumber: args.column || 0 },
-                        end,
-                        restrictToFunction: false
-                    });
+                const possibleBpResponse = await this.chrome.Debugger.getPossibleBreakpoints({
+                    start: { scriptId: script.scriptId, lineNumber: args.line, columnNumber: args.column || 0 },
+                    end,
+                    restrictToFunction: false
+                });
+                if (possibleBpResponse.locations) {
                     let breakpoints = possibleBpResponse.locations.map(loc => {
                         return <DebugProtocol.Breakpoint>{
                             line: loc.lineNumber,
@@ -349,9 +349,7 @@ export class Breakpoints {
                     const response = { breakpoints };
                     this.adapter.lineColTransformer.setBreakpointsResponse(response);
                     return response as DebugProtocol.BreakpointLocationsResponse['body'];
-                } catch (e) {
-                    // getPossibleBPs not supported
-                    logger.log('breakpointsLocations failed: ' + e.message);
+                } else {
                     return { breakpoints: [] };
                 }
             }


### PR DESCRIPTION
This PR forces `getBreakpointsLocation` function to swallow error messages in cases if environment doesn't support `getPossibleBreakpoints` request.
Fixes #534 