### PR TITLE
Added exception handlers for React Native Hermes debugging

### DIFF
--- a/src/chrome/variables.ts
+++ b/src/chrome/variables.ts
@@ -269,7 +269,7 @@ export function getRemoteObjectPreview_primitive(object: Crdp.Runtime.RemoteObje
     } else if (object.type === 'number') {
         // .value is truncated, so use .description, the full string representation
         // Should be like '3' or 'Infinity'.
-        return object.description;
+        return object.description || '' + object.value;
     } else if (object.type === 'boolean') {
         // Never stringified
         return '' + object.value;
@@ -367,14 +367,19 @@ export function createFunctionVariable(name: string,
                                 parentEvaluateName?: string): DebugProtocol.Variable {
 
     let value: string;
-    const firstBraceIdx = object.description.indexOf('{');
-    if (firstBraceIdx >= 0) {
-        value = object.description.substring(0, firstBraceIdx) + '{ … }';
+
+    if (object.description) {
+        const firstBraceIdx = object.description.indexOf('{');
+        if (firstBraceIdx >= 0) {
+            value = object.description.substring(0, firstBraceIdx) + '{ … }';
+        } else {
+            const firstArrowIdx = object.description.indexOf('=>');
+            value = firstArrowIdx >= 0 ?
+                object.description.substring(0, firstArrowIdx + 2) + ' …' :
+                object.description;
+        }
     } else {
-        const firstArrowIdx = object.description.indexOf('=>');
-        value = firstArrowIdx >= 0 ?
-            object.description.substring(0, firstArrowIdx + 2) + ' …' :
-            object.description;
+        value = 'function() { … }';
     }
 
     const evaluateName = ChromeUtils.getEvaluateName(parentEvaluateName, name);

--- a/src/chrome/variablesManager.ts
+++ b/src/chrome/variablesManager.ts
@@ -307,13 +307,18 @@ export class VariablesManager {
             if (response.exceptionDetails) {
                 const errMsg = ChromeUtils.errorMessageFromExceptionDetails(response.exceptionDetails);
                 return Promise.reject<IPropCount>(errors.errorFromEvaluate(errMsg));
-            } else {
+            } else if (response.result) {
                 const resultProps = response.result.value;
                 if (resultProps.length !== 2) {
                     return Promise.reject<IPropCount>(errors.errorFromEvaluate('Did not get expected props, got ' + JSON.stringify(resultProps)));
                 }
 
                 return { indexedVariables: resultProps[0], namedVariables: resultProps[1] };
+            } else {
+                return {
+                    indexedVariables: undefined,
+                    namedVariables: undefined
+                };
             }
         },
         error => Promise.reject<IPropCount>(errors.errorFromEvaluate(error.message)));

--- a/test/chrome/variables.test.ts
+++ b/test/chrome/variables.test.ts
@@ -135,6 +135,81 @@ suite('Variables', () => {
         });
     });
 
