### PR TITLE
Support urls without protocol

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -314,7 +314,7 @@ export function isURL(urlOrPath: string): boolean {
     }
     const { protocol, slashes } = url.parse(urlOrPath, false, true);
     // protocol will be true if the url has a protocol; for protocol-less urls (//example.com/foo), we check if slashes were found
-    return protocol || slashes;
+    return !!protocol || slashes;
 }
 
 export function isAbsolute(_path: string): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -277,7 +277,8 @@ export function errP(msg: string|Error): Promise<never> {
  */
 export function getURL(aUrl: string, options: https.RequestOptions = {}): Promise<string> {
     return new Promise((resolve, reject) => {
-        const parsedUrl = url.parse(aUrl);
+        // Support urls without protocol (e.g //example.com)
+        const parsedUrl = url.parse(aUrl, false, true);
         const get = parsedUrl.protocol === 'https:' ? https.get : http.get;
         options = <https.RequestOptions>{
             rejectUnauthorized: false,
@@ -308,7 +309,7 @@ export function getURL(aUrl: string, options: https.RequestOptions = {}): Promis
  * Returns true if urlOrPath is like "http://localhost" and not like "c:/code/file.js" or "/code/file.js"
  */
 export function isURL(urlOrPath: string): boolean {
-    return urlOrPath && !path.isAbsolute(urlOrPath) && !!url.parse(urlOrPath).protocol;
+    return urlOrPath && !path.isAbsolute(urlOrPath) && !!url.parse(urlOrPath, false, true).protocol;
 }
 
 export function isAbsolute(_path: string): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -309,7 +309,12 @@ export function getURL(aUrl: string, options: https.RequestOptions = {}): Promis
  * Returns true if urlOrPath is like "http://localhost" and not like "c:/code/file.js" or "/code/file.js"
  */
 export function isURL(urlOrPath: string): boolean {
-    return urlOrPath && !path.isAbsolute(urlOrPath) && !!url.parse(urlOrPath, false, true).protocol;
+    if (!urlOrPath || path.isAbsolute(urlOrPath)) {
+        return false;
+    }
+    const { protocol, slashes } = url.parse(urlOrPath, false, true);
+    // protocol will be true if the url has a protocol; for protocol-less urls (//example.com/foo), we check if slashes were found
+    return protocol || slashes;
 }
 
 export function isAbsolute(_path: string): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -309,12 +309,15 @@ export function getURL(aUrl: string, options: https.RequestOptions = {}): Promis
  * Returns true if urlOrPath is like "http://localhost" and not like "c:/code/file.js" or "/code/file.js"
  */
 export function isURL(urlOrPath: string): boolean {
-    if (!urlOrPath || path.isAbsolute(urlOrPath)) {
+    if (!urlOrPath) {
         return false;
     }
     const { protocol, slashes } = url.parse(urlOrPath, false, true);
-    // protocol will be true if the url has a protocol; for protocol-less urls (//example.com/foo), we check if slashes were found
-    return !!protocol || slashes;
+    if (slashes) {
+        // for protocol-less urls (//example.com/foo), we check if slashes were found
+        return true;
+    }
+    return !path.isAbsolute(urlOrPath) && !!protocol;
 }
 
 export function isAbsolute(_path: string): boolean {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -255,6 +255,7 @@ suite('Utils', () => {
             assertIsURL('file:///c:/project/code.js');
             assertIsURL('webpack:///webpack/webpackthing');
             assertIsURL('https://a.b.c:123/asdf?fsda');
+            assertIsURL('//a.b.c:123/asdf?fsda');
         });
 
         test('returns false for not-URLs', () => {


### PR DESCRIPTION
It's valid to have sourceMappingURLs without a protocol, e.g "sourceMappingUrl=//example.com/source.map". It's useful on pages that can be served over both http or https (common in development). This fixes the parser to accept this sort of URL as well. 