### PR TITLE
telemetry: prefix keys for classification in vscode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2073,7 +2073,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2094,12 +2095,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2114,17 +2117,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2241,7 +2247,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2253,6 +2260,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2267,6 +2275,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2274,12 +2283,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2298,6 +2309,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2378,7 +2390,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2390,6 +2403,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2475,7 +2489,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2511,6 +2526,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2530,6 +2546,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2573,12 +2590,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -26,6 +26,6 @@ suite('telemetry', () => {
             exceptionMessage: 'some error',
             exceptionName: 'SomeError',
             exceptionStack: 'foo.js:123',
-        } as IExecutionResultTelemetryProperties)
+        } as IExecutionResultTelemetryProperties);
     });
 });

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { TelemetryReporter, IExecutionResultTelemetryProperties } from '../src/telemetry';
+
+suite('telemetry', () => {
+    test('remaps exception keys', callback => {
+        const reporter = new TelemetryReporter();
+        reporter.setupEventHandler(event => {
+            callback();
+
+            assert.deepStrictEqual(event, {
+                successful: 'false',
+                exceptionType: 'uncaughtException',
+                '!exceptionMessage': 'some error',
+                exceptionName: 'SomeError',
+                '!exceptionStack': 'foo.js:123',
+            });
+        });
+
+        reporter.reportEvent('error', {
+            successful: 'false',
+            exceptionType: 'uncaughtException',
+            exceptionMessage: 'some error',
+            exceptionName: 'SomeError',
+            exceptionStack: 'foo.js:123',
+        } as IExecutionResultTelemetryProperties)
+    });
+});


### PR DESCRIPTION
Opted to remap it inside the telemetry reporter so that this is a single change and doesn't break the exposed interface.

Once this is published and packages updated, https://github.com/microsoft/vscode/issues/97628 can be closed.