+    suite('createFunctionVariable()', () => {
+
+        const _variableHandles = new Variables.VariableHandles()
+
+        function getFunctionRemoteObject(func: any, funcName: string): any {
+            return {
+                name: funcName,
+                value: <Crdp.Runtime.RemoteObject>{
+                    className: 'Function',
+                    description: func && func.toString(),
+                    objectId: '123',
+                    type: 'function',
+                }
+            }
+        }
+
+        test('not empty description', () => {
+            const rawObject = getFunctionRemoteObject(() => { console.log(123); return 123; }, 'testFunction');
+            const processedObject = Variables.createFunctionVariable(rawObject.name, rawObject.value, 'variables', _variableHandles, '');
+            assert.equal(processedObject.value, '() => { … }');
+        })
+
+        test('empty description', () => {
+            const rawObject = getFunctionRemoteObject(undefined, 'testFunction');
+            const processedObject = Variables.createFunctionVariable(rawObject.name, rawObject.value, 'variables', _variableHandles, '');
+            assert.equal(processedObject.value, 'function() { … }');
+        })
+    });
+
+    suite('getRemoteObjectPreview_primitive()', () => {
+        function getPrimitiveRemoteObject(value: any, hasDescription: boolean): Crdp.Runtime.RemoteObject {
+            return {
+                description: hasDescription ? '' + value : undefined,
+                value: value,
+                type: typeof value,
+            }
+        }
+
+        function testPrimitiveRemoteObject(obj: any, expected: string): void {
+            assert.equal(Variables.getRemoteObjectPreview_primitive(obj, true), expected);
+        }
+
+        test('number with description', () => {
+            testPrimitiveRemoteObject(getPrimitiveRemoteObject(123, true), '123');
+        })
+
+        test('boolean with description', () => {
+            testPrimitiveRemoteObject(getPrimitiveRemoteObject(false, true), 'false');
+        })
+
+        test('string with description', () => {
+            testPrimitiveRemoteObject(getPrimitiveRemoteObject('string', true), '"string"');
+        })
+
+        test('undefined with description', () => {
+            testPrimitiveRemoteObject(getPrimitiveRemoteObject(undefined, true), 'undefined');
+        })
+
+        test('number without description', () => {
+            testPrimitiveRemoteObject(getPrimitiveRemoteObject(123, false), '123');
+        })
+
+        test('boolean without description', () => {
+            testPrimitiveRemoteObject(getPrimitiveRemoteObject(false, false), 'false');
+        })
+
+        test('string without description', () => {
+            testPrimitiveRemoteObject(getPrimitiveRemoteObject('string', false), '"string"');
+        })
+
+        test('undefined without description', () => {
+            testPrimitiveRemoteObject(getPrimitiveRemoteObject(undefined, false), 'undefined');
+        })
+    });
+
     suite('isIndexedPropName()', () => {
         test('true for positive integers', () => {
             assert(Variables.isIndexedPropName('0'));

--- a/test/chrome/variables.test.ts
+++ b/test/chrome/variables.test.ts
@@ -137,7 +137,7 @@ suite('Variables', () => {
 
     suite('createFunctionVariable()', () => {
 
-        const _variableHandles = new Variables.VariableHandles()
+        const _variableHandles = new Variables.VariableHandles();
 
         function getFunctionRemoteObject(func: any, funcName: string): any {
             return {
@@ -148,7 +148,7 @@ suite('Variables', () => {
                     objectId: '123',
                     type: 'function',
                 }
-            }
+            };
         }
 
         test('not empty description', () => {
@@ -170,7 +170,7 @@ suite('Variables', () => {
                 description: hasDescription ? '' + value : undefined,
                 value: value,
                 type: typeof value,
-            }
+            };
         }
 
         function testPrimitiveRemoteObject(obj: any, expected: string): void {

--- a/test/chrome/variables.test.ts
+++ b/test/chrome/variables.test.ts
@@ -155,13 +155,13 @@ suite('Variables', () => {
             const rawObject = getFunctionRemoteObject(() => { console.log(123); return 123; }, 'testFunction');
             const processedObject = Variables.createFunctionVariable(rawObject.name, rawObject.value, 'variables', _variableHandles, '');
             assert.equal(processedObject.value, '() => { … }');
-        })
+        });
 
         test('empty description', () => {
             const rawObject = getFunctionRemoteObject(undefined, 'testFunction');
             const processedObject = Variables.createFunctionVariable(rawObject.name, rawObject.value, 'variables', _variableHandles, '');
             assert.equal(processedObject.value, 'function() { … }');
-        })
+        });
     });
 
     suite('getRemoteObjectPreview_primitive()', () => {
@@ -179,35 +179,23 @@ suite('Variables', () => {
 
         test('number with description', () => {
             testPrimitiveRemoteObject(getPrimitiveRemoteObject(123, true), '123');
-        })
-
-        test('boolean with description', () => {
-            testPrimitiveRemoteObject(getPrimitiveRemoteObject(false, true), 'false');
-        })
-
-        test('string with description', () => {
-            testPrimitiveRemoteObject(getPrimitiveRemoteObject('string', true), '"string"');
-        })
-
-        test('undefined with description', () => {
-            testPrimitiveRemoteObject(getPrimitiveRemoteObject(undefined, true), 'undefined');
-        })
+        });
 
         test('number without description', () => {
             testPrimitiveRemoteObject(getPrimitiveRemoteObject(123, false), '123');
-        })
+        });
 
-        test('boolean without description', () => {
-            testPrimitiveRemoteObject(getPrimitiveRemoteObject(false, false), 'false');
-        })
+        test('boolean with description', () => {
+            testPrimitiveRemoteObject(getPrimitiveRemoteObject(false, true), 'false');
+        });
 
-        test('string without description', () => {
-            testPrimitiveRemoteObject(getPrimitiveRemoteObject('string', false), '"string"');
-        })
+        test('string with description', () => {
+            testPrimitiveRemoteObject(getPrimitiveRemoteObject('string', true), '"string"');
+        });
 
-        test('undefined without description', () => {
-            testPrimitiveRemoteObject(getPrimitiveRemoteObject(undefined, false), 'undefined');
-        })
+        test('undefined with description', () => {
+            testPrimitiveRemoteObject(getPrimitiveRemoteObject(undefined, true), 'undefined');
+        });
     });
 
     suite('isIndexedPropName()', () => {


### PR DESCRIPTION
https://github.com/microsoft/vscode-chrome-debug-core/issues/517
The goal of this PR is to fix debugging of **React Native Hermes** applications via [React Native Tools extension](https://github.com/microsoft/vscode-react-native).
The table below contains the fixes descriptions:

|Problem|Before the fixes|After the fixes|Description|
|---|---|---|---|
|The debugger doesn’t show value of numeric variables (Problem №2 - Hermes known issues)|![Screen Shot 2019-12-25 at 13 38 33](https://user-images.githubusercontent.com/33267199/71443745-d340de00-271d-11ea-9bfa-42dadfb9edac.png)|![Screen Shot 2019-12-25 at 13 32 20](https://user-images.githubusercontent.com/33267199/71443750-df2ca000-271d-11ea-99f2-d1bd100e261f.png)|Added the special condition to handle the case if there isn't `description` field in a `RemoteObject`. See [getRemoteObjectPreview_primitive](https://github.com/RedMickey/vscode-chrome-debug-core/blob/92a04e319b93749af664177f7e828f6dbe1a231a/src/chrome/variables.ts#L265) method.|
|The debugger doesn’t show arrays' content (Problem №5 - Hermes known issues)|![Screen Shot 2019-12-25 at 13 37 40](https://user-images.githubusercontent.com/33267199/71444009-7f36f900-271f-11ea-85bc-0999e58955f3.png)|![Screen Shot 2019-12-25 at 13 35 53](https://user-images.githubusercontent.com/33267199/71444020-95dd5000-271f-11ea-9cef-9b47f61e3245.png)|Added the handler in case of `Runtime.callFunctionOn` method returns an empty object. See [getNumPropsByEval](https://github.com/RedMickey/vscode-chrome-debug-core/blob/92a04e319b93749af664177f7e828f6dbe1a231a/src/chrome/variablesManager.ts#L300) method.|
|The debugger doesn’t show functions' content(Problem №1, 4 - Hermes known issues)|![Screen Shot 2019-12-25 at 13 39 33](https://user-images.githubusercontent.com/33267199/71444242-d9848980-2720-11ea-9e6c-b4ff467d68e7.png)|![Screen Shot 2019-12-25 at 13 33 56](https://user-images.githubusercontent.com/33267199/71444238-cec9f480-2720-11ea-8d95-eb126e82d69f.png)|Added the handler in case of `RemoteObject` with function data doesn't contain `description` field. See [createFunctionVariable](https://github.com/RedMickey/vscode-chrome-debug-core/blob/92a04e319b93749af664177f7e828f6dbe1a231a/src/chrome/variables.ts#L363) method.|

For reference: the list of [known issues with Hermes debugging](https://github.com/microsoft/vscode-react-native/issues/1099) for React Native Tools extension.