### PR TITLE
Fixed silent crash for cases when first child of grouped log is null

### DIFF
--- a/src/chrome/consoleHelper.ts
+++ b/src/chrome/consoleHelper.ts
@@ -46,8 +46,9 @@ export function formatConsoleArguments(type: Crdp.Runtime.ConsoleAPICalledEvent[
         case 'startGroupCollapsed':
             let startMsg = '‹Start group›';
             const formattedGroupParams = resolveParams(args);
-            if (formattedGroupParams.length && formattedGroupParams[0].type === 'string') {
-                startMsg += ': ' + formattedGroupParams.shift().value;
+            const previewMessage = formattedGroupParams.find(x => x && x.type === 'string');
+            if (previewMessage) {
+                startMsg += ': ' + previewMessage.value;
             }
 
             args = [{ type: 'string', value: startMsg}, ...formattedGroupParams];


### PR DESCRIPTION
Recently, one of apps I support started crashing the debugging process in extension and I find out that it happen because of null value returned as first message of console.startGroup. I would like to upstream my local patch as fix.